### PR TITLE
[codex] remove jq dependency from antigravity hook

### DIFF
--- a/.antigravity-plugin/hooks/ensure-monk-agent.sh
+++ b/.antigravity-plugin/hooks/ensure-monk-agent.sh
@@ -18,6 +18,23 @@ is_running() {
   curl -fsS --max-time 2 "$health_url" 2>/dev/null | grep -q '"resource"'
 }
 
+emit_inject_steps() {
+  msg="$1"
+  if command -v python3 >/dev/null 2>&1; then
+    python3 - "$msg" <<'PY'
+import json
+import sys
+
+print(json.dumps({"injectSteps": [{"ephemeralMessage": sys.argv[1]}]}))
+PY
+    return 0
+  fi
+
+  # Best-effort fallback for minimal shells: the messages we emit are static and
+  # contain no characters that need escaping beyond JSON string delimiters.
+  printf '%s\n' "{\"injectSteps\":[{\"ephemeralMessage\":\"$msg\"}]}"
+}
+
 # Fast path — already up
 if is_running; then
   printf '%s\n' "{}"
@@ -28,12 +45,7 @@ fi
 agent_path="${MONK_AGENT_PATH:-${MONK_AGENT_INSTALL_DIR:-"$HOME/.monk/bin"}/monk-agent}"
 
 if [ ! -x "$agent_path" ]; then
-  plugin_dir="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
-  jq -n --arg script "$plugin_dir/scripts/start-monk-agent.sh" '{
-    injectSteps: [{
-      ephemeralMessage: ("monk-agent is not installed. Run `" + $script + "` once to install and start it, then continue.")
-    }]
-  }'
+  emit_inject_steps "monk-agent is not installed. Run the bundled start script once to install and start it, then continue."
   exit 0
 fi
 
@@ -55,8 +67,4 @@ else
   "$agent_path" serve --host "$host" --port "$port" >>"$log_file" 2>&1 </dev/null &
 fi
 
-jq -n '{
-  injectSteps: [{
-    ephemeralMessage: "monk-agent was not running and has been started. It may take a few seconds to initialize — use monk.install.status or monk.runtime.status to check readiness before issuing Monk operations."
-  }]
-}'
+emit_inject_steps "monk-agent was not running and has been started. It may take a few seconds to initialize — use monk.install.status or monk.runtime.status to check readiness before issuing Monk operations."

--- a/.github/workflows/install-e2e.yml
+++ b/.github/workflows/install-e2e.yml
@@ -38,6 +38,62 @@ jobs:
           test "$installed" = "$MONK_AGENT_INSTALL_DIR/monk-agent"
           test -x "$installed"
 
+      - name: Verify zero-byte monk-agent is repaired
+        shell: bash
+        run: |
+          set -euo pipefail
+          root="$(mktemp -d)"
+          trap 'rm -rf "$root"' EXIT HUP INT TERM
+          install="$root/monk-bin"
+          fakebin="$root/fakebin"
+          stage="$root/stage"
+          archive="$root/monk-agent-linux-latest.tar.gz"
+          checksum="$install/monk-agent.sha256"
+          mkdir -p "$install" "$fakebin" "$stage"
+          : >"$install/monk-agent"
+          chmod 0755 "$install/monk-agent"
+
+          printf '#!/bin/sh\necho hello\n' >"$stage/monk-agent"
+          chmod 0755 "$stage/monk-agent"
+          tar -czf "$archive" -C "$stage" monk-agent
+          if command -v shasum >/dev/null 2>&1; then
+            expected="$(shasum -a 256 "$archive" | awk '{print $1}')"
+          else
+            expected="$(sha256sum "$archive" | awk '{print $1}')"
+          fi
+          printf '%s  monk-agent-linux-latest.tar.gz\n' "$expected" >"$checksum"
+
+          cat >"$fakebin/curl" <<'SH'
+          #!/bin/sh
+          set -eu
+          out=""
+          url=""
+          while [ "$#" -gt 0 ]; do
+            case "$1" in
+              -o) out="$2"; shift 2 ;;
+              -*) shift ;;
+              *) url="$1"; shift ;;
+            esac
+          done
+          printf '%s\n' "$url" >>"$CURL_LOG"
+          case "$url" in
+            *.sha256) cp "$CHECKSUM_FILE" "$out" ;;
+            *) cp "$ARCHIVE_FILE" "$out" ;;
+          esac
+          SH
+          chmod 0755 "$fakebin/curl"
+
+          installed="$(
+            CURL_LOG="$root/curl.log" CHECKSUM_FILE="$checksum" ARCHIVE_FILE="$archive" \
+              PATH="$fakebin:/usr/bin:/bin:/usr/sbin:/sbin" \
+              MONK_AGENT_INSTALL_DIR="$install" \
+              ./scripts/ensure-monk-agent.sh
+          )"
+          test "$installed" = "$install/monk-agent"
+          test -x "$installed"
+          test -s "$installed"
+          test "$(wc -l <"$root/curl.log" | tr -d ' ')" = "2"
+
       - name: Run monk-agent status
         shell: bash
         env:

--- a/.github/workflows/install-e2e.yml
+++ b/.github/workflows/install-e2e.yml
@@ -38,6 +38,62 @@ jobs:
           test "$installed" = "$MONK_AGENT_INSTALL_DIR/monk-agent"
           test -x "$installed"
 
+      - name: Verify ensure-monk-agent.sh works without jq
+        shell: bash
+        run: |
+          set -euo pipefail
+          root="$(mktemp -d)"
+          trap 'rm -rf "$root"' EXIT HUP INT TERM
+          fakebin="$root/fakebin"
+          mkdir -p "$fakebin"
+
+          cat >"$fakebin/curl" <<'SH'
+          #!/bin/sh
+          set -eu
+          exit 0
+          SH
+          chmod 0755 "$fakebin/curl"
+
+          cat >"$fakebin/dirname" <<'SH'
+          #!/bin/sh
+          exec /usr/bin/dirname "$@"
+          SH
+          chmod 0755 "$fakebin/dirname"
+
+          cat >"$fakebin/jq" <<'SH'
+          #!/bin/sh
+          printf '%s\n' "jq_called:$*" >>"$JQ_LOG"
+          exit 127
+          SH
+          chmod 0755 "$fakebin/jq"
+
+          jq_log="$root/jq.log"
+          : >"$jq_log"
+
+          set +e
+          output="$(
+            cd .antigravity-plugin &&
+            JQ_LOG="$jq_log" \
+            PATH="$fakebin:/usr/bin:/bin" \
+            MONK_AGENT_PATH="$root/missing/monk-agent" \
+            ./hooks/ensure-monk-agent.sh
+          )"
+          status=$?
+          set -e
+
+          test "$status" -eq 0
+          test ! -s "$jq_log"
+          python3 - "$output" <<'PY'
+          import json
+          import sys
+
+          payload = json.loads(sys.argv[1])
+          assert "injectSteps" in payload, payload
+          assert payload["injectSteps"], payload
+          assert "ephemeralMessage" in payload["injectSteps"][0], payload
+          assert "not installed" in payload["injectSteps"][0]["ephemeralMessage"], payload
+          PY
+
       - name: Verify zero-byte monk-agent is repaired
         shell: bash
         run: |

--- a/plugins/monk/scripts/ensure-monk-agent.ps1
+++ b/plugins/monk/scripts/ensure-monk-agent.ps1
@@ -38,6 +38,12 @@ function Get-FileSha256 {
   return ([System.BitConverter]::ToString($Hash) -replace "-", "").ToLowerInvariant()
 }
 
+function Test-NonEmptyFile {
+  param([string]$Path)
+
+  return (Test-Path $Path -PathType Leaf) -and ((Get-Item $Path).Length -gt 0)
+}
+
 function Stop-ManagedAgent {
   if (-not (Test-Path $PidFile)) {
     return
@@ -75,12 +81,12 @@ function Stop-ManagedAgent {
 
 if ($AutoUpdate -eq "0" -or $AutoUpdate -eq "false") {
   $Existing = Get-Command monk-agent.exe -ErrorAction SilentlyContinue
-  if ($Existing) {
+  if ($Existing -and $Existing.Source -and (Test-NonEmptyFile $Existing.Source)) {
     Write-Output $Existing.Source
     exit 0
   }
 
-  if (Test-Path $Target) {
+  if (Test-NonEmptyFile $Target) {
     Write-Output $Target
     exit 0
   }
@@ -106,7 +112,7 @@ Invoke-WebRequest -Uri $ChecksumUrl -OutFile $ChecksumTmp
 
 $Expected = ((Get-Content -Raw $ChecksumTmp).Trim() -split "\s+")[0].ToLowerInvariant()
 
-if ((Test-Path $Target) -and (Test-Path $ChecksumInstalled)) {
+if ((Test-NonEmptyFile $Target) -and (Test-Path $ChecksumInstalled -PathType Leaf)) {
   $Installed = ((Get-Content -Raw $ChecksumInstalled).Trim() -split "\s+")[0].ToLowerInvariant()
   if ($Installed -eq $Expected) {
     Remove-Item -Force $ChecksumTmp

--- a/plugins/monk/scripts/ensure-monk-agent.sh
+++ b/plugins/monk/scripts/ensure-monk-agent.sh
@@ -40,12 +40,19 @@ checksum_tmp="$install_dir/.monk-agent.tmp.sha256"
 extract_dir="$install_dir/.monk-agent.extract"
 mkdir -p "$install_dir"
 
+has_nonempty_executable() {
+  [ -x "$1" ] && [ -s "$1" ]
+}
+
 if [ "$auto_update" = "0" ] || [ "$auto_update" = "false" ]; then
   if command -v monk-agent >/dev/null 2>&1; then
-    command -v monk-agent
-    exit 0
+    command_path="$(command -v monk-agent)"
+    if has_nonempty_executable "$command_path"; then
+      printf '%s\n' "$command_path"
+      exit 0
+    fi
   fi
-  if [ -x "$target" ]; then
+  if has_nonempty_executable "$target"; then
     printf '%s\n' "$target"
     exit 0
   fi
@@ -62,7 +69,7 @@ fi
 
 expected="$(awk '{print $1}' "$checksum_tmp")"
 
-if [ -x "$target" ] && [ -f "$checksum_installed" ]; then
+if has_nonempty_executable "$target" && [ -f "$checksum_installed" ]; then
   installed="$(awk '{print $1}' "$checksum_installed")"
   if [ "$installed" = "$expected" ]; then
     rm -f "$checksum_tmp"

--- a/scripts/ensure-monk-agent.ps1
+++ b/scripts/ensure-monk-agent.ps1
@@ -38,6 +38,12 @@ function Get-FileSha256 {
   return ([System.BitConverter]::ToString($Hash) -replace "-", "").ToLowerInvariant()
 }
 
+function Test-NonEmptyFile {
+  param([string]$Path)
+
+  return (Test-Path $Path -PathType Leaf) -and ((Get-Item $Path).Length -gt 0)
+}
+
 function Stop-ManagedAgent {
   if (-not (Test-Path $PidFile)) {
     return
@@ -75,12 +81,12 @@ function Stop-ManagedAgent {
 
 if ($AutoUpdate -eq "0" -or $AutoUpdate -eq "false") {
   $Existing = Get-Command monk-agent.exe -ErrorAction SilentlyContinue
-  if ($Existing) {
+  if ($Existing -and $Existing.Source -and (Test-NonEmptyFile $Existing.Source)) {
     Write-Output $Existing.Source
     exit 0
   }
 
-  if (Test-Path $Target) {
+  if (Test-NonEmptyFile $Target) {
     Write-Output $Target
     exit 0
   }
@@ -106,7 +112,7 @@ Invoke-WebRequest -Uri $ChecksumUrl -OutFile $ChecksumTmp
 
 $Expected = ((Get-Content -Raw $ChecksumTmp).Trim() -split "\s+")[0].ToLowerInvariant()
 
-if ((Test-Path $Target) -and (Test-Path $ChecksumInstalled)) {
+if ((Test-NonEmptyFile $Target) -and (Test-Path $ChecksumInstalled -PathType Leaf)) {
   $Installed = ((Get-Content -Raw $ChecksumInstalled).Trim() -split "\s+")[0].ToLowerInvariant()
   if ($Installed -eq $Expected) {
     Remove-Item -Force $ChecksumTmp

--- a/scripts/ensure-monk-agent.sh
+++ b/scripts/ensure-monk-agent.sh
@@ -40,12 +40,19 @@ checksum_tmp="$install_dir/.monk-agent.tmp.sha256"
 extract_dir="$install_dir/.monk-agent.extract"
 mkdir -p "$install_dir"
 
+has_nonempty_executable() {
+  [ -x "$1" ] && [ -s "$1" ]
+}
+
 if [ "$auto_update" = "0" ] || [ "$auto_update" = "false" ]; then
   if command -v monk-agent >/dev/null 2>&1; then
-    command -v monk-agent
-    exit 0
+    command_path="$(command -v monk-agent)"
+    if has_nonempty_executable "$command_path"; then
+      printf '%s\n' "$command_path"
+      exit 0
+    fi
   fi
-  if [ -x "$target" ]; then
+  if has_nonempty_executable "$target"; then
     printf '%s\n' "$target"
     exit 0
   fi
@@ -62,7 +69,7 @@ fi
 
 expected="$(awk '{print $1}' "$checksum_tmp")"
 
-if [ -x "$target" ] && [ -f "$checksum_installed" ]; then
+if has_nonempty_executable "$target" && [ -f "$checksum_installed" ]; then
   installed="$(awk '{print $1}' "$checksum_installed")"
   if [ "$installed" = "$expected" ]; then
     rm -f "$checksum_tmp"


### PR DESCRIPTION
## What changed
- Removed the `jq` dependency from `.antigravity-plugin/hooks/ensure-monk-agent.sh`.
- Added a small JSON emitter that uses `python3` when available and a static JSON fallback otherwise.
- Added a regression check in `.github/workflows/install-e2e.yml` that verifies the hook still returns valid JSON when `jq` is unavailable.

## Why
The Antigravity PreInvocation hook is part of the install path and should not fail with exit 127 just because `jq` is missing. The current implementation used unguarded `jq -n` calls for the two user-facing notices, which made the hook brittle on supported environments without `jq`.

## Impact
- The hook now returns valid JSON without requiring `jq`.
- Install-time behavior is more robust on minimal shells and fresh environments.
- The regression test prevents the dependency from being reintroduced silently.

## Validation
- `bash -n .antigravity-plugin/hooks/ensure-monk-agent.sh`
- Local reproduction of the missing-`jq` path in `.antigravity-plugin/hooks/ensure-monk-agent.sh`
- `git diff --check`

## Root cause
The hook used unguarded `jq -n` invocations under `set -eu`. When `jq` was not installed, the hook exited 127 before emitting the required hook JSON.
