### PR TITLE
Test monk-agent bootstrap across platforms

### DIFF
--- a/.github/workflows/install-e2e.yml
+++ b/.github/workflows/install-e2e.yml
@@ -87,7 +87,12 @@ jobs:
         run: |
           $statusPath = "$env:RUNNER_TEMP\status.json"
           & "$env:RUNNER_TEMP\monk-bin\monk-agent.exe" status | Tee-Object -FilePath $statusPath
-          $status = Get-Content -Raw $statusPath | ConvertFrom-Json
+          $rawStatus = Get-Content -Raw $statusPath
+          $jsonStart = $rawStatus.IndexOf("{")
+          if ($jsonStart -lt 0) {
+            throw "monk-agent status did not print JSON"
+          }
+          $status = $rawStatus.Substring($jsonStart) | ConvertFrom-Json
           if (-not $status.version) {
             throw "missing version in monk-agent status"
           }

--- a/.github/workflows/install-e2e.yml
+++ b/.github/workflows/install-e2e.yml
@@ -1,0 +1,96 @@
+name: Install E2E
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  unix:
+    name: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install monk-agent
+        shell: bash
+        env:
+          MONK_AGENT_INSTALL_DIR: ${{ runner.temp }}/monk-bin
+          MONK_AGENT_CHANNEL: nightly
+        run: |
+          set -euo pipefail
+          installed="$(./scripts/ensure-monk-agent.sh)"
+          test "$installed" = "$MONK_AGENT_INSTALL_DIR/monk-agent"
+          test -x "$installed"
+
+      - name: Run monk-agent status
+        shell: bash
+        env:
+          MONK_AGENT_HOME: ${{ runner.temp }}/monk-home
+          MONK_AGENT_DEV: "1"
+          MONK_AGENT_SIMULATE_AUTH: "1"
+          MONK_AGENT_MOCK_RUNTIME: "1"
+          MONK_AGENT_VAULT_BACKEND: file
+          MONK_AGENT_STORE: file
+          MONK_TELEMETRY: "0"
+        run: |
+          set -euo pipefail
+          "$RUNNER_TEMP/monk-bin/monk-agent" status | tee "$RUNNER_TEMP/status.json"
+          grep '"version"' "$RUNNER_TEMP/status.json"
+          grep '"signedIn": true' "$RUNNER_TEMP/status.json"
+
+  windows:
+    name: windows-latest
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install monk-agent
+        shell: pwsh
+        env:
+          MONK_AGENT_INSTALL_DIR: ${{ runner.temp }}\monk-bin
+          MONK_AGENT_CHANNEL: nightly
+        run: |
+          $installed = .\scripts\ensure-monk-agent.ps1
+          if ($installed -ne "$env:MONK_AGENT_INSTALL_DIR\monk-agent.exe") {
+            throw "unexpected install path: $installed"
+          }
+          if (-not (Test-Path $installed)) {
+            throw "monk-agent.exe was not installed"
+          }
+
+      - name: Run monk-agent status
+        shell: pwsh
+        env:
+          MONK_AGENT_HOME: ${{ runner.temp }}\monk-home
+          MONK_AGENT_DEV: "1"
+          MONK_AGENT_SIMULATE_AUTH: "1"
+          MONK_AGENT_MOCK_RUNTIME: "1"
+          MONK_AGENT_VAULT_BACKEND: file
+          MONK_AGENT_STORE: file
+          MONK_TELEMETRY: "0"
+        run: |
+          $statusPath = "$env:RUNNER_TEMP\status.json"
+          & "$env:RUNNER_TEMP\monk-bin\monk-agent.exe" status | Tee-Object -FilePath $statusPath
+          $status = Get-Content -Raw $statusPath | ConvertFrom-Json
+          if (-not $status.version) {
+            throw "missing version in monk-agent status"
+          }
+          if (-not $status.auth.signedIn) {
+            throw "expected simulated auth to be signed in"
+          }

--- a/scripts/ensure-monk-agent.ps1
+++ b/scripts/ensure-monk-agent.ps1
@@ -36,7 +36,7 @@ $ChecksumTmp = Join-Path $InstallDir ".monk-agent.tmp.sha256"
 $ExtractDir = Join-Path $InstallDir ".monk-agent.extract"
 New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
 
-Write-Error "Installing monk-agent from $Url"
+Write-Host "Installing monk-agent from $Url"
 Invoke-WebRequest -Uri $Url -OutFile $ArchiveTmp
 Invoke-WebRequest -Uri $ChecksumUrl -OutFile $ChecksumTmp
 


### PR DESCRIPTION
## Summary
- add GitHub Actions install E2E coverage on ubuntu-latest, macos-latest, and windows-latest
- install monk-agent from get.monk.io nightly aliases into a temp bin directory
- run monk-agent status in mocked/dev mode to prove the downloaded binary starts
- fix PowerShell bootstrap logging so normal install progress does not use Write-Error

## Tests
- git diff --check
- sh -n scripts/ensure-monk-agent.sh

The hosted GitHub runners are the intended end-to-end validation for macOS and Windows.