### PR TITLE
Fix Codex marketplace install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Or, pointing directly at the plugin repo:
 ### OpenAI Codex
 
 ```text
-codex marketplace add monk-io/monk-plugin
+codex plugin marketplace add monk-io/monk-plugin
 ```
 
 Then start `codex`, run `/plugins`, open the `monk-plugins` marketplace, and


### PR DESCRIPTION
﻿## Summary
- Correct the OpenAI Codex marketplace command by adding the missing `plugin` subcommand.
- Keep the existing `/plugins` installation flow unchanged.

## Why
`codex marketplace add` is not a valid Codex CLI command. The supported marketplace command is `codex plugin marketplace add`, so the current README blocks Codex users during installation.

Fixes #5

## Validation
- Compared the command with the current OpenAI Codex manual.
- Ran `git diff --check`.
