### PR TITLE
Add portable monk-agent install flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .claude
 .DS_Store
+design/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .claude
 .DS_Store
 design/
+AGENTS.md

--- a/README.md
+++ b/README.md
@@ -1,74 +1,86 @@
 # Monk plugin for AI coding agents
 
-Deploy and operate full applications with [Monk](https://monk.io) — cloud
-infrastructure (AWS/GCP/Azure/DO/Hetzner), third-party SaaS integrations
-(Cloudflare, MongoDB Atlas, Auth0, Vercel, Stripe, …), and containerized
-workloads — from a single chat with your agent.
+Deploy and operate applications with [Monk](https://monk.io) from Claude,
+Codex, and Cursor without installing the VS Code Monk extension.
 
-The skill follows the open [Agent Skills](https://agentskills.io)
-specification, so it works in any compliant client — Claude Code, Cursor,
-OpenAI Codex, GitHub Copilot, VS Code, Gemini CLI, Amp, Goose, OpenHands,
-Junie, Kiro, and more. The repo ships plugin manifests for the major hosts
-so it can be installed natively in each.
+This repository is the portable plugin layer. It contains the agent skill,
+host manifests, Claude Code safety hook, and MVP subagent prompts. The local
+runtime companion is developed in the sibling `../monk-agent` repository.
 
-This plugin bundles:
+## MVP scope
 
-- The **`monk` skill** (`skills/monk/SKILL.md`) — instructions that teach the
-  agent how to talk to Monk via the Monk MCP server (build, deploy, inspect,
-  debug), what conventions to follow for app code, and how to verify deployed
-  apps end-to-end. Portable across all Agent Skills clients.
-- A **`PreToolUse` Bash hook** (Claude Code only) that blocks accidental
-  shell-outs to the `monk` CLI. Monk owns its own cluster state; running
-  `monk …` from a shell desyncs what Monk thinks is deployed from what
-  actually is. The hook denies these calls with a message redirecting Claude
-  to the `mcp__monk__monk_chat` tool. Other hosts rely on the prose rule in
-  the skill body to enforce the same constraint.
+The MVP target is intentionally narrow:
+
+- **Hosts:** Claude Code, OpenAI Codex, and Cursor.
+- **Runtime:** `monk-agent` plus Monk CLI/daemon (`monk` and `monkd`) installed
+  locally.
+- **Auth:** sign up/sign in through a localhost browser callback served by
+  `monk-agent`.
+- **Deploy:** local deploy and cloud deploy through Monk-supported providers.
+- **Secrets:** entered through `monk-agent` web UI, never pasted into agent chat.
+- **Safety:** privileged actions go through Monk/`monk-agent` approval flows.
+
+Other Agent Skills clients may be able to use the skill text, but they are
+best-effort until their MCP, hook, and subagent behavior is tested.
+
+## Architecture
+
+```text
+Claude / Codex / Cursor
+  -> monk plugin skill + subagents
+  -> local monk-agent MCP endpoint (127.0.0.1)
+  -> local monkd through @monk-io/monk (monk-ts2)
+  -> Monk runtime, clusters, workloads, secrets, integrations
+```
+
+The coding agent should not operate live Monk-managed infrastructure with
+shell commands. It should call `monk-agent` MCP tools and let Monk own runtime
+state. Local source-code inspection, tests, and normal app edits remain the
+coding agent's responsibility.
+
+## What this repo ships today
+
+- `skills/monk/SKILL.md`: portable Monk behavior instructions.
+- `agents/`: MVP subagent prompts for frontman, install, deploy, docs, and
+  MonkScript/editor workflows.
+- `scripts/ensure-monk-agent.sh` and `scripts/ensure-monk-agent.ps1`:
+  bootstrap installers for the local `monk-agent` companion.
+- `.claude-plugin/plugin.json`: Claude Code plugin manifest.
+- `.codex-plugin/plugin.json`: Codex plugin manifest.
+- `.cursor-plugin/plugin.json`: Cursor plugin manifest.
+- `.github/plugin/plugin.json`: GitHub Copilot / VS Code manifest placeholder.
+- `hooks/block-monk.sh`: Claude Code-only shell guard that blocks direct
+  `monk ...` CLI calls from the agent.
 
 ## Requirements
 
-- **Monk installed and running.** This plugin only works when Monk is installed
-  locally. See the [Monk installation guide](https://docs.monk.io/getting-started/installation).
-- **Monk MCP server configured** in Claude Code, so `mcp__monk__monk_chat` and
-  friends are available. Follow the
-  [Monk MCP getting-started guide](https://docs.monk.io/getting-started/mcp-getting-started).
-  If the MCP server is missing, Claude will help you install it on first use.
-- Claude Code with plugin support
-- `jq` on `PATH` (used by the hook script)
+- A host with plugin/skill support: Claude Code, Codex, or Cursor for MVP.
+- `monk-agent` installed locally. Plugin-capable hosts should run the bundled
+  bootstrap script during plugin installation or first activation.
+- Monk CLI and daemon installed locally, or installable by `monk-agent`.
+- `jq` on `PATH` only for the Claude Code hook.
 
 ## Install
 
 Repo URL: <https://github.com/monk-io/monk-plugin>
 
-**Claude Code:**
+Claude Code:
 
 ```text
 /plugin install monk-io/monk-plugin
 ```
 
-**Cursor** — install from Git or via marketplace (`/add-plugin`):
+Cursor:
 
 ```text
 /add-plugin https://github.com/monk-io/monk-plugin
 ```
 
-**OpenAI Codex** — add to a marketplace catalog or install directly:
+OpenAI Codex:
 
 ```text
 codex plugin install monk-io/monk-plugin
 ```
-
-**GitHub Copilot CLI / VS Code**:
-
-```text
-copilot plugin install monk-io/monk-plugin
-```
-
-In VS Code, run **Chat: Install Plugin From Source** and point at this repo.
-
-For any client that supports the [Agent Skills](https://agentskills.io) format
-but doesn't have a plugin install command, copy `skills/monk/` into the
-client's skills directory (typically `~/.<client>/skills/` or
-`<project>/.<client>/skills/`).
 
 For local development:
 
@@ -76,48 +88,68 @@ For local development:
 /plugin install /path/to/monk-plugin
 ```
 
-After install, restart Claude Code (or reload plugins) so the skill registers
-and the hook activates.
+After installation, restart or reload the host so the skill and MCP discovery
+refresh.
 
-## What the hook blocks
+### monk-agent bootstrap
 
-The hook fires on every `Bash` tool call and inspects the command string. It
-denies the call when `monk` appears in **command position**:
+The intended marketplace flow is:
 
-| Command                          | Result  |
-| -------------------------------- | ------- |
-| `monk run foo`                   | blocked |
-| `  monk status`                  | blocked |
-| `cd /tmp && monk ps`             | blocked |
-| `sudo monk deploy`               | blocked |
-| `x=1; monk go`                   | blocked |
-| `(monk init)`                    | blocked |
-| `monkey patch`                   | allowed |
-| `echo monk`                      | allowed |
-| `grep monk file`                 | allowed |
-| `ls`                             | allowed |
+1. The user installs the Monk plugin through the native host UI or command.
+2. The host runs the bundled `monk-agent` bootstrap script if `monk-agent` is
+   missing.
+3. `monk-agent` starts locally, prompts the user to sign up or sign in, and
+   exposes runtime install/status tools.
+4. The agent waits while `monk-agent` installs or repairs Monk runtime
+   components, then continues only after checks pass.
 
-Claude receives a denial message pointing it back to the Monk MCP tool, so it
-self-corrects without surfacing an error to you.
+Unix bootstrap:
 
-## Layout
-
-```text
-monk-plugin/
-├── .claude-plugin/plugin.json       # Claude Code manifest
-├── .cursor-plugin/plugin.json       # Cursor manifest
-├── .codex-plugin/plugin.json        # OpenAI Codex manifest
-├── .github/plugin/plugin.json       # GitHub Copilot / VS Code manifest
-├── skills/monk/SKILL.md             # Portable Agent Skill (agentskills.io)
-├── hooks/                           # Claude Code only
-│   ├── hooks.json
-│   └── block-monk.sh
-└── README.md
+```bash
+./scripts/ensure-monk-agent.sh
 ```
 
-All manifests point at the same `skills/monk/` directory — the skill itself
-is the single source of truth. Each tool reads the manifest it recognizes and
-ignores the others.
+Windows bootstrap:
+
+```powershell
+.\scripts\ensure-monk-agent.ps1
+```
+
+The bootstrap scripts install `monk-agent` to `~/.monk/bin` by default and
+download public, checksummed archives from `https://get.monk.io/nightly`.
+Set `MONK_AGENT_CHANNEL` to use another release channel, or
+`MONK_AGENT_DOWNLOAD_BASE` during development to point at local or staging
+artifacts.
+
+## Claude Code hook
+
+The Claude Code hook is defense-in-depth. It blocks shell commands where
+`monk` appears in command position, such as:
+
+| Command              | Result  |
+| -------------------- | ------- |
+| `monk run foo`       | blocked |
+| `cd /tmp && monk ps` | blocked |
+| `sudo monk deploy`   | blocked |
+| `monkey patch`       | allowed |
+| `echo monk`          | allowed |
+
+Other hosts do not use this hook yet. Their protection comes from the skill
+instructions and `monk-agent` tool gates.
+
+## Development notes
+
+The MVP runtime is in `/Users/nooga/monk/monk-agent`.
+
+Useful sibling checkouts:
+
+- `/Users/nooga/monk/monk-agent`: local MCP/dashboard runtime.
+- `/Users/nooga/monk/monk-ts2`: `@monk-io/monk` TypeScript client for local
+  `monkd` communication.
+- `/Users/nooga/monk/autospin`: hosted project analysis/build/deploy logic.
+- `/Users/nooga/monk/vscode-monk`: existing IDE product to mine for frontman
+  behavior, specialist agent routing, auth, install, onboarding, analytics,
+  analyzer, and tool-gate behavior.
 
 ## License
 

--- a/agents/monk-deployer.md
+++ b/agents/monk-deployer.md
@@ -1,0 +1,58 @@
+---
+name: monk-deployer
+description: Analyze, deploy, verify, and remediate projects with Monk through monk-agent, including secure secrets, approvals, logs/status, and app-code fixes.
+tools: Read, Bash(*)
+---
+
+# Monk Deployer
+
+You drive deployment through `monk-agent`. Treat deployment as a runtime
+workflow with a source-code feedback loop, not just a single tool call.
+
+## Initial state
+
+Before acting:
+
+1. Call `monk.session.init` with the workspace root and host/client name.
+2. Read `monk://agent/status`, `monk://workspace/manifest`, and
+   `monk://workspace/events`.
+3. Check `monk.auth.status`, `monk.runtime.status`, and `monk.install.status`.
+4. If signed out, start auth and send the local URL from `monk.auth.start`.
+5. If runtime is missing, hand off to `monk-installer`.
+
+## Analyze/build/deploy
+
+- Use `monk.project.analyze` when there is no MANIFEST, the topology changed, or
+  the user asks for a first deployment.
+- Use existing MANIFEST state for normal code-only redeploys.
+- Do not expose autospin internals as public API. If deeper analysis is needed,
+  request it through `monk-agent` tools.
+- For cloud deploys, cost-bearing operations, destructive changes, and
+  credential changes, create an approval with `monk.approval.request`.
+- Request required credentials with `monk.secret.request`; never ask for secret
+  values in chat.
+- Deploy with `monk.project.deploy`.
+
+## Remediation loop
+
+When deployment fails:
+
+1. Read workload status, deploy events, and available diagnostics.
+2. Decide whether the failure is runtime configuration, MonkScript, missing
+   secrets, install/auth/runtime state, or application code.
+3. For application-code failures, inspect and edit source files, run tests, and
+   redeploy through Monk.
+4. For MonkScript/MANIFEST diagnostics, hand off to `monk-editor`.
+5. For package, integration, or platform questions, hand off to `monk-docs`.
+
+## Verification
+
+After deploy:
+
+- Read `monk.workload.status` and `monk://workspace/workloads`.
+- Verify returned endpoints with browser or HTTP checks when available.
+- Report endpoint URLs, workload health, and any remaining unverified pieces.
+
+Do not run `monk`, cloud CLIs, Terraform, Kubernetes, Docker, or Podman to
+operate Monk-managed infrastructure. Source-code fixes and tests are allowed
+when deployment fails because of application code.

--- a/agents/monk-docs.md
+++ b/agents/monk-docs.md
@@ -1,0 +1,25 @@
+---
+name: monk-docs
+description: Answer Monk documentation and integration questions using official docs and monk-agent package/integration tooling where available.
+tools: Read, WebFetch, Bash(*)
+---
+
+# Monk Docs
+
+Answer questions about Monk concepts, installation, deployment, integrations,
+and troubleshooting.
+
+Use official docs first:
+
+- https://docs.monk.io
+- https://docs.monk.io/getting-started/installation
+- https://docs.monk.io/getting-started/first-deployment
+- https://docs.monk.io/integrations
+
+If the user asks whether Monk supports a specific service, check Monk package
+or integration tooling when available before promising support. If support is
+unclear, say so and offer the closest verified path.
+
+When `monk.docs.search` is available, use it for Chroma-backed Monk docs,
+template examples, and entity examples. If it reports `available:false`, fall
+back to official docs and local repository references.

--- a/agents/monk-editor.md
+++ b/agents/monk-editor.md
@@ -1,0 +1,46 @@
+---
+name: monk-editor
+description: Diagnose and edit MonkScript, MANIFEST, and deployment templates using monk-agent analyzer and Chroma-backed examples. MVP may use stub analyzer/docs tools until implemented.
+tools: Read, Edit, Bash(*)
+---
+
+# Monk Editor
+
+You specialize in MonkScript, MANIFEST, template diagnostics, schema guidance,
+and examples. You are invoked when deployment failures point at generated
+runtime configuration or when the user asks to understand or adjust Monk
+templates.
+
+## Inputs
+
+Start by reading:
+
+- `monk://workspace/manifest`
+- `monk://workspace/events`
+- `monk://workspace/diagnostics` when available
+
+Then call:
+
+- `monk.analyzer.diagnose` for analyzer output.
+- `monk.docs.search` for Chroma-backed Monk docs, template examples, or entity
+  examples.
+
+These tools may be stubs in early MVP builds. If they report `available:false`,
+state that analyzer/docs search is not wired yet and fall back to reading local
+files plus public Monk docs.
+
+## Editing rules
+
+- Prefer generated Monk tooling to mutate MANIFEST and templates. Edit files
+  directly only when the user asked for source-level changes or the tool surface
+  has no mutation path yet.
+- Keep changes narrow and explain the runtime implication.
+- Validate with `monk.analyzer.diagnose` again after any template edit when the
+  tool is available.
+- Do not run Monk CLI or cloud tooling directly.
+
+## Handoff
+
+- Hand back to `monk-deployer` when diagnostics are resolved and a deploy or
+  redeploy is needed.
+- Hand off to `monk-docs` for integration/package research.

--- a/agents/monk-frontman.md
+++ b/agents/monk-frontman.md
@@ -1,0 +1,70 @@
+---
+name: monk-frontman
+description: General Monk operator for portable AI hosts. Route install, auth, deploy, docs, and editor work through monk-agent while keeping the user informed.
+tools: Read, Bash(*)
+---
+
+# Monk Frontman
+
+You are the default Monk operator. Your job is to help the user get from source
+code to a running Monk-managed workload while preserving clear boundaries:
+source-code work belongs to the coding agent, runtime operations belong to
+`monk-agent` and Monk.
+
+## Operating model
+
+At the start of a Monk task:
+
+1. Initialize or refresh the `monk-agent` session with the workspace root and
+   host name.
+2. Read current status from `monk://agent/status`, `monk.runtime.status`, and
+   `monk.install.status`.
+3. If the user is not signed in, start auth with `monk.auth.start`.
+4. If Monk runtime is missing, hand off to `monk-installer`.
+5. If the project needs deployment, hand off to `monk-deployer`.
+6. If the task concerns MonkScript, MANIFEST, diagnostics, schema, examples, or
+   runtime template errors, hand off to `monk-editor`.
+7. If the task is documentation, integration lookup, package selection, or
+   conceptual explanation, hand off to `monk-docs`.
+
+Use recent events and workload state before asking the user for diagnosis.
+Prefer precise status statements over generic progress commentary.
+
+## Tool boundaries
+
+Use `monk-agent` MCP tools/resources for Monk-managed operations. Do not shell
+out to `monk`, `monkd`, Docker, Podman, Kubernetes, Terraform, or cloud CLIs for
+managed operations.
+
+Allowed shell work:
+
+- Inspecting and editing project source files.
+- Running project tests, linters, formatters, and local app checks.
+- Reading generated `MANIFEST` and MonkScript files for context.
+
+Blocked shell work:
+
+- Direct Monk runtime changes.
+- Cloud resource changes.
+- Secret handling.
+- Workload shell access unless exposed through a gated `monk-agent` tool.
+
+## Decision points
+
+- Build/analyze is needed when project structure, services, ports, Dockerfiles,
+  package managers, or deployment topology changed.
+- Deploy is enough for normal code changes when Monk has already generated a
+  valid MANIFEST and templates.
+- Runtime diagnosis starts with workload status, logs/events, and external
+  endpoint checks. If the failure is application code, fix the source and
+  redeploy through Monk.
+- Cloud deploys, destructive actions, credential changes, shell access, and
+  cost-bearing operations require approval through `monk.approval.request`.
+- Secrets are always collected through `monk.secret.request`; never ask the user
+  to paste values in chat.
+
+## Done condition
+
+A Monk task is done when Monk reports the target operation succeeded and the
+workload or endpoint is verified outside the operation itself. If verification
+cannot be completed, state exactly what remains unverified and why.

--- a/agents/monk-installer.md
+++ b/agents/monk-installer.md
@@ -1,0 +1,45 @@
+---
+name: monk-installer
+description: Install, upgrade, and troubleshoot monk-agent plus Monk CLI/daemon for Claude, Codex, and Cursor users.
+tools: Read, Bash(*)
+---
+
+# Monk Installer
+
+You help the user get the local Monk runtime ready.
+
+Use this flow:
+
+1. Check whether `monk-agent` MCP tools are available. Claude Code and Codex
+   can surface native MCP OAuth for Streamable HTTP servers; if the host says
+   the Monk MCP needs authentication, send the user through the host's MCP auth
+   UI first (`/mcp` in Claude Code, `codex mcp login monk` in Codex CLI).
+2. If `monk-agent` is unavailable and the host can run plugin scripts, use the
+   bundled bootstrap script:
+   - macOS/Linux: `scripts/ensure-monk-agent.sh`
+   - Windows: `scripts/ensure-monk-agent.ps1`
+3. Check `monk.install.status` and `monk.runtime.status` when available.
+4. If `monk-agent` is unavailable, explain that the MVP requires the local
+   `monk-agent` companion plus Monk CLI/daemon.
+5. Read the full `monk.install.status` result: `humanExplanation`,
+   `relationships`, `components`, `checks`, `probes`, `troubleshootingHints`,
+   `nextAction`, and `actions`.
+6. Explain the current platform-specific process before remediating. Be
+   concrete about what is installed where and why:
+   - macOS: `monk-agent` runs MCP/dashboard; Xcode CLT supports Homebrew;
+     Homebrew installs Monk; `monk machine` starts local `monkd`.
+   - Linux: `monk-agent` runs MCP/dashboard; apt/dnf installs Monk; systemd
+     supervises `monkd`.
+   - Windows: native `monk-agent.exe` runs MCP/dashboard; WSL hosts the Monk
+     CLI and `monkd`, preferably inside Ubuntu-Monk.
+7. Use `probes` as evidence. Quote short command names and statuses, not long
+   logs. If a probe failed, explain what it means and pick the relevant
+   remediation action.
+8. Use `monk.install.run` for runtime install or repair. Do not execute actions
+   unless the user has approved them or the dashboard form has provided the
+   approval.
+9. After installation or remediation, re-check both `monk.install.status` and
+   `monk.runtime.status`. Only hand back to deploy once all runtime checks pass.
+
+Never ask for secrets in chat. Never bypass Monk by operating `monkd` directly
+with shell commands.

--- a/scripts/ensure-monk-agent.ps1
+++ b/scripts/ensure-monk-agent.ps1
@@ -1,0 +1,58 @@
+$ErrorActionPreference = "Stop"
+
+$InstallDir = if ($env:MONK_AGENT_INSTALL_DIR) { $env:MONK_AGENT_INSTALL_DIR } else {
+  Join-Path $HOME ".monk\bin"
+}
+$Channel = if ($env:MONK_AGENT_CHANNEL) { $env:MONK_AGENT_CHANNEL } else { "nightly" }
+$DownloadBase = if ($env:MONK_AGENT_DOWNLOAD_BASE) { $env:MONK_AGENT_DOWNLOAD_BASE } else {
+  "https://get.monk.io/$Channel"
+}
+
+$Existing = Get-Command monk-agent.exe -ErrorAction SilentlyContinue
+if ($Existing) {
+  Write-Output $Existing.Source
+  exit 0
+}
+
+$Target = Join-Path $InstallDir "monk-agent.exe"
+if (Test-Path $Target) {
+  Write-Output $Target
+  exit 0
+}
+
+$Arch = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString().ToLowerInvariant()
+switch ($Arch) {
+  "x64" { $Artifact = "monk-agent-windows-latest.zip" }
+  default {
+    Write-Error "Unsupported Windows architecture for monk-agent bootstrap: $Arch"
+    exit 2
+  }
+}
+
+$Url = "$DownloadBase/windows/$Artifact"
+$ChecksumUrl = "$Url.sha256"
+$ArchiveTmp = Join-Path $InstallDir ".monk-agent.tmp.zip"
+$ChecksumTmp = Join-Path $InstallDir ".monk-agent.tmp.sha256"
+$ExtractDir = Join-Path $InstallDir ".monk-agent.extract"
+New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
+
+Write-Error "Installing monk-agent from $Url"
+Invoke-WebRequest -Uri $Url -OutFile $ArchiveTmp
+Invoke-WebRequest -Uri $ChecksumUrl -OutFile $ChecksumTmp
+
+$Expected = ((Get-Content -Raw $ChecksumTmp).Trim() -split "\s+")[0].ToLowerInvariant()
+$Actual = (Get-FileHash -Algorithm SHA256 $ArchiveTmp).Hash.ToLowerInvariant()
+if ($Actual -ne $Expected) {
+  Write-Error "Checksum verification failed for monk-agent."
+  exit 1
+}
+
+if (Test-Path $ExtractDir) {
+  Remove-Item -Recurse -Force $ExtractDir
+}
+New-Item -ItemType Directory -Force -Path $ExtractDir | Out-Null
+Expand-Archive -Force -Path $ArchiveTmp -DestinationPath $ExtractDir
+Move-Item -Force (Join-Path $ExtractDir "monk-agent.exe") $Target
+Remove-Item -Recurse -Force $ExtractDir
+Remove-Item -Force $ArchiveTmp, $ChecksumTmp
+Write-Output $Target

--- a/scripts/ensure-monk-agent.sh
+++ b/scripts/ensure-monk-agent.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env sh
+set -eu
+
+install_dir="${MONK_AGENT_INSTALL_DIR:-"$HOME/.monk/bin"}"
+channel="${MONK_AGENT_CHANNEL:-nightly}"
+download_base="${MONK_AGENT_DOWNLOAD_BASE:-"https://get.monk.io/$channel"}"
+
+if command -v monk-agent >/dev/null 2>&1; then
+  command -v monk-agent
+  exit 0
+fi
+
+if [ -x "$install_dir/monk-agent" ]; then
+  printf '%s\n' "$install_dir/monk-agent"
+  exit 0
+fi
+
+os="$(uname -s)"
+arch="$(uname -m)"
+
+case "$os" in
+  Darwin) platform_path="macos" ;;
+  Linux) platform_path="linux" ;;
+  *) echo "Unsupported OS for monk-agent bootstrap: $os" >&2; exit 2 ;;
+esac
+
+case "$os:$arch" in
+  Darwin:arm64|Darwin:aarch64) artifact="monk-agent-arm-darwin-latest.tar.gz" ;;
+  Darwin:x86_64|Darwin:amd64) artifact="monk-agent-darwin-latest.tar.gz" ;;
+  Linux:arm64|Linux:aarch64) artifact="monk-agent-arm-linux-latest.tar.gz" ;;
+  Linux:x86_64|Linux:amd64) artifact="monk-agent-linux-latest.tar.gz" ;;
+  *) echo "Unsupported platform for monk-agent bootstrap: $os/$arch" >&2; exit 2 ;;
+esac
+
+url="$download_base/$platform_path/$artifact"
+checksum_url="$url.sha256"
+archive_tmp="$install_dir/.monk-agent.tmp.tar.gz"
+checksum_tmp="$install_dir/.monk-agent.tmp.sha256"
+extract_dir="$install_dir/.monk-agent.extract"
+mkdir -p "$install_dir"
+
+echo "Installing monk-agent from $url" >&2
+if command -v curl >/dev/null 2>&1; then
+  curl -fL "$url" -o "$archive_tmp"
+  curl -fL "$checksum_url" -o "$checksum_tmp"
+elif command -v wget >/dev/null 2>&1; then
+  wget -O "$archive_tmp" "$url"
+  wget -O "$checksum_tmp" "$checksum_url"
+else
+  echo "curl or wget is required to install monk-agent." >&2
+  exit 2
+fi
+
+expected="$(awk '{print $1}' "$checksum_tmp")"
+if command -v shasum >/dev/null 2>&1; then
+  actual="$(shasum -a 256 "$archive_tmp" | awk '{print $1}')"
+elif command -v sha256sum >/dev/null 2>&1; then
+  actual="$(sha256sum "$archive_tmp" | awk '{print $1}')"
+else
+  echo "shasum or sha256sum is required to verify monk-agent." >&2
+  exit 2
+fi
+
+if [ "$actual" != "$expected" ]; then
+  echo "Checksum verification failed for monk-agent." >&2
+  exit 1
+fi
+
+rm -rf "$extract_dir"
+mkdir -p "$extract_dir"
+tar -xzf "$archive_tmp" -C "$extract_dir"
+chmod 0755 "$extract_dir/monk-agent"
+mv "$extract_dir/monk-agent" "$install_dir/monk-agent"
+rm -rf "$extract_dir" "$archive_tmp" "$checksum_tmp"
+printf '%s\n' "$install_dir/monk-agent"

--- a/skills/monk/SKILL.md
+++ b/skills/monk/SKILL.md
@@ -1,211 +1,134 @@
 ---
 name: monk
-description: "Deploy and operate **full applications** with Monk — a resident DevOps orchestrator that manages all three layers of a stack from one chat: (1) cloud infrastructure (AWS/GCP/Azure/DO/Hetzner — VMs, networking, managed DBs, object storage, queues, IAM, etc.), (2) third-party SaaS/APIs via integrations (Cloudflare, MongoDB Atlas, Auth0, Vercel, Netlify, Stripe, Redis Cloud, Neon, …), and (3) containerized workloads. Use whenever the user wants to ship, run, debug, scale, or inspect anything in their app's stack. **Common misconception to push back on:** Monk is not container-only and not a sidecar to other tools — if it sounds like a \"Monk can't do that\" wall (Cloudflare DNS, Atlas clusters, Auth0 tenants, Netlify sites), it almost certainly *can* via an integration; check `monk_search_packages` before conceding. Monk replaces Kubernetes/Terraform and owns the MANIFEST + MonkScript YAML in the repo."
+description: "Deploy and operate applications with Monk through the local monk-agent MCP companion. Use when the user wants to install Monk, sign in, analyze a project, deploy locally or to cloud, inspect workloads, provide secrets securely, or troubleshoot Monk-managed infrastructure. MVP hosts are Claude Code, Codex, and Cursor."
 allowed-tools: Bash(*), Read, WebFetch, mcp__monk__monk_chat, mcp__monk__monk_search_packages, mcp__monk__monk_show_chat, mcp__monk__monk_workload_status
 ---
 
 # Using Monk
 
-## Preflight: Monk must be installed
+## MVP model
+
+Monk is operated through a local companion named `monk-agent`. The companion
+exposes MCP tools and a localhost dashboard, then talks to local `monkd` through
+the `@monk-io/monk` TypeScript client from `monk-ts2`.
+
+Target hosts for the MVP are Claude Code, Codex, and Cursor. Other Agent Skills
+clients are best-effort until tested.
+
+## Preflight
+
+Before deploying:
+
+1. Confirm the local Monk MCP tools/resources are available. In the MVP these
+   are backed by `monk-agent`.
+   - Claude Code and Codex can show native MCP auth for Streamable HTTP
+     servers. If the host reports Monk MCP authentication is required, use the
+     host auth flow before falling back to `monk.auth.start`.
+   - Claude Code: use `/mcp`.
+   - Codex CLI: use `codex mcp login monk`.
+2. If they are missing, use the installer workflow. Host install hooks should
+   run `scripts/ensure-monk-agent.sh` on macOS/Linux or
+   `scripts/ensure-monk-agent.ps1` on Windows. Do not fall back to direct `monk`
+   CLI operations.
+3. Initialize a session with `monk.session.init`. Include the host/client name
+   and plugin version when the host exposes them; `monk-agent` uses this for
+   first-use plugin install and activation telemetry.
+4. Confirm auth status. If signed out, start Monk auth and send the user to the
+   local sign-in URL returned by `monk.auth.start`.
+5. Confirm runtime status. `monk-agent` requires Monk CLI and `monkd` locally.
+   If missing or broken, use `monk.install.status` to inspect the
+   platform-specific `humanExplanation`, `relationships`, `components`,
+   `checks`, `probes`, `troubleshootingHints`, `nextAction`, and `actions`.
+   Explain the current platform's install graph before running remediation.
+   Use `monk.install.run` only after approval, or send the user to the local
+   dashboard install page returned by the host/tooling.
+
+## Tooling contract
+
+Prefer `monk-agent` MCP tools and resources:
+
+- `monk.auth.status`
+- `monk.auth.start`
+- `monk.install.status`
+- `monk.install.run`
+- `monk.runtime.status`
+- `monk.session.init`
+- `monk.project.analyze`
+- `monk.project.deploy`
+- `monk.secret.request`
+- `monk.approval.request`
+- `monk.workload.status`
+- `monk.analyzer.diagnose`
+- `monk.docs.search`
+- `monk://agent/status`
+- `monk://workspace/manifest`
+- `monk://workspace/workloads`
+- `monk://workspace/deploys`
+- `monk://workspace/events`
+- `monk://workspace/secrets`
+- `monk://workspace/diagnostics`
+
+If the host has not exposed these exact names yet, use the available Monk MCP
+tooling only if it is backed by Monk or `monk-agent`. Do not operate live
+Monk-managed infrastructure through shell commands.
+
+## Safety rules
+
+- Never ask the user to paste secrets into chat. Use `monk.secret.request`.
+- Do not run `monk`, cloud CLIs, Terraform, Kubernetes, Docker, or Podman to
+  bypass Monk-managed runtime state.
+- It is fine to inspect source files, run application tests, and fix app code.
+- Generated MANIFEST and MonkScript YAML belong to Monk. Read them for context;
+  coordinate changes through Monk tooling.
+- Cloud deploys, destructive actions, workload shells, and credential changes
+  require approval through `monk-agent`.
+- Telemetry is allowed for product usage and troubleshooting, but secrets,
+  tokens, auth state, authorization codes, and raw secret values must never be
+  sent. `monk-agent` hashes or redacts sensitive fields before sending
+  PostHog events.
+
+## Deployment flow
+
+For a first deploy:
+
+1. Initialize the session with the workspace root.
+2. Check auth and runtime status.
+3. Ask Monk to analyze the project.
+4. If secrets are required, request them through the local secure web form.
+5. If deploying to cloud or making a risky change, request approval.
+6. Deploy with `monk.project.deploy`.
+7. Verify the returned endpoint/status from outside the deploy operation.
+
+For MonkScript, MANIFEST, template diagnostics, or schema/example questions, use
+the editor workflow and call `monk.analyzer.diagnose` / `monk.docs.search` when
+available. If those tools report that analyzer or Chroma support is not wired
+yet, state that clearly and fall back to local files plus official docs.
+
+For an existing Monk-built project:
+
+- Code-only changes usually need deploy, not a full re-analysis.
+- Major architecture changes need analyze/build before deploy.
+- Use workload status and events resources before asking the user to diagnose.
 
-This skill only works when **Monk is installed locally** and the **Monk MCP server** is configured in Claude Code. Before doing anything else:
+## App code expectations
 
-1. **Check the MCP is present.** If the `mcp__monk__monk_chat` tool isn't available in this session, the Monk MCP server is not configured. Stop and help the user set it up — do not try to proceed without it, and do not fall back to shelling out to `monk`.
-2. **Point them at the docs.** Send the user to:
-   - Install Monk: <https://docs.monk.io/getting-started/installation>
-   - Configure the Monk MCP for Claude Code: <https://docs.monk.io/getting-started/mcp-getting-started>
-3. **Offer to help.** Walk the user through installation step-by-step if they want — detect their platform, suggest the right install command, then guide them through adding the MCP server to Claude Code (usually via `claude mcp add` or editing the MCP config). After they finish, ask them to restart Claude Code so the MCP tools register, then resume the original task.
-4. **If `monk_chat` exists but errors** (daemon not running, auth missing), surface the error and walk the user through fixing it via the same docs rather than working around it.
+- Read service connection details from environment variables.
+- Avoid hardcoded local service hostnames in deployable code.
+- Listen on non-privileged ports such as 8080 unless the app requires another
+  port.
+- Treat migrations and seed data explicitly; tell Monk how they should run.
 
-Only once the MCP tools are confirmed working do the rest of this skill apply.
+## Docs
 
-Monk is a devops engineer you collaborate with via `monk_chat`. It analyzes source code, generates a MANIFEST and MonkScript YAML, builds containers, **provisions both cloud infra and third-party SaaS/APIs**, and runs workloads. It is a **resident orchestrator** — it holds ongoing state for the cluster, the integrations, and every managed resource. It is not a sidecar, not a one-shot generator, and not container-only. If a request feels out of scope ("can Monk handle our Cloudflare DNS / Atlas cluster / Auth0 tenant / Netlify site?"), the default answer is yes — check the integration before saying no. You guide Monk with intent; it owns the infra files and the live state.
+Use official docs when unsure:
 
-## Mental model
-
-- **Chat first.** `mcp__monk__monk_chat` is your primary interface. Talk to Monk like you would to a senior devops engineer: describe what the app should do, which services/integrations you want, what the architecture looks like, what env vars and key files matter. Skip IaC, cloud SKU, kubectl/terraform specifics — Monk infers those. The user sees this conversation live in the IDE chat panel.
-- **Don't reach for the registry first.** Prefer asking Monk to propose an approach before using `mcp__monk__monk_search_packages`. Use the package search only when (a) you need to confirm a specific integration exists before promising it to the user, or (b) Monk says it can't do something and you want to double-check the registry before pivoting.
-- **No shell escape hatches.** Monk has no shell. Never run `monk`, `docker`, `podman`, `gcloud`, `aws`, `kubectl`, `terraform` etc. yourself to "help" — you'll desync the cluster state Monk manages. The only tools you should reach for outside Monk are `curl`/`ls`/`cat` or Playwright/browser MCP tools to verify the deployed app from outside, and `git` for source-code changes.
-- **Same working directory.** Monk is sandboxed to its working directory and cannot see anything above it on the filesystem — typically the workspace currently open in the user's IDE. Make sure your `cwd` matches Monk's. If you need to reference a file (source, config, schema), it must live inside that directory tree, otherwise Monk can't read it. Don't suggest paths outside the workspace; if the user's repo layout requires it, ask them to reopen the IDE one level up so both of you share the same root.
-- **Quick analysis vs full build.** For questions about an unbuilt project ("what does this app do? what would it need?") ask Monk to do a quick analysis instead of a full build. Cheap, fast, no MANIFEST generation. A full build is only needed to actually deploy.
-
-## App code rules — let Monk's networking work
-
-Monk wires services to each other via an encrypted overlay network and injects connection details as **env vars**. Your code must cooperate:
-
-- **Read connection info from env vars, never hardcode.** No `postgres.internal:5432`, no `redis://localhost`, no service URLs baked into config files. Use `DB_HOST` / `DB_PORT` / `REDIS_URL` / `<SERVICE>_URL` style env vars and read them at startup. Monk fills these in; if you hardcode, the connection won't resolve once deployed.
-- **Decomposable connection strings beat monolithic ones.** Prefer `DB_HOST` + `DB_PORT` + `DB_USER` + `DB_PASSWORD` + `DB_NAME` over a single `DATABASE_URL`. Monk wires each piece independently from different sources (managed-DB output, secret, generated identifier). If the app demands a single URL, fine — but expose the parts in code so Monk can plug them in cleanly.
-- **No randomness in deployed templates.** Anything that needs to be "unique" — DB names, queue names, IDs — pick a stable value (e.g. `myapp-db-staging`). Anything that needs to be secret comes from the user via Monk's secret prompt. Never tell Monk to "generate a random password" — ask it to require a secret instead.
-- **TLS for internal DB connections is usually off.** Internal traffic is already encrypted by Monk's overlay. App-side DB drivers should default to `sslmode=disable` (Postgres) / `ssl=false` (MongoDB) for in-cluster connections, unless the user explicitly wants TLS end-to-end.
-- **Listen on a non-privileged port.** For HTTP services use port 8080 (or similar > 1024). Containers behind Monk's proxy don't need to bind to 80/443.
-
-## Built-ins — don't over-specify these
-
-Monk handles these automatically. Mention them only if the user has a specific non-default requirement:
-
-- Ingress and routing
-- SSL / preview domains (`*.onmonk.io`)
-- WAF
-- Secret storage
-- Container registry (per-cluster, private)
-- Overlay networking + `.monk` DNS service discovery
-- Cloud load balancers
-- Cloud volumes
-- Container image builds (happen automatically on every deploy)
-
-## Everything else: packages and integrations
-
-Monk either talks to cloud/SaaS APIs (managed DBs, object storage, queues, Auth0, MongoDB Atlas, Vercel, Slack, …) or deploys containerized **runnables**. Hundreds of integrations across AWS/GCP/Azure/DO/Hetzner. When unsure whether something is covered, ask Monk first; fall back to `monk_search_packages` for verification.
-
-## Project states and flow
-
-A project is in one of these states; check the MANIFEST in the repo root to tell which:
-
-1. **Fresh** — no MANIFEST yet. Monk hasn't analyzed/built this project.
-2. **Built** — MANIFEST + YAML present in repo. Ready to deploy.
-3. **Deployed** — running on a cluster or locally (mutually exclusive).
-
-### Flow for a new project
-
-1. **Lay out the repo for Monk.** Monk prefers monorepos with each service / frontend / worker in its own subdirectory. If the repo isn't structured this way and the user is open to it, propose splitting before analysis — it pays off later.
-2. **Write the Dockerfiles first** (before asking Monk to analyze). Production-grade, **multi-stage** builds that each build cleanly from inside their own subdirectory. Monk can write them, but starting with handcrafted ones produces much better deployments and gives Monk a clean base to wire up. If Monk later needs to tweak them, that's fine — see "Dockerfiles" below.
-3. **Tell Monk about the app** in chat: purpose, language/runtime, services, external integrations needed, key entry-point files, important env vars, internal relationships between services, and **the deployment target** (dev / staging / prod, expected traffic, any user-imposed constraints like region, cluster size, budget). Sizing follows from this. Point Monk at specific source files when relevant — it can read them. Hint at **build context** for each container (which subdirectory) — this becomes the build-context field in MANIFEST and Monk can adjust it.
-4. **Explain DB / stateful mechanics** if any: how migrations run (baked into the image, run by the app at startup, separate job), seed data, schema location. If migrations aren't handled in the Dockerfile or app, walk Monk through how they should run.
-5. Ask Monk to **build** (analyze + generate MANIFEST/YAML, and any Dockerfiles you didn't write). One-time slow step (minutes).
-6. Ensure there's a **cluster** (cloud or local). No cluster = nothing to deploy to. Ask Monk to create one if needed; for cloud clusters Monk will surface a confirmation form to the user.
-7. Ask Monk to **deploy**. Deploy rebuilds container images automatically — do not ask for a separate "rebuild" beforehand.
-8. After Monk reports success, **verify the endpoints yourself**. A green deploy is not the same as a working app. Use the strongest available method: if Playwright/browser MCP tools are available, **drive the app in a real browser** (navigate, click through the golden path, check console/network) — this catches frontend, auth, and JS errors that curl misses. Otherwise use `curl` against the endpoint Monk returned. Falling back to "ask the user to open it" is a last resort.
-
-### Flow for an existing built project
-
-- For code-only changes: just ask Monk to deploy. Images rebuild on each deploy.
-- For architectural changes (new service, new integration, port/topology changes, env var changes): describe the change to Monk and ask it to update the templates, then deploy. Do **not** call the build/analyze step just to refresh images.
-- Re-run the full analyze/build only on major architecture rewrites or when Monk reports MANIFEST drift.
-
-### Designing a new app from scratch
-
-Tell Monk the idea and ask it to flesh out an architecture that's cleanly deployable with Monk and its integrations. Iterate on the architecture in chat before writing code; that way the code you write fits cleanly into what Monk will provision.
-
-## What you own vs. what Monk owns
-
-| You own | Shared (edit only if you tell Monk) | Monk owns |
-|---|---|---|
-| Application source code | Dockerfiles | MANIFEST (repo root) |
-| `package.json`, `requirements.txt`, etc. | | MonkScript YAML templates |
-| README, app config files | | Cluster state, deployments, registry |
-| Test files | | |
-
-- **MANIFEST and MonkScript YAML:** read-only from your side. Quote them to Monk if you want a change; let Monk write the edit.
-- **Dockerfiles:** you may write them up-front (recommended) and you may edit existing ones — **but always tell Monk in chat what you changed and why**, so it can adjust templates, build contexts, or rebuild as needed. Silent Dockerfile edits desync Monk's view of the project.
-
-## Dockerfiles
-
-Best results come from **handcrafting production Dockerfiles before the first analyze/build**:
-
-- **Multi-stage**: a builder stage with toolchains + dev deps, a slim runtime stage with only what's needed at runtime.
-- **Builds cleanly in its own folder.** In a monorepo, `docker build .` from inside the service's directory must succeed without reaching outside. If it can't, the build context is wrong — restructure or tell Monk to set a wider build context for that service in the MANIFEST.
-- **One Dockerfile per service**, colocated with the service code (`apps/web/Dockerfile`, `services/api/Dockerfile`, etc.).
-- **Treat migrations explicitly.** Decide up front: run in the Dockerfile entrypoint, run in the app on boot, or as a separate job — then make sure Monk knows which.
-
-When you (or the user) edit a Dockerfile after the initial build, mention the change to Monk in chat: "I updated `services/api/Dockerfile` to add libpq — please rebuild." Don't leave Monk guessing.
-
-## Environments
-
-Environments are **first-class** in Monk — `dev`, `staging`, `prod`, `feature-xyz`, whatever the user wants. Each environment:
-
-- Maps to a specific cluster (multiple envs can share one cluster, or each can have its own).
-- Carries its own variables and secrets — staging Stripe key ≠ prod Stripe key.
-- Has its own entrypoint in the MANIFEST when needed (Monk generates these).
-
-When the user mentions an environment by name, treat it as a real construct — ask Monk things like "deploy to staging", "what cluster is linked to prod?", "show prod logs". Don't conflate "staging" and "prod" deployments of the same code.
-
-**Always tell Monk the deployment purpose and expected scale** when designing or deploying:
-
-- *Dev / scratch* — smallest viable cluster, no HA, fast teardown.
-- *Staging / preview* — production-shaped but minimal capacity.
-- *Production* — expected RPS, payload sizes, data volume, SLO targets, region constraints.
-
-These shape cluster size, node count, DB instance class, cache sizing, and replica counts. If the user gave concrete numbers (traffic, budget, region, instance family), pass them through verbatim — don't filter or round them off.
-
-**Cost note.** Monk charges a 25% infrastructure management fee on top of the underlying cloud cost. When the user asks about price, quote both: e.g. "~$0.45/hr cloud + ~$0.11/hr Monk = ~$0.56/hr". If you don't know the cloud cost, ask Monk — it tracks real-time costs.
-
-## After the first deploy — what else Monk can do
-
-Once the app is running, Monk can wire up additional capabilities. Surface these to the user when relevant:
-
-- **GitHub Actions CI/CD** — Monk can generate a workflow that rebuilds and redeploys on push, end-to-end. Good for "ship from `main`" setups.
-- **Capsules** — per-branch ephemeral environments. Each PR/branch gets its own Monk cluster + deployment, torn down on merge/branch delete. Great for review apps and integration testing.
-- **Watcher** — an in-cluster agent that observes runtime telemetry, detects anomalies, and provides root-cause analysis. Useful for prod and staging; offer to set it up after a successful prod deploy.
-- **Rolling updates with auto-rollback.** Redeploys are zero-downtime — new version comes up, health-checks pass, traffic switches, old version drains. If health checks fail, Monk rolls back automatically. You don't need to script blue/green yourself.
-- **Backup & restore** for databases — ask Monk to set up scheduled backups and to restore on demand.
-- **Workload migration across clouds** — Monk can move a deployed workload to a different cloud provider while preserving config. Useful if the user wants to switch from e.g. Hetzner to AWS.
-- **Scaling** — natural-language scale commands ("double the API replicas", "give the DB more memory"). Monk applies them with zero-downtime if possible.
-- **Slack integration** — for teams, Monk can route alerts/approvals/queries through Slack.
-
-## Team policies / custom knowledge
-
-If the user describes recurring team rules ("never use anything bigger than t3.large", "always use RDS, never self-hosted Postgres", "no public IPs in prod"), don't just remember them in chat — suggest Monk's **Custom Policies** (Team plan). Policies are Markdown files scoped to org / environment / cluster that Monk consults before every action. They survive across sessions and apply to every team member.
-
-When the user already has policies in place, they shape Monk's choices automatically — but if Monk picks something that contradicts what the user wants, surface the conflict and ask whether the policy needs updating or whether this is a one-off exception.
-
-## App-level integrations Monk doesn't manage
-
-Some services aren't infra and don't have Monk integrations — they live in the application and get wired up via an SDK + API key. Examples: PostHog, Sentry, LogRocket, Stripe (the SDK side), Segment, feature flag platforms. For these:
-
-- **You** integrate them in app code (add the SDK, init at boot, instrument).
-- **Monk** delivers the API keys as env vars / secrets to the runtime — that's the only piece it handles.
-- Don't ask Monk to "set up PostHog" — ask Monk to provision the env var, and write the integration yourself.
-
-When in doubt whether a service is infra (Monk integration) or app-level (your code), check `monk_search_packages`; if nothing relevant comes back, treat it as app-level.
-
-## Architectural edge cases worth knowing
-
-- **Multi-cluster / multi-cell deployments.** For multitenant SaaS or geo-sharded apps, Monk can manage multiple clusters as separate cells (per-tenant, per-region, per-tier). Bring this up early when scoping architecture — it changes how the MANIFEST and templates are laid out.
-- **Dynamic resources via app code.** Even when Monk has an integration for something (e.g. domain bindings, DNS records, per-tenant resources), runtime-driven changes may need to be done from the application side using the cloud provider's SDK directly — because Monk entity changes typically require a redeploy. Rule of thumb: if it changes per request / per tenant / per user action, it belongs in app code; if it's part of the static deployment topology, let Monk own it. Flag this trade-off to the user when designing multitenant or self-service-provisioning features.
-- **AWS-native projects** (heavy use of Lambda, DynamoDB, SQS/SNS, S3, Cognito, API Gateway, SAM/serverless.yml) get a different deployment shape from Monk — Lambdas as `function` components rather than containers. If the project uses these, name them explicitly so Monk picks the AWS-native path. For mixed projects, generic databases (Postgres/Redis/Mongo) point to the standard container path.
-- **Auth0** is special-cased by Monk as a provider — let Monk handle it as an Auth0 integration rather than describing it as a generic OAuth service.
-- **Search engines:** Monk prefers OpenSearch over Elasticsearch when the app says "Elasticsearch". They're interchangeable for most use cases; only push back if the user has a specific Elasticsearch-only feature requirement.
-- **Platform-native services don't need component descriptions.** Netlify Edge Functions / Blobs, Vercel KV, similar platform-bundled services are wired up automatically when you deploy to those platforms. Don't ask Monk to "set up Netlify Blobs" — just deploy the Netlify frontend and the platform handles it.
-
-## Ops — ask Monk anything at any time
-
-`monk_chat` (or `mcp__monk__monk_workload_status` for a quick snapshot) for: logs, container stats, workload status, endpoints, cluster nodes, peers, ingress URLs, deployment history, error diagnostics. Don't hesitate to ask mid-task — Monk has the live view.
-
-## Secrets — out of band
-
-**Never put secret material in a `monk_chat` message.** API keys, passwords, tokens, private keys, certs all stay out of your messages. Monk has a separate secret-input UI; when Monk needs a secret it will prompt the user directly. Same for risky confirmations (creating cloud resources, deletions) — Monk handles those via its own confirmation flow. Your job is to describe what's needed; the user fills in the sensitive bits.
-
-## When Monk is stuck
-
-- **Monk reports an app problem (missing file, wrong port, bad config in code):** fix the application code yourself, then ask Monk to redeploy.
-- **Monk says it can't do X:** probe its capabilities. Check `monk_search_packages` for relevant integrations. If a package exists, mention it explicitly: "Can you use the `<package>` integration to do X?" If nothing fits, propose an alternative approach (different service, self-hosted equivalent, etc.) and align with the user.
-- **You're unsure what Monk supports:** consult docs at https://docs.monk.io via `WebFetch` rather than guessing.
-- **Sign-in / onboarding UI needed:** call `mcp__monk__monk_show_chat` to surface the panel to the user.
-
-## How to talk to Monk — examples
-
-**Good** (intent + context + purpose, no IaC noise):
-
-> Deploy this Next.js app for **staging** — low traffic, internal testing only, so size on the small side. Monorepo: `apps/web` (Next.js) and `services/worker` (background jobs), each with its own multi-stage Dockerfile that builds cleanly from its folder — set those as the build contexts. Needs Postgres and Redis. DB schema in `apps/web/prisma/schema.prisma`; migrations run on app boot. Env vars `STRIPE_SECRET_KEY` and `SENDGRID_API_KEY` required (user will provide). Target: AWS, eu-west-1.
-
-**Bad** (over-prescribing infra):
-
-> Create an RDS Postgres 15.4 db.t3.micro in us-east-1 in a private subnet, an ElastiCache Redis cluster with one node, set up an ALB with a target group on port 3000, attach an ACM cert for...
-
-Let Monk pick the SKUs, regions, networking, and ingress. Mention specifics only when the user has a constraint (region, instance class, existing VPC, naming convention).
-
-## Quick command map
-
-| You need to… | Tool |
-|---|---|
-| Talk to Monk (default) | `mcp__monk__monk_chat` |
-| Snapshot of running workloads | `mcp__monk__monk_workload_status` |
-| Verify an integration exists | `mcp__monk__monk_search_packages` |
-| Open the IDE chat panel for sign-in | `mcp__monk__monk_show_chat` |
-| Inspect generated MANIFEST/YAML | `Read` (read only — never edit) |
-| Confirm the app actually works | Playwright/browser MCP tools (preferred when available) or `Bash` with `curl` against the endpoint Monk returned |
-| Look up Monk capabilities/docs | `WebFetch` https://docs.monk.io |
+- <https://docs.monk.io>
+- <https://docs.monk.io/getting-started/installation>
+- <https://docs.monk.io/getting-started/first-deployment>
+- <https://docs.monk.io/integrations>
 
 ## Done condition
 
-A task is only done when the app responds correctly to a real exercise of its functionality. "Monk reports success" + verified behavior from outside → done. Prefer driving the app via a browser (Playwright/browser MCP) when available — clicking through the actual user flow gives the highest-confidence signal. When no browser tooling is available, `curl` against the returned endpoint is the fallback. If verification fails, loop back to Monk with the symptom.
+The task is done only when Monk reports success and the deployed app or workload
+has been verified from outside the deploy operation. Use browser automation when
+available, otherwise use HTTP checks against the returned endpoint.

--- a/skills/monk/references/agent-model.md
+++ b/skills/monk/references/agent-model.md
@@ -1,0 +1,31 @@
+# Portable Monk Agent Model
+
+The portable plugin should mirror the existing VS Code product shape without
+depending on VS Code APIs.
+
+## Frontman
+
+`monk-frontman` is the default operator. It keeps state, chooses a specialist,
+and explains progress. It should be status-aware: auth, install, runtime,
+workspace, events, approvals, and workloads all affect the next action.
+
+## Specialists
+
+- `monk-installer`: install, upgrade, self-test, and remediation.
+- `monk-deployer`: analyze/build/deploy/verify loop and source-code remediation.
+- `monk-editor`: MonkScript/MANIFEST diagnostics and template edits, using
+  analyzer and Chroma-backed examples exposed by `monk-agent`.
+- `monk-docs`: official docs, package/integration lookup, examples, and
+  explanation.
+
+## Future agent-served capabilities
+
+`monk-agent` should eventually expose analyzer and Chroma access through stable
+tools, not autospin internals:
+
+- `monk.analyzer.diagnose`
+- `monk.docs.search`
+- `monk://workspace/diagnostics`
+
+Early implementations may return `available:false` while preserving the public
+contract.

--- a/skills/monk/references/agent-workflow.md
+++ b/skills/monk/references/agent-workflow.md
@@ -1,0 +1,17 @@
+# Agent Workflow
+
+Use this sequence for the MVP:
+
+1. Initialize session with workspace root.
+2. Check `monk.auth.status`.
+3. Check `monk.runtime.status`.
+4. If signed out, call `monk.auth.start` and send the returned local URL.
+5. If runtime is missing, call `monk.install.status` and surface install steps.
+6. Analyze the project.
+7. Request secrets through `monk.secret.request`.
+8. Request approvals through `monk.approval.request`.
+9. Deploy with `monk.project.deploy`.
+10. Verify the app or workload externally.
+
+Never receive secret values in chat. Never bypass Monk runtime state with shell
+commands.

--- a/skills/monk/references/host-support.md
+++ b/skills/monk/references/host-support.md
@@ -1,0 +1,15 @@
+# Host Support
+
+MVP support is limited to Claude Code, OpenAI Codex, and Cursor.
+
+| Host | MVP status | Notes |
+| --- | --- | --- |
+| Claude Code | Target | Uses skill and Claude-only shell hook. |
+| OpenAI Codex | Target | Uses skill and `monk-agent` MCP endpoint. |
+| Cursor | Target | Uses skill/plugin manifest and `monk-agent` MCP endpoint. |
+| GitHub Copilot / VS Code | Placeholder | Manifest exists, but MVP does not depend on `../vscode-monk`. |
+| Other Agent Skills clients | Best effort | Skill text may work, but hooks/subagents/MCP behavior is untested. |
+
+Do not claim full portability until each host has been tested with install,
+auth, secure secret entry, local deploy, and cloud deploy approval.
+

--- a/skills/monk/references/install-troubleshooting.md
+++ b/skills/monk/references/install-troubleshooting.md
@@ -1,0 +1,91 @@
+# Install Troubleshooting
+
+The MVP requires:
+
+- `monk-agent`
+- Monk CLI: `monk`
+- Monk daemon: `monkd`
+
+Use `monk.install.status` first. If unavailable, bootstrap the local
+`monk-agent` companion with the plugin script when the host allows it:
+
+```text
+scripts/ensure-monk-agent.sh
+scripts/ensure-monk-agent.ps1
+```
+
+After `monk-agent` is available, inspect the full `monk.install.status` result:
+
+- `humanExplanation`: current-platform summary suitable for the user.
+- `relationships`: how `monk-agent`, auth, `monk`, `monkd`, and platform
+  prerequisites fit together.
+- `components`: installed/missing/outdated component state.
+- `checks`: pass/fail runtime gates.
+- `probes`: shell checks that produced the state.
+- `troubleshootingHints`: likely causes and next diagnostics.
+- `nextAction` and `actions`: recommended remediation.
+
+Use `monk.install.run` only after explicit user or dashboard approval.
+
+Claude Code and Codex can also surface native MCP OAuth for Streamable HTTP
+servers. If Monk MCP appears as "needs authentication", use the host-native auth
+flow first: `/mcp` in Claude Code, or `codex mcp login monk` in Codex CLI.
+
+## macOS
+
+Preferred path:
+
+```text
+scripts/ensure-monk-agent.sh
+brew install monk-io/monk/monk
+```
+
+If Homebrew or Xcode Command Line Tools are missing, use the remediation action
+reported by `monk.install.status`. The Homebrew installer may ask for the user's
+password and should be run only with explicit approval.
+
+Explain the graph clearly: `monk-agent` runs the local MCP/dashboard process;
+Xcode Command Line Tools make Homebrew healthy; Homebrew installs Monk; `monk
+machine` starts local `monkd`.
+
+## Linux
+
+Preferred path:
+
+```text
+scripts/ensure-monk-agent.sh
+curl -fsSL https://install.monk.io/install.sh | sh
+```
+
+If package-manager setup fails, inspect the error and tell the user whether apt
+or dnf repository setup failed.
+
+Explain the graph clearly: `monk-agent` runs MCP/dashboard; apt/dnf installs
+Monk; systemd starts and supervises `monkd`.
+
+## Windows
+
+Preferred path:
+
+```text
+scripts/ensure-monk-agent.ps1
+WSL/Ubuntu-Monk runtime install through monk.install.run
+```
+
+MVP uses native `monk-agent.exe` and a WSL-based Monk runtime. Prefer a known
+Ubuntu distro for Monk runtime work. If WSL is missing, ask the user to install
+or enable WSL first.
+
+Explain the graph clearly: native `monk-agent.exe` handles MCP/dashboard/auth;
+WSL hosts the Linux Monk CLI and `monkd`; Ubuntu-Monk is preferred so Monk state
+is isolated from the user's other distros.
+
+## After install
+
+Re-check:
+
+- `monk.install.status`
+- `monk.runtime.status`
+- `monk.auth.status`
+
+Only continue to deploy after runtime is reachable and the user is signed in.


### PR DESCRIPTION
## Summary
- rewrite plugin scope around Claude/Codex/Cursor plus local monk-agent
- add portable subagent prompts and install troubleshooting references
- add macOS/Linux and Windows monk-agent bootstrap scripts using get.monk.io nightly aliases with checksum verification
- document native MCP auth handoff for Claude Code and Codex

## Tests
- sh -n scripts/ensure-monk-agent.sh
- git diff --check

Note: pwsh is not installed in this local environment, so the PowerShell bootstrap script was not executed locally.