### PR TITLE
fix(launcher): custom MONK_AGENT_PATH no longer restarts healthy agent every session

### DIFF
--- a/.antigravity-plugin/scripts/start-monk-agent.ps1
+++ b/.antigravity-plugin/scripts/start-monk-agent.ps1
@@ -172,7 +172,6 @@ try {
 }
 
 $ManagedAgentPath = Join-Path $InstallDir "monk-agent.exe"
-$AgentHashBefore = Get-FileSha256 $ManagedAgentPath
 
 if ($env:MONK_AGENT_PATH) {
   $AgentPath = $env:MONK_AGENT_PATH
@@ -193,6 +192,12 @@ if (-not (Test-Path $AgentPath)) {
   exit 2
 }
 
+# Both hashes must come from the resolved $AgentPath so a custom
+# MONK_AGENT_PATH doesn't look "updated" on every launch. Previously
+# $AgentHashBefore was read from $ManagedAgentPath while $AgentHashAfter
+# came from $AgentPath — when those differed (e.g. a custom executable),
+# the hashes never matched and the launcher restarted every session.
+$AgentHashBefore = Get-FileSha256 $AgentPath
 $AgentHashAfter = Get-FileSha256 $AgentPath
 $AgentUpdated = $AgentHashAfter -and ($AgentHashBefore -ne $AgentHashAfter)
 

--- a/.antigravity-plugin/scripts/start-monk-agent.sh
+++ b/.antigravity-plugin/scripts/start-monk-agent.sh
@@ -183,7 +183,6 @@ hash_file() {
 
 os="$(uname -s)"
 managed_agent_path="${MONK_AGENT_INSTALL_DIR:-"$HOME/.monk/bin"}/monk-agent"
-agent_hash_before="$(hash_file "$managed_agent_path")"
 
 if [ -n "${MONK_AGENT_PATH:-}" ]; then
   agent_path="$MONK_AGENT_PATH"
@@ -198,6 +197,13 @@ if [ ! -x "$agent_path" ]; then
   exit 2
 fi
 
+# Both hashes must come from the resolved agent_path so that a custom
+# MONK_AGENT_PATH doesn'''t look "updated" on every invocation. Previously
+# agent_hash_before was read from managed_agent_path while agent_hash_after
+# came from agent_path — when those differed (e.g. a custom executable),
+# the hashes never matched and the launcher always skipped the healthy
+# fast-path, restarting the agent every session.
+agent_hash_before="$(hash_file "$agent_path")"
 agent_hash_after="$(hash_file "$agent_path")"
 agent_updated=0
 if [ -n "$agent_hash_after" ] && [ "$agent_hash_before" != "$agent_hash_after" ]; then

--- a/plugins/monk/scripts/start-monk-agent.ps1
+++ b/plugins/monk/scripts/start-monk-agent.ps1
@@ -172,7 +172,6 @@ try {
 }
 
 $ManagedAgentPath = Join-Path $InstallDir "monk-agent.exe"
-$AgentHashBefore = Get-FileSha256 $ManagedAgentPath
 
 if ($env:MONK_AGENT_PATH) {
   $AgentPath = $env:MONK_AGENT_PATH
@@ -193,6 +192,12 @@ if (-not (Test-Path $AgentPath)) {
   exit 2
 }
 
+# Both hashes must come from the resolved $AgentPath so a custom
+# MONK_AGENT_PATH doesn't look "updated" on every launch. Previously
+# $AgentHashBefore was read from $ManagedAgentPath while $AgentHashAfter
+# came from $AgentPath — when those differed (e.g. a custom executable),
+# the hashes never matched and the launcher restarted every session.
+$AgentHashBefore = Get-FileSha256 $AgentPath
 $AgentHashAfter = Get-FileSha256 $AgentPath
 $AgentUpdated = $AgentHashAfter -and ($AgentHashBefore -ne $AgentHashAfter)
 

--- a/plugins/monk/scripts/start-monk-agent.sh
+++ b/plugins/monk/scripts/start-monk-agent.sh
@@ -183,7 +183,6 @@ hash_file() {
 
 os="$(uname -s)"
 managed_agent_path="${MONK_AGENT_INSTALL_DIR:-"$HOME/.monk/bin"}/monk-agent"
-agent_hash_before="$(hash_file "$managed_agent_path")"
 
 if [ -n "${MONK_AGENT_PATH:-}" ]; then
   agent_path="$MONK_AGENT_PATH"
@@ -198,6 +197,13 @@ if [ ! -x "$agent_path" ]; then
   exit 2
 fi
 
+# Both hashes must come from the resolved agent_path so that a custom
+# MONK_AGENT_PATH doesn'''t look "updated" on every invocation. Previously
+# agent_hash_before was read from managed_agent_path while agent_hash_after
+# came from agent_path — when those differed (e.g. a custom executable),
+# the hashes never matched and the launcher always skipped the healthy
+# fast-path, restarting the agent every session.
+agent_hash_before="$(hash_file "$agent_path")"
 agent_hash_after="$(hash_file "$agent_path")"
 agent_updated=0
 if [ -n "$agent_hash_after" ] && [ "$agent_hash_before" != "$agent_hash_after" ]; then

--- a/scripts/start-monk-agent.ps1
+++ b/scripts/start-monk-agent.ps1
@@ -172,7 +172,6 @@ try {
 }
 
 $ManagedAgentPath = Join-Path $InstallDir "monk-agent.exe"
-$AgentHashBefore = Get-FileSha256 $ManagedAgentPath
 
 if ($env:MONK_AGENT_PATH) {
   $AgentPath = $env:MONK_AGENT_PATH
@@ -193,6 +192,12 @@ if (-not (Test-Path $AgentPath)) {
   exit 2
 }
 
+# Both hashes must come from the resolved $AgentPath so a custom
+# MONK_AGENT_PATH doesn't look "updated" on every launch. Previously
+# $AgentHashBefore was read from $ManagedAgentPath while $AgentHashAfter
+# came from $AgentPath — when those differed (e.g. a custom executable),
+# the hashes never matched and the launcher restarted every session.
+$AgentHashBefore = Get-FileSha256 $AgentPath
 $AgentHashAfter = Get-FileSha256 $AgentPath
 $AgentUpdated = $AgentHashAfter -and ($AgentHashBefore -ne $AgentHashAfter)
 

--- a/scripts/start-monk-agent.sh
+++ b/scripts/start-monk-agent.sh
@@ -183,7 +183,6 @@ hash_file() {
 
 os="$(uname -s)"
 managed_agent_path="${MONK_AGENT_INSTALL_DIR:-"$HOME/.monk/bin"}/monk-agent"
-agent_hash_before="$(hash_file "$managed_agent_path")"
 
 if [ -n "${MONK_AGENT_PATH:-}" ]; then
   agent_path="$MONK_AGENT_PATH"
@@ -198,6 +197,13 @@ if [ ! -x "$agent_path" ]; then
   exit 2
 fi
 
+# Both hashes must come from the resolved agent_path so that a custom
+# MONK_AGENT_PATH doesn'''t look "updated" on every invocation. Previously
+# agent_hash_before was read from managed_agent_path while agent_hash_after
+# came from agent_path — when those differed (e.g. a custom executable),
+# the hashes never matched and the launcher always skipped the healthy
+# fast-path, restarting the agent every session.
+agent_hash_before="$(hash_file "$agent_path")"
 agent_hash_after="$(hash_file "$agent_path")"
 agent_updated=0
 if [ -n "$agent_hash_after" ] && [ "$agent_hash_before" != "$agent_hash_after" ]; then


### PR DESCRIPTION
## Problem

Setting `MONK_AGENT_PATH` to a custom executable causes the launcher to restart the agent on **every** session, even when the executable hasn't changed and the agent is healthy.

The root cause: `agent_hash_before` / `$AgentHashBefore` was read from the **managed install path** (`~/.monk/bin/monk-agent`), while `agent_hash_after` / `$AgentHashAfter` was read from the **resolved agent path** (which is `MONK_AGENT_PATH` when set). When those are different files, their hashes never match, so `agent_updated` is always `true` and the healthy fast-path never fires.

On macOS this causes repeated `launchctl bootout`/`bootstrap` churn. On Windows, same behavior with the PowerShell launcher.

## Fix

Both hashes are now read from the **resolved** agent path — after `MONK_AGENT_PATH` / `ensure-monk-agent` resolution. This means:

- A stable custom path correctly registers as unchanged → healthy fast-path works.
- A real binary swap still triggers a restart (the hash changes).
- First install still works (`hash_file` returns empty for a nonexistent file, so `agent_updated` is `0` — no false restart).

Both POSIX (`start-monk-agent.sh`) and Windows (`start-monk-agent.ps1`) launchers are fixed, across all three plugin directory copies.

## Testing

```bash
# Simulate: custom path + healthy agent
export MONK_AGENT_PATH=/path/to/custom/monk-agent
# Run launcher twice with the same custom path
# Before: agent restarted every time (launchd churn on macOS)
# After:  second invocation detects healthy agent, exits 0 immediately
```

Fixes #10