### PR TITLE
Reuse healthy custom monk-agent paths

### DIFF
--- a/.antigravity-plugin/scripts/start-monk-agent.ps1
+++ b/.antigravity-plugin/scripts/start-monk-agent.ps1
@@ -18,6 +18,7 @@ $RunDir = Join-Path $DataDir "run"
 $LogOut = Join-Path $LogDir "monk-agent.out.log"
 $LogErr = Join-Path $LogDir "monk-agent.err.log"
 $PidFile = Join-Path $RunDir "monk-agent.pid"
+$PathFile = Join-Path $RunDir "monk-agent.path"
 $HealthUrl = "http://${AgentHost}:$Port/.well-known/oauth-protected-resource"
 
 New-Item -ItemType Directory -Force -Path $LogDir, $RunDir | Out-Null
@@ -172,19 +173,24 @@ try {
 }
 
 $ManagedAgentPath = Join-Path $InstallDir "monk-agent.exe"
-$AgentHashBefore = Get-FileSha256 $ManagedAgentPath
+$AgentHashBefore = ""
+$ManagedAgentEnsured = $false
+$CustomAgentPath = $false
 
 if ($env:MONK_AGENT_PATH) {
   $AgentPath = $env:MONK_AGENT_PATH
+  $CustomAgentPath = $true
 } elseif ($env:MONK_AGENT_SKIP_ENSURE -eq "1") {
   $AgentPath = $ManagedAgentPath
 } else {
+  $AgentHashBefore = Get-FileSha256 $ManagedAgentPath
   $EnsureScript = Join-Path $PluginRoot "scripts\ensure-monk-agent.ps1"
   if (-not (Test-Path $EnsureScript)) {
     Write-Error "monk-agent installer not found at $EnsureScript"
     exit 2
   }
   $AgentPath = (& $EnsureScript | Select-Object -Last 1)
+  $ManagedAgentEnsured = $true
 }
 
 $AgentPath = [string]$AgentPath
@@ -193,10 +199,23 @@ if (-not (Test-Path $AgentPath)) {
   exit 2
 }
 
-$AgentHashAfter = Get-FileSha256 $AgentPath
-$AgentUpdated = $AgentHashAfter -and ($AgentHashBefore -ne $AgentHashAfter)
+$AgentUpdated = $false
+if ($ManagedAgentEnsured) {
+  $AgentHashAfter = Get-FileSha256 $AgentPath
+  $AgentUpdated = $AgentHashAfter -and ($AgentHashBefore -ne $AgentHashAfter)
+}
 
-if (-not $AgentUpdated -and (Test-AgentRunning)) {
+function Test-AgentPathConfigured {
+  if (-not $CustomAgentPath) {
+    return $true
+  }
+  if (-not (Test-Path $PathFile)) {
+    return $false
+  }
+  return ((Get-Content -Raw $PathFile).Trim() -ieq $AgentPath)
+}
+
+if (-not $AgentUpdated -and (Test-AgentPathConfigured) -and (Test-AgentRunning)) {
   Show-SigninNudge
   exit 0
 }
@@ -221,6 +240,7 @@ $Process = Start-Process `
   -RedirectStandardError $LogErr
 
 $Process.Id | Set-Content -NoNewline $PidFile
+$AgentPath | Set-Content -NoNewline $PathFile
 
 for ($Attempt = 0; $Attempt -lt 180; $Attempt++) {
   if (Test-AgentRunning) {

--- a/.antigravity-plugin/scripts/start-monk-agent.sh
+++ b/.antigravity-plugin/scripts/start-monk-agent.sh
@@ -38,6 +38,7 @@ log_dir="$data_dir/logs"
 run_dir="$data_dir/run"
 log_file="$log_dir/monk-agent.log"
 pid_file="$run_dir/monk-agent.pid"
+path_file="$run_dir/monk-agent.path"
 launchd_label="io.monk.agent"
 launchd_plist="$HOME/Library/LaunchAgents/$launchd_label.plist"
 
@@ -183,14 +184,19 @@ hash_file() {
 
 os="$(uname -s)"
 managed_agent_path="${MONK_AGENT_INSTALL_DIR:-"$HOME/.monk/bin"}/monk-agent"
-agent_hash_before="$(hash_file "$managed_agent_path")"
+agent_hash_before=""
+managed_agent_ensured=0
+custom_agent_path=0
 
 if [ -n "${MONK_AGENT_PATH:-}" ]; then
   agent_path="$MONK_AGENT_PATH"
+  custom_agent_path=1
 elif [ "${MONK_AGENT_SKIP_ENSURE:-0}" = "1" ]; then
   agent_path="$managed_agent_path"
 else
+  agent_hash_before="$(hash_file "$managed_agent_path")"
   agent_path="$("$plugin_root/scripts/ensure-monk-agent.sh")"
+  managed_agent_ensured=1
 fi
 
 if [ ! -x "$agent_path" ]; then
@@ -198,10 +204,12 @@ if [ ! -x "$agent_path" ]; then
   exit 2
 fi
 
-agent_hash_after="$(hash_file "$agent_path")"
 agent_updated=0
-if [ -n "$agent_hash_after" ] && [ "$agent_hash_before" != "$agent_hash_after" ]; then
-  agent_updated=1
+if [ "$managed_agent_ensured" = "1" ]; then
+  agent_hash_after="$(hash_file "$agent_path")"
+  if [ -n "$agent_hash_after" ] && [ "$agent_hash_before" != "$agent_hash_after" ]; then
+    agent_updated=1
+  fi
 fi
 
 launchd_configured() {
@@ -217,6 +225,7 @@ launchd_configured() {
   # moment the agent should restart so telemetry reports the new version. It
   # cannot cause the per-session restart churn PATH did.
   [ -f "$launchd_plist" ] &&
+    grep -Fq "<string>$agent_path</string>" "$launchd_plist" &&
     grep -q "<string>$auth_client_id</string>" "$launchd_plist" &&
     grep -q "<string>$auth_url</string>" "$launchd_plist" &&
     grep -q "<string>$auth_audience</string>" "$launchd_plist" &&
@@ -225,8 +234,13 @@ launchd_configured() {
     grep -q "<string>${MONK_PLUGIN_VERSION:-}</string>" "$launchd_plist"
 }
 
+background_process_configured() {
+  [ "$custom_agent_path" != "1" ] ||
+    { [ -f "$path_file" ] && [ "$(cat "$path_file" 2>/dev/null || true)" = "$agent_path" ]; }
+}
+
 if [ "${MONK_AGENT_SKIP_ENSURE:-0}" != "1" ]; then
-  if [ "$os" != "Darwin" ] && [ "$agent_updated" = "0" ] && is_running; then
+  if [ "$os" != "Darwin" ] && [ "$agent_updated" = "0" ] && background_process_configured && is_running; then
     register_antigravity_mcp
     emit_signin_nudge
     exit 0
@@ -316,6 +330,7 @@ start_with_background_process() {
   fi
   pid="$!"
   printf '%s\n' "$pid" >"$pid_file"
+  printf '%s\n' "$agent_path" >"$path_file"
 }
 
 case "$os" in

--- a/plugins/monk/scripts/start-monk-agent.ps1
+++ b/plugins/monk/scripts/start-monk-agent.ps1
@@ -18,6 +18,7 @@ $RunDir = Join-Path $DataDir "run"
 $LogOut = Join-Path $LogDir "monk-agent.out.log"
 $LogErr = Join-Path $LogDir "monk-agent.err.log"
 $PidFile = Join-Path $RunDir "monk-agent.pid"
+$PathFile = Join-Path $RunDir "monk-agent.path"
 $HealthUrl = "http://${AgentHost}:$Port/.well-known/oauth-protected-resource"
 
 New-Item -ItemType Directory -Force -Path $LogDir, $RunDir | Out-Null
@@ -172,19 +173,24 @@ try {
 }
 
 $ManagedAgentPath = Join-Path $InstallDir "monk-agent.exe"
-$AgentHashBefore = Get-FileSha256 $ManagedAgentPath
+$AgentHashBefore = ""
+$ManagedAgentEnsured = $false
+$CustomAgentPath = $false
 
 if ($env:MONK_AGENT_PATH) {
   $AgentPath = $env:MONK_AGENT_PATH
+  $CustomAgentPath = $true
 } elseif ($env:MONK_AGENT_SKIP_ENSURE -eq "1") {
   $AgentPath = $ManagedAgentPath
 } else {
+  $AgentHashBefore = Get-FileSha256 $ManagedAgentPath
   $EnsureScript = Join-Path $PluginRoot "scripts\ensure-monk-agent.ps1"
   if (-not (Test-Path $EnsureScript)) {
     Write-Error "monk-agent installer not found at $EnsureScript"
     exit 2
   }
   $AgentPath = (& $EnsureScript | Select-Object -Last 1)
+  $ManagedAgentEnsured = $true
 }
 
 $AgentPath = [string]$AgentPath
@@ -193,10 +199,23 @@ if (-not (Test-Path $AgentPath)) {
   exit 2
 }
 
-$AgentHashAfter = Get-FileSha256 $AgentPath
-$AgentUpdated = $AgentHashAfter -and ($AgentHashBefore -ne $AgentHashAfter)
+$AgentUpdated = $false
+if ($ManagedAgentEnsured) {
+  $AgentHashAfter = Get-FileSha256 $AgentPath
+  $AgentUpdated = $AgentHashAfter -and ($AgentHashBefore -ne $AgentHashAfter)
+}
 
-if (-not $AgentUpdated -and (Test-AgentRunning)) {
+function Test-AgentPathConfigured {
+  if (-not $CustomAgentPath) {
+    return $true
+  }
+  if (-not (Test-Path $PathFile)) {
+    return $false
+  }
+  return ((Get-Content -Raw $PathFile).Trim() -ieq $AgentPath)
+}
+
+if (-not $AgentUpdated -and (Test-AgentPathConfigured) -and (Test-AgentRunning)) {
   Show-SigninNudge
   exit 0
 }
@@ -221,6 +240,7 @@ $Process = Start-Process `
   -RedirectStandardError $LogErr
 
 $Process.Id | Set-Content -NoNewline $PidFile
+$AgentPath | Set-Content -NoNewline $PathFile
 
 for ($Attempt = 0; $Attempt -lt 180; $Attempt++) {
   if (Test-AgentRunning) {

--- a/plugins/monk/scripts/start-monk-agent.sh
+++ b/plugins/monk/scripts/start-monk-agent.sh
@@ -38,6 +38,7 @@ log_dir="$data_dir/logs"
 run_dir="$data_dir/run"
 log_file="$log_dir/monk-agent.log"
 pid_file="$run_dir/monk-agent.pid"
+path_file="$run_dir/monk-agent.path"
 launchd_label="io.monk.agent"
 launchd_plist="$HOME/Library/LaunchAgents/$launchd_label.plist"
 
@@ -183,14 +184,19 @@ hash_file() {
 
 os="$(uname -s)"
 managed_agent_path="${MONK_AGENT_INSTALL_DIR:-"$HOME/.monk/bin"}/monk-agent"
-agent_hash_before="$(hash_file "$managed_agent_path")"
+agent_hash_before=""
+managed_agent_ensured=0
+custom_agent_path=0
 
 if [ -n "${MONK_AGENT_PATH:-}" ]; then
   agent_path="$MONK_AGENT_PATH"
+  custom_agent_path=1
 elif [ "${MONK_AGENT_SKIP_ENSURE:-0}" = "1" ]; then
   agent_path="$managed_agent_path"
 else
+  agent_hash_before="$(hash_file "$managed_agent_path")"
   agent_path="$("$plugin_root/scripts/ensure-monk-agent.sh")"
+  managed_agent_ensured=1
 fi
 
 if [ ! -x "$agent_path" ]; then
@@ -198,10 +204,12 @@ if [ ! -x "$agent_path" ]; then
   exit 2
 fi
 
-agent_hash_after="$(hash_file "$agent_path")"
 agent_updated=0
-if [ -n "$agent_hash_after" ] && [ "$agent_hash_before" != "$agent_hash_after" ]; then
-  agent_updated=1
+if [ "$managed_agent_ensured" = "1" ]; then
+  agent_hash_after="$(hash_file "$agent_path")"
+  if [ -n "$agent_hash_after" ] && [ "$agent_hash_before" != "$agent_hash_after" ]; then
+    agent_updated=1
+  fi
 fi
 
 launchd_configured() {
@@ -217,6 +225,7 @@ launchd_configured() {
   # moment the agent should restart so telemetry reports the new version. It
   # cannot cause the per-session restart churn PATH did.
   [ -f "$launchd_plist" ] &&
+    grep -Fq "<string>$agent_path</string>" "$launchd_plist" &&
     grep -q "<string>$auth_client_id</string>" "$launchd_plist" &&
     grep -q "<string>$auth_url</string>" "$launchd_plist" &&
     grep -q "<string>$auth_audience</string>" "$launchd_plist" &&
@@ -225,8 +234,13 @@ launchd_configured() {
     grep -q "<string>${MONK_PLUGIN_VERSION:-}</string>" "$launchd_plist"
 }
 
+background_process_configured() {
+  [ "$custom_agent_path" != "1" ] ||
+    { [ -f "$path_file" ] && [ "$(cat "$path_file" 2>/dev/null || true)" = "$agent_path" ]; }
+}
+
 if [ "${MONK_AGENT_SKIP_ENSURE:-0}" != "1" ]; then
-  if [ "$os" != "Darwin" ] && [ "$agent_updated" = "0" ] && is_running; then
+  if [ "$os" != "Darwin" ] && [ "$agent_updated" = "0" ] && background_process_configured && is_running; then
     register_antigravity_mcp
     emit_signin_nudge
     exit 0
@@ -316,6 +330,7 @@ start_with_background_process() {
   fi
   pid="$!"
   printf '%s\n' "$pid" >"$pid_file"
+  printf '%s\n' "$agent_path" >"$path_file"
 }
 
 case "$os" in

--- a/scripts/start-monk-agent.ps1
+++ b/scripts/start-monk-agent.ps1
@@ -18,6 +18,7 @@ $RunDir = Join-Path $DataDir "run"
 $LogOut = Join-Path $LogDir "monk-agent.out.log"
 $LogErr = Join-Path $LogDir "monk-agent.err.log"
 $PidFile = Join-Path $RunDir "monk-agent.pid"
+$PathFile = Join-Path $RunDir "monk-agent.path"
 $HealthUrl = "http://${AgentHost}:$Port/.well-known/oauth-protected-resource"
 
 New-Item -ItemType Directory -Force -Path $LogDir, $RunDir | Out-Null
@@ -172,19 +173,24 @@ try {
 }
 
 $ManagedAgentPath = Join-Path $InstallDir "monk-agent.exe"
-$AgentHashBefore = Get-FileSha256 $ManagedAgentPath
+$AgentHashBefore = ""
+$ManagedAgentEnsured = $false
+$CustomAgentPath = $false
 
 if ($env:MONK_AGENT_PATH) {
   $AgentPath = $env:MONK_AGENT_PATH
+  $CustomAgentPath = $true
 } elseif ($env:MONK_AGENT_SKIP_ENSURE -eq "1") {
   $AgentPath = $ManagedAgentPath
 } else {
+  $AgentHashBefore = Get-FileSha256 $ManagedAgentPath
   $EnsureScript = Join-Path $PluginRoot "scripts\ensure-monk-agent.ps1"
   if (-not (Test-Path $EnsureScript)) {
     Write-Error "monk-agent installer not found at $EnsureScript"
     exit 2
   }
   $AgentPath = (& $EnsureScript | Select-Object -Last 1)
+  $ManagedAgentEnsured = $true
 }
 
 $AgentPath = [string]$AgentPath
@@ -193,10 +199,23 @@ if (-not (Test-Path $AgentPath)) {
   exit 2
 }
 
-$AgentHashAfter = Get-FileSha256 $AgentPath
-$AgentUpdated = $AgentHashAfter -and ($AgentHashBefore -ne $AgentHashAfter)
+$AgentUpdated = $false
+if ($ManagedAgentEnsured) {
+  $AgentHashAfter = Get-FileSha256 $AgentPath
+  $AgentUpdated = $AgentHashAfter -and ($AgentHashBefore -ne $AgentHashAfter)
+}
 
-if (-not $AgentUpdated -and (Test-AgentRunning)) {
+function Test-AgentPathConfigured {
+  if (-not $CustomAgentPath) {
+    return $true
+  }
+  if (-not (Test-Path $PathFile)) {
+    return $false
+  }
+  return ((Get-Content -Raw $PathFile).Trim() -ieq $AgentPath)
+}
+
+if (-not $AgentUpdated -and (Test-AgentPathConfigured) -and (Test-AgentRunning)) {
   Show-SigninNudge
   exit 0
 }
@@ -221,6 +240,7 @@ $Process = Start-Process `
   -RedirectStandardError $LogErr
 
 $Process.Id | Set-Content -NoNewline $PidFile
+$AgentPath | Set-Content -NoNewline $PathFile
 
 for ($Attempt = 0; $Attempt -lt 180; $Attempt++) {
   if (Test-AgentRunning) {

--- a/scripts/start-monk-agent.sh
+++ b/scripts/start-monk-agent.sh
@@ -38,6 +38,7 @@ log_dir="$data_dir/logs"
 run_dir="$data_dir/run"
 log_file="$log_dir/monk-agent.log"
 pid_file="$run_dir/monk-agent.pid"
+path_file="$run_dir/monk-agent.path"
 launchd_label="io.monk.agent"
 launchd_plist="$HOME/Library/LaunchAgents/$launchd_label.plist"
 
@@ -183,14 +184,19 @@ hash_file() {
 
 os="$(uname -s)"
 managed_agent_path="${MONK_AGENT_INSTALL_DIR:-"$HOME/.monk/bin"}/monk-agent"
-agent_hash_before="$(hash_file "$managed_agent_path")"
+agent_hash_before=""
+managed_agent_ensured=0
+custom_agent_path=0
 
 if [ -n "${MONK_AGENT_PATH:-}" ]; then
   agent_path="$MONK_AGENT_PATH"
+  custom_agent_path=1
 elif [ "${MONK_AGENT_SKIP_ENSURE:-0}" = "1" ]; then
   agent_path="$managed_agent_path"
 else
+  agent_hash_before="$(hash_file "$managed_agent_path")"
   agent_path="$("$plugin_root/scripts/ensure-monk-agent.sh")"
+  managed_agent_ensured=1
 fi
 
 if [ ! -x "$agent_path" ]; then
@@ -198,10 +204,12 @@ if [ ! -x "$agent_path" ]; then
   exit 2
 fi
 
-agent_hash_after="$(hash_file "$agent_path")"
 agent_updated=0
-if [ -n "$agent_hash_after" ] && [ "$agent_hash_before" != "$agent_hash_after" ]; then
-  agent_updated=1
+if [ "$managed_agent_ensured" = "1" ]; then
+  agent_hash_after="$(hash_file "$agent_path")"
+  if [ -n "$agent_hash_after" ] && [ "$agent_hash_before" != "$agent_hash_after" ]; then
+    agent_updated=1
+  fi
 fi
 
 launchd_configured() {
@@ -217,6 +225,7 @@ launchd_configured() {
   # moment the agent should restart so telemetry reports the new version. It
   # cannot cause the per-session restart churn PATH did.
   [ -f "$launchd_plist" ] &&
+    grep -Fq "<string>$agent_path</string>" "$launchd_plist" &&
     grep -q "<string>$auth_client_id</string>" "$launchd_plist" &&
     grep -q "<string>$auth_url</string>" "$launchd_plist" &&
     grep -q "<string>$auth_audience</string>" "$launchd_plist" &&
@@ -225,8 +234,13 @@ launchd_configured() {
     grep -q "<string>${MONK_PLUGIN_VERSION:-}</string>" "$launchd_plist"
 }
 
+background_process_configured() {
+  [ "$custom_agent_path" != "1" ] ||
+    { [ -f "$path_file" ] && [ "$(cat "$path_file" 2>/dev/null || true)" = "$agent_path" ]; }
+}
+
 if [ "${MONK_AGENT_SKIP_ENSURE:-0}" != "1" ]; then
-  if [ "$os" != "Darwin" ] && [ "$agent_updated" = "0" ] && is_running; then
+  if [ "$os" != "Darwin" ] && [ "$agent_updated" = "0" ] && background_process_configured && is_running; then
     register_antigravity_mcp
     emit_signin_nudge
     exit 0
@@ -316,6 +330,7 @@ start_with_background_process() {
   fi
   pid="$!"
   printf '%s\n' "$pid" >"$pid_file"
+  printf '%s\n' "$agent_path" >"$path_file"
 }
 
 case "$os" in

--- a/tests/fixtures/start-monk-agent/curl
+++ b/tests/fixtures/start-monk-agent/curl
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+printf '%s\n' '{"resource":"http://127.0.0.1:7419/mcp"}'

--- a/tests/fixtures/start-monk-agent/uname
+++ b/tests/fixtures/start-monk-agent/uname
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+printf '%s\n' 'Linux'

--- a/tests/start-monk-agent-custom-path.sh
+++ b/tests/start-monk-agent-custom-path.sh
@@ -3,17 +3,24 @@ set -eu
 
 repo_root="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
 fixture_bin="$repo_root/tests/fixtures/start-monk-agent"
-tmp_dir="$(mktemp -d)"
-trap 'rm -rf "$tmp_dir"' EXIT HUP INT TERM
-run_dir="$tmp_dir/monk/agent/launcher/run"
+same_dir="$(mktemp -d)"
+changed_dir="$(mktemp -d)"
+trap 'rm -rf "$same_dir" "$changed_dir"' EXIT HUP INT TERM
+
+run_launcher() {
+  agent_home="$1"
+  PATH="$fixture_bin:/usr/bin:/bin" \
+  MONK_AGENT_PATH=/usr/bin/true \
+  MONK_AGENT_HOME="$agent_home" \
+  MONK_AGENT_SKIP_SIGNIN_NUDGE=1 \
+    "$repo_root/scripts/start-monk-agent.sh"
+}
+
+run_dir="$same_dir/monk/agent/launcher/run"
 mkdir -p "$run_dir"
 printf '%s\n' /usr/bin/true >"$run_dir/monk-agent.path"
 
-PATH="$fixture_bin:/usr/bin:/bin" \
-MONK_AGENT_PATH=/usr/bin/true \
-MONK_AGENT_HOME="$tmp_dir/monk" \
-MONK_AGENT_SKIP_SIGNIN_NUDGE=1 \
-  "$repo_root/scripts/start-monk-agent.sh"
+run_launcher "$same_dir/monk"
 
 pid_file="$run_dir/monk-agent.pid"
 if [ -e "$pid_file" ]; then
@@ -21,4 +28,19 @@ if [ -e "$pid_file" ]; then
   exit 1
 fi
 
-echo "custom agent was reused"
+changed_run_dir="$changed_dir/monk/agent/launcher/run"
+mkdir -p "$changed_run_dir"
+printf '%s\n' /usr/bin/false >"$changed_run_dir/monk-agent.path"
+
+run_launcher "$changed_dir/monk"
+
+if [ ! -e "$changed_run_dir/monk-agent.pid" ]; then
+  echo "custom agent was not restarted after its configured path changed" >&2
+  exit 1
+fi
+if [ "$(cat "$changed_run_dir/monk-agent.path")" != /usr/bin/true ]; then
+  echo "updated custom agent path was not recorded" >&2
+  exit 1
+fi
+
+echo "custom agent was reused when unchanged and restarted once when changed"

--- a/tests/start-monk-agent-custom-path.sh
+++ b/tests/start-monk-agent-custom-path.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env sh
+set -eu
+
+repo_root="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+fixture_bin="$repo_root/tests/fixtures/start-monk-agent"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT HUP INT TERM
+run_dir="$tmp_dir/monk/agent/launcher/run"
+mkdir -p "$run_dir"
+printf '%s\n' /usr/bin/true >"$run_dir/monk-agent.path"
+
+PATH="$fixture_bin:/usr/bin:/bin" \
+MONK_AGENT_PATH=/usr/bin/true \
+MONK_AGENT_HOME="$tmp_dir/monk" \
+MONK_AGENT_SKIP_SIGNIN_NUDGE=1 \
+  "$repo_root/scripts/start-monk-agent.sh"
+
+pid_file="$run_dir/monk-agent.pid"
+if [ -e "$pid_file" ]; then
+  echo "custom agent was restarted even though the health check passed" >&2
+  exit 1
+fi
+
+echo "custom agent was reused"


### PR DESCRIPTION
## Summary

- calculate binary-update hashes only when the managed installer actually ran
- record the selected custom executable path and reuse a healthy companion only when that path still matches
- make the macOS launchd configuration check include the selected executable
- apply the same behavior to the POSIX and PowerShell launchers across all three distributed script copies
- add deterministic regression coverage for reuse when the custom path is unchanged and one restart when it changes

## Root cause

With `MONK_AGENT_PATH` set, the launchers calculated the “before” hash from the managed install but the “after” hash from the custom executable. Those two unrelated files normally differ, so every session set `agent_updated`/`AgentUpdated` and bypassed the healthy-agent fast path.

## User impact

A custom companion now restarts once when the configured executable changes, then remains running across later sessions while it is healthy. This avoids unnecessary process or launchd churn and prevents avoidable MCP/auth-session interruption during local plugin development.

## Validation

- reproduced the failure against the unmodified launcher with a healthy local endpoint fixture
- `sh tests/start-monk-agent-custom-path.sh` (proves unchanged-path reuse and changed-path restart)
- `sh -n scripts/start-monk-agent.sh`
- `sh -n plugins/monk/scripts/start-monk-agent.sh`
- confirmed root and packaged POSIX launchers are identical
- confirmed root and packaged PowerShell launchers are identical
- confirmed the hidden Antigravity launcher copies are identical too
- `git diff --check`

Fixes #10
