### PR TITLE
fix(launcher): don't abort on malformed Antigravity MCP config

### DIFF
--- a/.antigravity-plugin/scripts/start-monk-agent.sh
+++ b/.antigravity-plugin/scripts/start-monk-agent.sh
@@ -62,24 +62,37 @@ register_antigravity_mcp() {
     has_existing=1
   fi
   tmp="$(mktemp)"
-  if command -v jq >/dev/null 2>&1; then
-    if [ "$has_existing" = "1" ]; then
-      jq --arg u "$server_url" '.mcpServers.monk = {serverUrl: $u}' "$mcp_cfg" >"$tmp"
-    else
-      jq -n --arg u "$server_url" '{mcpServers: {monk: {serverUrl: $u}}}' >"$tmp"
+  if [ "$has_existing" = "1" ] && command -v jq >/dev/null 2>&1; then
+    # Validate the existing config before merging — a malformed file must not
+    # abort the launcher (set -e). If jq can't parse it, warn and fall back to
+    # manual instructions.
+    if ! jq empty "$mcp_cfg" 2>/dev/null; then
+      rm -f "$tmp"
+      echo "Warning: $mcp_cfg is not valid JSON — skipping auto-registration." >&2
+      echo "Fix the file or add monk manually:" >&2
+      printf '  {"mcpServers":{"monk":{"serverUrl":"%s"}}}\n' "$server_url" >&2
+      return 0
     fi
-  elif command -v python3 >/dev/null 2>&1; then
-    if [ "$has_existing" = "1" ]; then
-      python3 -c "
+    jq --arg u "$server_url" '.mcpServers.monk = {serverUrl: $u}' "$mcp_cfg" >"$tmp"
+  elif [ "$has_existing" = "0" ] && command -v jq >/dev/null 2>&1; then
+    jq -n --arg u "$server_url" '{mcpServers: {monk: {serverUrl: $u}}}' >"$tmp"
+  elif [ "$has_existing" = "1" ] && command -v python3 >/dev/null 2>&1; then
+    if ! python3 -c "import json; json.load(open('$mcp_cfg'))" 2>/dev/null; then
+      rm -f "$tmp"
+      echo "Warning: $mcp_cfg is not valid JSON — skipping auto-registration." >&2
+      echo "Fix the file or add monk manually:" >&2
+      printf '  {"mcpServers":{"monk":{"serverUrl":"%s"}}}\n' "$server_url" >&2
+      return 0
+    fi
+    python3 -c "
 import json, sys
 cfg = json.load(open('$mcp_cfg'))
 cfg.setdefault('mcpServers', {})['monk'] = {'serverUrl': '$server_url'}
 json.dump(cfg, sys.stdout, indent=2)
 print()
 " >"$tmp"
-    else
-      printf '{"mcpServers":{"monk":{"serverUrl":"%s"}}}\n' "$server_url" >"$tmp"
-    fi
+  elif [ "$has_existing" = "0" ] && command -v python3 >/dev/null 2>&1; then
+    printf '{"mcpServers":{"monk":{"serverUrl":"%s"}}}\n' "$server_url" >"$tmp"
   else
     rm -f "$tmp"
     echo "Add monk to $mcp_cfg to enable Antigravity MCP (jq or python3 required to auto-write):" >&2

--- a/plugins/monk/scripts/start-monk-agent.sh
+++ b/plugins/monk/scripts/start-monk-agent.sh
@@ -62,24 +62,37 @@ register_antigravity_mcp() {
     has_existing=1
   fi
   tmp="$(mktemp)"
-  if command -v jq >/dev/null 2>&1; then
-    if [ "$has_existing" = "1" ]; then
-      jq --arg u "$server_url" '.mcpServers.monk = {serverUrl: $u}' "$mcp_cfg" >"$tmp"
-    else
-      jq -n --arg u "$server_url" '{mcpServers: {monk: {serverUrl: $u}}}' >"$tmp"
+  if [ "$has_existing" = "1" ] && command -v jq >/dev/null 2>&1; then
+    # Validate the existing config before merging — a malformed file must not
+    # abort the launcher (set -e). If jq can't parse it, warn and fall back to
+    # manual instructions.
+    if ! jq empty "$mcp_cfg" 2>/dev/null; then
+      rm -f "$tmp"
+      echo "Warning: $mcp_cfg is not valid JSON — skipping auto-registration." >&2
+      echo "Fix the file or add monk manually:" >&2
+      printf '  {"mcpServers":{"monk":{"serverUrl":"%s"}}}\n' "$server_url" >&2
+      return 0
     fi
-  elif command -v python3 >/dev/null 2>&1; then
-    if [ "$has_existing" = "1" ]; then
-      python3 -c "
+    jq --arg u "$server_url" '.mcpServers.monk = {serverUrl: $u}' "$mcp_cfg" >"$tmp"
+  elif [ "$has_existing" = "0" ] && command -v jq >/dev/null 2>&1; then
+    jq -n --arg u "$server_url" '{mcpServers: {monk: {serverUrl: $u}}}' >"$tmp"
+  elif [ "$has_existing" = "1" ] && command -v python3 >/dev/null 2>&1; then
+    if ! python3 -c "import json; json.load(open('$mcp_cfg'))" 2>/dev/null; then
+      rm -f "$tmp"
+      echo "Warning: $mcp_cfg is not valid JSON — skipping auto-registration." >&2
+      echo "Fix the file or add monk manually:" >&2
+      printf '  {"mcpServers":{"monk":{"serverUrl":"%s"}}}\n' "$server_url" >&2
+      return 0
+    fi
+    python3 -c "
 import json, sys
 cfg = json.load(open('$mcp_cfg'))
 cfg.setdefault('mcpServers', {})['monk'] = {'serverUrl': '$server_url'}
 json.dump(cfg, sys.stdout, indent=2)
 print()
 " >"$tmp"
-    else
-      printf '{"mcpServers":{"monk":{"serverUrl":"%s"}}}\n' "$server_url" >"$tmp"
-    fi
+  elif [ "$has_existing" = "0" ] && command -v python3 >/dev/null 2>&1; then
+    printf '{"mcpServers":{"monk":{"serverUrl":"%s"}}}\n' "$server_url" >"$tmp"
   else
     rm -f "$tmp"
     echo "Add monk to $mcp_cfg to enable Antigravity MCP (jq or python3 required to auto-write):" >&2

--- a/scripts/start-monk-agent.sh
+++ b/scripts/start-monk-agent.sh
@@ -62,24 +62,37 @@ register_antigravity_mcp() {
     has_existing=1
   fi
   tmp="$(mktemp)"
-  if command -v jq >/dev/null 2>&1; then
-    if [ "$has_existing" = "1" ]; then
-      jq --arg u "$server_url" '.mcpServers.monk = {serverUrl: $u}' "$mcp_cfg" >"$tmp"
-    else
-      jq -n --arg u "$server_url" '{mcpServers: {monk: {serverUrl: $u}}}' >"$tmp"
+  if [ "$has_existing" = "1" ] && command -v jq >/dev/null 2>&1; then
+    # Validate the existing config before merging — a malformed file must not
+    # abort the launcher (set -e). If jq can't parse it, warn and fall back to
+    # manual instructions.
+    if ! jq empty "$mcp_cfg" 2>/dev/null; then
+      rm -f "$tmp"
+      echo "Warning: $mcp_cfg is not valid JSON — skipping auto-registration." >&2
+      echo "Fix the file or add monk manually:" >&2
+      printf '  {"mcpServers":{"monk":{"serverUrl":"%s"}}}\n' "$server_url" >&2
+      return 0
     fi
-  elif command -v python3 >/dev/null 2>&1; then
-    if [ "$has_existing" = "1" ]; then
-      python3 -c "
+    jq --arg u "$server_url" '.mcpServers.monk = {serverUrl: $u}' "$mcp_cfg" >"$tmp"
+  elif [ "$has_existing" = "0" ] && command -v jq >/dev/null 2>&1; then
+    jq -n --arg u "$server_url" '{mcpServers: {monk: {serverUrl: $u}}}' >"$tmp"
+  elif [ "$has_existing" = "1" ] && command -v python3 >/dev/null 2>&1; then
+    if ! python3 -c "import json; json.load(open('$mcp_cfg'))" 2>/dev/null; then
+      rm -f "$tmp"
+      echo "Warning: $mcp_cfg is not valid JSON — skipping auto-registration." >&2
+      echo "Fix the file or add monk manually:" >&2
+      printf '  {"mcpServers":{"monk":{"serverUrl":"%s"}}}\n' "$server_url" >&2
+      return 0
+    fi
+    python3 -c "
 import json, sys
 cfg = json.load(open('$mcp_cfg'))
 cfg.setdefault('mcpServers', {})['monk'] = {'serverUrl': '$server_url'}
 json.dump(cfg, sys.stdout, indent=2)
 print()
 " >"$tmp"
-    else
-      printf '{"mcpServers":{"monk":{"serverUrl":"%s"}}}\n' "$server_url" >"$tmp"
-    fi
+  elif [ "$has_existing" = "0" ] && command -v python3 >/dev/null 2>&1; then
+    printf '{"mcpServers":{"monk":{"serverUrl":"%s"}}}\n' "$server_url" >"$tmp"
   else
     rm -f "$tmp"
     echo "Add monk to $mcp_cfg to enable Antigravity MCP (jq or python3 required to auto-write):" >&2


### PR DESCRIPTION
## Problem

When `~/.gemini/config/mcp_config.json` exists but contains invalid JSON (e.g. `{invalid`), the launcher crashes with exit code 5 even though the Monk companion is healthy:

```
jq: parse error: Invalid numeric literal
```

This happens because `register_antigravity_mcp` runs `jq` directly on the existing config. The launcher uses `set -e`, so jq's non-zero exit propagates and kills the entire script right after the health check succeeds.

This is especially bad because the registration runs whenever `~/.gemini/config/` exists — even when the current host is Codex or Claude Code, not Antigravity. A damaged Antigravity config can prevent an otherwise healthy session from starting in a completely different coding agent.

## Fix

`register_antigravity_mcp` now validates the existing config before attempting to merge:

- If `jq` is available, runs `jq empty` first to check the file parses. On failure, prints a warning with manual instructions and returns 0.
- Same validation for the `python3` fallback path (`json.load` in a pre-check).
- Empty/missing files are unaffected — they always worked and still do.

## Testing

```bash
# malformed config (the bug)
printf '{invalid' > ~/.gemini/config/mcp_config.json
# Before: launcher exits 5, jq parse error
# After:  warning printed, launcher continues, agent starts

# valid config
printf '{"existing":"config"}' > ~/.gemini/config/mcp_config.json
# Before & After: monk merged in correctly

# no config file
rm ~/.gemini/config/mcp_config.json
# Before & After: fresh config created with monk entry
```

All three cases verified — no regression in the valid/missing paths.

Fixes #12