### PR TITLE
fix(plugin): reject zero-byte monk-agent installs

### DIFF
--- a/.github/workflows/install-e2e.yml
+++ b/.github/workflows/install-e2e.yml
@@ -38,6 +38,62 @@ jobs:
           test "$installed" = "$MONK_AGENT_INSTALL_DIR/monk-agent"
           test -x "$installed"
 
+      - name: Verify zero-byte monk-agent is repaired
+        shell: bash
+        run: |
+          set -euo pipefail
+          root="$(mktemp -d)"
+          trap 'rm -rf "$root"' EXIT HUP INT TERM
+          install="$root/monk-bin"
+          fakebin="$root/fakebin"
+          stage="$root/stage"
+          archive="$root/monk-agent-linux-latest.tar.gz"
+          checksum="$install/monk-agent.sha256"
+          mkdir -p "$install" "$fakebin" "$stage"
+          : >"$install/monk-agent"
+          chmod 0755 "$install/monk-agent"
+
+          printf '#!/bin/sh\necho hello\n' >"$stage/monk-agent"
+          chmod 0755 "$stage/monk-agent"
+          tar -czf "$archive" -C "$stage" monk-agent
+          if command -v shasum >/dev/null 2>&1; then
+            expected="$(shasum -a 256 "$archive" | awk '{print $1}')"
+          else
+            expected="$(sha256sum "$archive" | awk '{print $1}')"
+          fi
+          printf '%s  monk-agent-linux-latest.tar.gz\n' "$expected" >"$checksum"
+
+          cat >"$fakebin/curl" <<'SH'
+          #!/bin/sh
+          set -eu
+          out=""
+          url=""
+          while [ "$#" -gt 0 ]; do
+            case "$1" in
+              -o) out="$2"; shift 2 ;;
+              -*) shift ;;
+              *) url="$1"; shift ;;
+            esac
+          done
+          printf '%s\n' "$url" >>"$CURL_LOG"
+          case "$url" in
+            *.sha256) cp "$CHECKSUM_FILE" "$out" ;;
+            *) cp "$ARCHIVE_FILE" "$out" ;;
+          esac
+          SH
+          chmod 0755 "$fakebin/curl"
+
+          installed="$(
+            CURL_LOG="$root/curl.log" CHECKSUM_FILE="$checksum" ARCHIVE_FILE="$archive" \
+              PATH="$fakebin:/usr/bin:/bin:/usr/sbin:/sbin" \
+              MONK_AGENT_INSTALL_DIR="$install" \
+              ./scripts/ensure-monk-agent.sh
+          )"
+          test "$installed" = "$install/monk-agent"
+          test -x "$installed"
+          test -s "$installed"
+          test "$(wc -l <"$root/curl.log" | tr -d ' ')" = "2"
+
       - name: Run monk-agent status
         shell: bash
         env:

--- a/plugins/monk/scripts/ensure-monk-agent.ps1
+++ b/plugins/monk/scripts/ensure-monk-agent.ps1
@@ -38,6 +38,12 @@ function Get-FileSha256 {
   return ([System.BitConverter]::ToString($Hash) -replace "-", "").ToLowerInvariant()
 }
 
+function Test-NonEmptyFile {
+  param([string]$Path)
+
+  return (Test-Path $Path -PathType Leaf) -and ((Get-Item $Path).Length -gt 0)
+}
+
 function Stop-ManagedAgent {
   if (-not (Test-Path $PidFile)) {
     return
@@ -75,12 +81,12 @@ function Stop-ManagedAgent {
 
 if ($AutoUpdate -eq "0" -or $AutoUpdate -eq "false") {
   $Existing = Get-Command monk-agent.exe -ErrorAction SilentlyContinue
-  if ($Existing) {
+  if ($Existing -and $Existing.Source -and (Test-NonEmptyFile $Existing.Source)) {
     Write-Output $Existing.Source
     exit 0
   }
 
-  if (Test-Path $Target) {
+  if (Test-NonEmptyFile $Target) {
     Write-Output $Target
     exit 0
   }
@@ -106,7 +112,7 @@ Invoke-WebRequest -Uri $ChecksumUrl -OutFile $ChecksumTmp
 
 $Expected = ((Get-Content -Raw $ChecksumTmp).Trim() -split "\s+")[0].ToLowerInvariant()
 
-if ((Test-Path $Target) -and (Test-Path $ChecksumInstalled)) {
+if ((Test-NonEmptyFile $Target) -and (Test-Path $ChecksumInstalled -PathType Leaf)) {
   $Installed = ((Get-Content -Raw $ChecksumInstalled).Trim() -split "\s+")[0].ToLowerInvariant()
   if ($Installed -eq $Expected) {
     Remove-Item -Force $ChecksumTmp

--- a/plugins/monk/scripts/ensure-monk-agent.sh
+++ b/plugins/monk/scripts/ensure-monk-agent.sh
@@ -40,12 +40,19 @@ checksum_tmp="$install_dir/.monk-agent.tmp.sha256"
 extract_dir="$install_dir/.monk-agent.extract"
 mkdir -p "$install_dir"
 
+has_nonempty_executable() {
+  [ -x "$1" ] && [ -s "$1" ]
+}
+
 if [ "$auto_update" = "0" ] || [ "$auto_update" = "false" ]; then
   if command -v monk-agent >/dev/null 2>&1; then
-    command -v monk-agent
-    exit 0
+    command_path="$(command -v monk-agent)"
+    if has_nonempty_executable "$command_path"; then
+      printf '%s\n' "$command_path"
+      exit 0
+    fi
   fi
-  if [ -x "$target" ]; then
+  if has_nonempty_executable "$target"; then
     printf '%s\n' "$target"
     exit 0
   fi
@@ -62,7 +69,7 @@ fi
 
 expected="$(awk '{print $1}' "$checksum_tmp")"
 
-if [ -x "$target" ] && [ -f "$checksum_installed" ]; then
+if has_nonempty_executable "$target" && [ -f "$checksum_installed" ]; then
   installed="$(awk '{print $1}' "$checksum_installed")"
   if [ "$installed" = "$expected" ]; then
     rm -f "$checksum_tmp"

--- a/scripts/ensure-monk-agent.ps1
+++ b/scripts/ensure-monk-agent.ps1
@@ -38,6 +38,12 @@ function Get-FileSha256 {
   return ([System.BitConverter]::ToString($Hash) -replace "-", "").ToLowerInvariant()
 }
 
+function Test-NonEmptyFile {
+  param([string]$Path)
+
+  return (Test-Path $Path -PathType Leaf) -and ((Get-Item $Path).Length -gt 0)
+}
+
 function Stop-ManagedAgent {
   if (-not (Test-Path $PidFile)) {
     return
@@ -75,12 +81,12 @@ function Stop-ManagedAgent {
 
 if ($AutoUpdate -eq "0" -or $AutoUpdate -eq "false") {
   $Existing = Get-Command monk-agent.exe -ErrorAction SilentlyContinue
-  if ($Existing) {
+  if ($Existing -and $Existing.Source -and (Test-NonEmptyFile $Existing.Source)) {
     Write-Output $Existing.Source
     exit 0
   }
 
-  if (Test-Path $Target) {
+  if (Test-NonEmptyFile $Target) {
     Write-Output $Target
     exit 0
   }
@@ -106,7 +112,7 @@ Invoke-WebRequest -Uri $ChecksumUrl -OutFile $ChecksumTmp
 
 $Expected = ((Get-Content -Raw $ChecksumTmp).Trim() -split "\s+")[0].ToLowerInvariant()
 
-if ((Test-Path $Target) -and (Test-Path $ChecksumInstalled)) {
+if ((Test-NonEmptyFile $Target) -and (Test-Path $ChecksumInstalled -PathType Leaf)) {
   $Installed = ((Get-Content -Raw $ChecksumInstalled).Trim() -split "\s+")[0].ToLowerInvariant()
   if ($Installed -eq $Expected) {
     Remove-Item -Force $ChecksumTmp

--- a/scripts/ensure-monk-agent.sh
+++ b/scripts/ensure-monk-agent.sh
@@ -40,12 +40,19 @@ checksum_tmp="$install_dir/.monk-agent.tmp.sha256"
 extract_dir="$install_dir/.monk-agent.extract"
 mkdir -p "$install_dir"
 
+has_nonempty_executable() {
+  [ -x "$1" ] && [ -s "$1" ]
+}
+
 if [ "$auto_update" = "0" ] || [ "$auto_update" = "false" ]; then
   if command -v monk-agent >/dev/null 2>&1; then
-    command -v monk-agent
-    exit 0
+    command_path="$(command -v monk-agent)"
+    if has_nonempty_executable "$command_path"; then
+      printf '%s\n' "$command_path"
+      exit 0
+    fi
   fi
-  if [ -x "$target" ]; then
+  if has_nonempty_executable "$target"; then
     printf '%s\n' "$target"
     exit 0
   fi
@@ -62,7 +69,7 @@ fi
 
 expected="$(awk '{print $1}' "$checksum_tmp")"
 
-if [ -x "$target" ] && [ -f "$checksum_installed" ]; then
+if has_nonempty_executable "$target" && [ -f "$checksum_installed" ]; then
   installed="$(awk '{print $1}' "$checksum_installed")"
   if [ "$installed" = "$expected" ]; then
     rm -f "$checksum_tmp"


### PR DESCRIPTION
## Why
`monk-plugin` accepts a zero-byte `monk-agent` as a valid installed binary when the checksum sidecar still matches. That leaves a broken agent in place and skips the repair path.

Fixes #23.

## What Changed
- Treat `monk-agent` as valid only when it is both executable and non-empty in the Unix and PowerShell bootstrap scripts.
- Apply the same guard to the `auto_update=0/false` fast path.
- Add a Unix CI regression that truncates the installed binary to zero bytes and verifies the installer repairs it.

## Verification
- `bash -n` on the edited shell scripts
- Local deterministic reproduction showing the zero-byte target now triggers a re-download and repair
- `git diff --check`
