### PR TITLE
Fix IPv6 companion URLs

### DIFF
--- a/.antigravity-plugin/hooks/ensure-monk-agent.ps1
+++ b/.antigravity-plugin/hooks/ensure-monk-agent.ps1
@@ -18,7 +18,12 @@ if (Get-Command bash -ErrorAction SilentlyContinue) { exit 0 }
 
 $Port = if ($env:MONK_AGENT_PORT) { $env:MONK_AGENT_PORT } else { "7419" }
 $AgentHost = if ($env:MONK_AGENT_HOST) { $env:MONK_AGENT_HOST } else { "127.0.0.1" }
-$HealthUrl = "http://${AgentHost}:$Port/.well-known/oauth-protected-resource"
+$UrlHost = if ($AgentHost.Contains(":") -and -not ($AgentHost.StartsWith("[") -and $AgentHost.EndsWith("]"))) {
+  "[$AgentHost]"
+} else {
+  $AgentHost
+}
+$HealthUrl = "http://${UrlHost}:$Port/.well-known/oauth-protected-resource"
 
 function Write-Json {
   param([object]$Object)

--- a/.antigravity-plugin/hooks/ensure-monk-agent.sh
+++ b/.antigravity-plugin/hooks/ensure-monk-agent.sh
@@ -11,7 +11,12 @@ set -eu
 
 port="${MONK_AGENT_PORT:-7419}"
 host="${MONK_AGENT_HOST:-127.0.0.1}"
-health_url="http://$host:$port/.well-known/oauth-protected-resource"
+url_host="$host"
+case "$url_host" in
+  \[*\]) ;;
+  *:*) url_host="[$url_host]" ;;
+esac
+health_url="http://$url_host:$port/.well-known/oauth-protected-resource"
 
 is_running() {
   command -v curl >/dev/null 2>&1 || return 1

--- a/.antigravity-plugin/scripts/start-monk-agent.ps1
+++ b/.antigravity-plugin/scripts/start-monk-agent.ps1
@@ -18,7 +18,13 @@ $RunDir = Join-Path $DataDir "run"
 $LogOut = Join-Path $LogDir "monk-agent.out.log"
 $LogErr = Join-Path $LogDir "monk-agent.err.log"
 $PidFile = Join-Path $RunDir "monk-agent.pid"
-$HealthUrl = "http://${AgentHost}:$Port/.well-known/oauth-protected-resource"
+$UrlHost = if ($AgentHost.Contains(":") -and -not ($AgentHost.StartsWith("[") -and $AgentHost.EndsWith("]"))) {
+  "[$AgentHost]"
+} else {
+  $AgentHost
+}
+$BaseUrl = "http://${UrlHost}:$Port"
+$HealthUrl = "$BaseUrl/.well-known/oauth-protected-resource"
 
 New-Item -ItemType Directory -Force -Path $LogDir, $RunDir | Out-Null
 
@@ -46,7 +52,7 @@ function Show-SigninNudge {
   # /status.json, which runs ~10 synchronous install probes (~2s/call and
   # serializes under concurrent dashboard/MCP load) — that latency made this
   # check racy against a cold, signed-out agent.
-  $StatusUrl = "http://${AgentHost}:$Port/auth.json"
+  $StatusUrl = "$BaseUrl/auth.json"
   # A just-(re)started agent can still report a transient MISS on the first probe
   # (connection refused during the restart window, or a 500 from a cold DPAPI
   # read the agent itself retries then surfaces as an error rather than a false
@@ -90,7 +96,7 @@ function Show-SigninNudge {
   }
   $Client = if ($env:CLAUDE_PLUGIN_ROOT) { "claude-code" } elseif ($env:PLUGIN_ROOT) { "codex" } else { "unknown" }
   try {
-    Invoke-RestMethod -Uri "http://${AgentHost}:$Port/plugin/nudge?type=signin&client=$Client" -Method Post -TimeoutSec 2 | Out-Null
+    Invoke-RestMethod -Uri "$BaseUrl/plugin/nudge?type=signin&client=$Client" -Method Post -TimeoutSec 2 | Out-Null
   } catch {
   }
   $Msg = "monk-agent is running but you are NOT signed in to Monk. The Monk MCP tools require sign-in. If the user asks to deploy, analyze, or operate anything with Monk, first tell them to run /mcp and authenticate the monk MCP server (this signs them in to Monk). Do NOT describe this as a connection or restart problem, and do NOT deploy via Docker or another platform to work around it."

--- a/.antigravity-plugin/scripts/start-monk-agent.sh
+++ b/.antigravity-plugin/scripts/start-monk-agent.sh
@@ -43,7 +43,13 @@ launchd_plist="$HOME/Library/LaunchAgents/$launchd_label.plist"
 
 mkdir -p "$log_dir" "$run_dir"
 
-health_url="http://$host:$port/.well-known/oauth-protected-resource"
+url_host="$host"
+case "$url_host" in
+  \[*\]) ;;
+  *:*) url_host="[$url_host]" ;;
+esac
+base_url="http://$url_host:$port"
+health_url="$base_url/.well-known/oauth-protected-resource"
 
 # Register monk in Antigravity's global MCP config if ~/.gemini/config/ exists.
 # Idempotent — skips if already registered. Uses jq when available; prints
@@ -52,7 +58,7 @@ register_antigravity_mcp() {
   gemini_cfg="$HOME/.gemini/config"
   [ -d "$gemini_cfg" ] || return 0
   mcp_cfg="$gemini_cfg/mcp_config.json"
-  server_url="http://$host:$port/mcp"
+  server_url="$base_url/mcp"
   if [ -f "$mcp_cfg" ] && grep -q '"monk"' "$mcp_cfg" 2>/dev/null; then
     return 0
   fi
@@ -103,7 +109,7 @@ emit_signin_nudge() {
   # /status.json, which runs ~10 synchronous install probes (~2s/call and
   # serializes under concurrent dashboard/MCP load) — that latency pushed this
   # check past the curl timeout and made the nudge racy.
-  status_url="http://$host:$port/auth.json"
+  status_url="$base_url/auth.json"
   body=""
   # A just-(re)started agent can still report a transient MISS on the first probe
   # (connection refused during the restart window, or a 500 from a cold macOS
@@ -137,7 +143,7 @@ emit_signin_nudge() {
   elif [ -n "${PLUGIN_ROOT:-}" ]; then
     client="codex"
   fi
-  nudge_url="http://$host:$port/plugin/nudge?type=signin&client=$client"
+  nudge_url="$base_url/plugin/nudge?type=signin&client=$client"
   if command -v curl >/dev/null 2>&1; then
     curl -fsS --max-time 2 -X POST "$nudge_url" >/dev/null 2>&1 || true
   elif command -v wget >/dev/null 2>&1; then

--- a/.github/workflows/install-e2e.yml
+++ b/.github/workflows/install-e2e.yml
@@ -54,6 +54,10 @@ jobs:
           grep '"version"' "$RUNNER_TEMP/status.json"
           grep '"signedIn": true' "$RUNNER_TEMP/status.json"
 
+      - name: Verify IPv6 companion URLs
+        shell: bash
+        run: ./tests/start-monk-agent-ipv6.sh
+
   windows:
     name: windows-latest
     runs-on: windows-latest

--- a/plugins/monk/scripts/start-monk-agent.ps1
+++ b/plugins/monk/scripts/start-monk-agent.ps1
@@ -18,7 +18,13 @@ $RunDir = Join-Path $DataDir "run"
 $LogOut = Join-Path $LogDir "monk-agent.out.log"
 $LogErr = Join-Path $LogDir "monk-agent.err.log"
 $PidFile = Join-Path $RunDir "monk-agent.pid"
-$HealthUrl = "http://${AgentHost}:$Port/.well-known/oauth-protected-resource"
+$UrlHost = if ($AgentHost.Contains(":") -and -not ($AgentHost.StartsWith("[") -and $AgentHost.EndsWith("]"))) {
+  "[$AgentHost]"
+} else {
+  $AgentHost
+}
+$BaseUrl = "http://${UrlHost}:$Port"
+$HealthUrl = "$BaseUrl/.well-known/oauth-protected-resource"
 
 New-Item -ItemType Directory -Force -Path $LogDir, $RunDir | Out-Null
 
@@ -46,7 +52,7 @@ function Show-SigninNudge {
   # /status.json, which runs ~10 synchronous install probes (~2s/call and
   # serializes under concurrent dashboard/MCP load) — that latency made this
   # check racy against a cold, signed-out agent.
-  $StatusUrl = "http://${AgentHost}:$Port/auth.json"
+  $StatusUrl = "$BaseUrl/auth.json"
   # A just-(re)started agent can still report a transient MISS on the first probe
   # (connection refused during the restart window, or a 500 from a cold DPAPI
   # read the agent itself retries then surfaces as an error rather than a false
@@ -90,7 +96,7 @@ function Show-SigninNudge {
   }
   $Client = if ($env:CLAUDE_PLUGIN_ROOT) { "claude-code" } elseif ($env:PLUGIN_ROOT) { "codex" } else { "unknown" }
   try {
-    Invoke-RestMethod -Uri "http://${AgentHost}:$Port/plugin/nudge?type=signin&client=$Client" -Method Post -TimeoutSec 2 | Out-Null
+    Invoke-RestMethod -Uri "$BaseUrl/plugin/nudge?type=signin&client=$Client" -Method Post -TimeoutSec 2 | Out-Null
   } catch {
   }
   $Msg = "monk-agent is running but you are NOT signed in to Monk. The Monk MCP tools require sign-in. If the user asks to deploy, analyze, or operate anything with Monk, first tell them to run /mcp and authenticate the monk MCP server (this signs them in to Monk). Do NOT describe this as a connection or restart problem, and do NOT deploy via Docker or another platform to work around it."

--- a/plugins/monk/scripts/start-monk-agent.sh
+++ b/plugins/monk/scripts/start-monk-agent.sh
@@ -43,7 +43,13 @@ launchd_plist="$HOME/Library/LaunchAgents/$launchd_label.plist"
 
 mkdir -p "$log_dir" "$run_dir"
 
-health_url="http://$host:$port/.well-known/oauth-protected-resource"
+url_host="$host"
+case "$url_host" in
+  \[*\]) ;;
+  *:*) url_host="[$url_host]" ;;
+esac
+base_url="http://$url_host:$port"
+health_url="$base_url/.well-known/oauth-protected-resource"
 
 # Register monk in Antigravity's global MCP config if ~/.gemini/config/ exists.
 # Idempotent — skips if already registered. Uses jq when available; prints
@@ -52,7 +58,7 @@ register_antigravity_mcp() {
   gemini_cfg="$HOME/.gemini/config"
   [ -d "$gemini_cfg" ] || return 0
   mcp_cfg="$gemini_cfg/mcp_config.json"
-  server_url="http://$host:$port/mcp"
+  server_url="$base_url/mcp"
   if [ -f "$mcp_cfg" ] && grep -q '"monk"' "$mcp_cfg" 2>/dev/null; then
     return 0
   fi
@@ -103,7 +109,7 @@ emit_signin_nudge() {
   # /status.json, which runs ~10 synchronous install probes (~2s/call and
   # serializes under concurrent dashboard/MCP load) — that latency pushed this
   # check past the curl timeout and made the nudge racy.
-  status_url="http://$host:$port/auth.json"
+  status_url="$base_url/auth.json"
   body=""
   # A just-(re)started agent can still report a transient MISS on the first probe
   # (connection refused during the restart window, or a 500 from a cold macOS
@@ -137,7 +143,7 @@ emit_signin_nudge() {
   elif [ -n "${PLUGIN_ROOT:-}" ]; then
     client="codex"
   fi
-  nudge_url="http://$host:$port/plugin/nudge?type=signin&client=$client"
+  nudge_url="$base_url/plugin/nudge?type=signin&client=$client"
   if command -v curl >/dev/null 2>&1; then
     curl -fsS --max-time 2 -X POST "$nudge_url" >/dev/null 2>&1 || true
   elif command -v wget >/dev/null 2>&1; then

--- a/scripts/start-monk-agent.ps1
+++ b/scripts/start-monk-agent.ps1
@@ -18,7 +18,13 @@ $RunDir = Join-Path $DataDir "run"
 $LogOut = Join-Path $LogDir "monk-agent.out.log"
 $LogErr = Join-Path $LogDir "monk-agent.err.log"
 $PidFile = Join-Path $RunDir "monk-agent.pid"
-$HealthUrl = "http://${AgentHost}:$Port/.well-known/oauth-protected-resource"
+$UrlHost = if ($AgentHost.Contains(":") -and -not ($AgentHost.StartsWith("[") -and $AgentHost.EndsWith("]"))) {
+  "[$AgentHost]"
+} else {
+  $AgentHost
+}
+$BaseUrl = "http://${UrlHost}:$Port"
+$HealthUrl = "$BaseUrl/.well-known/oauth-protected-resource"
 
 New-Item -ItemType Directory -Force -Path $LogDir, $RunDir | Out-Null
 
@@ -46,7 +52,7 @@ function Show-SigninNudge {
   # /status.json, which runs ~10 synchronous install probes (~2s/call and
   # serializes under concurrent dashboard/MCP load) — that latency made this
   # check racy against a cold, signed-out agent.
-  $StatusUrl = "http://${AgentHost}:$Port/auth.json"
+  $StatusUrl = "$BaseUrl/auth.json"
   # A just-(re)started agent can still report a transient MISS on the first probe
   # (connection refused during the restart window, or a 500 from a cold DPAPI
   # read the agent itself retries then surfaces as an error rather than a false
@@ -90,7 +96,7 @@ function Show-SigninNudge {
   }
   $Client = if ($env:CLAUDE_PLUGIN_ROOT) { "claude-code" } elseif ($env:PLUGIN_ROOT) { "codex" } else { "unknown" }
   try {
-    Invoke-RestMethod -Uri "http://${AgentHost}:$Port/plugin/nudge?type=signin&client=$Client" -Method Post -TimeoutSec 2 | Out-Null
+    Invoke-RestMethod -Uri "$BaseUrl/plugin/nudge?type=signin&client=$Client" -Method Post -TimeoutSec 2 | Out-Null
   } catch {
   }
   $Msg = "monk-agent is running but you are NOT signed in to Monk. The Monk MCP tools require sign-in. If the user asks to deploy, analyze, or operate anything with Monk, first tell them to run /mcp and authenticate the monk MCP server (this signs them in to Monk). Do NOT describe this as a connection or restart problem, and do NOT deploy via Docker or another platform to work around it."

--- a/scripts/start-monk-agent.sh
+++ b/scripts/start-monk-agent.sh
@@ -43,7 +43,13 @@ launchd_plist="$HOME/Library/LaunchAgents/$launchd_label.plist"
 
 mkdir -p "$log_dir" "$run_dir"
 
-health_url="http://$host:$port/.well-known/oauth-protected-resource"
+url_host="$host"
+case "$url_host" in
+  \[*\]) ;;
+  *:*) url_host="[$url_host]" ;;
+esac
+base_url="http://$url_host:$port"
+health_url="$base_url/.well-known/oauth-protected-resource"
 
 # Register monk in Antigravity's global MCP config if ~/.gemini/config/ exists.
 # Idempotent — skips if already registered. Uses jq when available; prints
@@ -52,7 +58,7 @@ register_antigravity_mcp() {
   gemini_cfg="$HOME/.gemini/config"
   [ -d "$gemini_cfg" ] || return 0
   mcp_cfg="$gemini_cfg/mcp_config.json"
-  server_url="http://$host:$port/mcp"
+  server_url="$base_url/mcp"
   if [ -f "$mcp_cfg" ] && grep -q '"monk"' "$mcp_cfg" 2>/dev/null; then
     return 0
   fi
@@ -103,7 +109,7 @@ emit_signin_nudge() {
   # /status.json, which runs ~10 synchronous install probes (~2s/call and
   # serializes under concurrent dashboard/MCP load) — that latency pushed this
   # check past the curl timeout and made the nudge racy.
-  status_url="http://$host:$port/auth.json"
+  status_url="$base_url/auth.json"
   body=""
   # A just-(re)started agent can still report a transient MISS on the first probe
   # (connection refused during the restart window, or a 500 from a cold macOS
@@ -137,7 +143,7 @@ emit_signin_nudge() {
   elif [ -n "${PLUGIN_ROOT:-}" ]; then
     client="codex"
   fi
-  nudge_url="http://$host:$port/plugin/nudge?type=signin&client=$client"
+  nudge_url="$base_url/plugin/nudge?type=signin&client=$client"
   if command -v curl >/dev/null 2>&1; then
     curl -fsS --max-time 2 -X POST "$nudge_url" >/dev/null 2>&1 || true
   elif command -v wget >/dev/null 2>&1; then

--- a/tests/start-monk-agent-ipv6.sh
+++ b/tests/start-monk-agent-ipv6.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env sh
+set -eu
+
+repo="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+root="$(mktemp -d)"
+trap 'rm -rf "$root"' EXIT HUP INT TERM
+
+mkdir -p "$root/bin" "$root/home/.gemini/config" "$root/install"
+
+cat >"$root/bin/uname" <<'EOF'
+#!/usr/bin/env sh
+printf '%s\n' Linux
+EOF
+
+cat >"$root/bin/curl" <<'EOF'
+#!/usr/bin/env sh
+set -eu
+url=""
+for arg in "$@"; do
+  case "$arg" in
+    http://*) url="$arg" ;;
+  esac
+done
+printf '%s\n' "$url" >>"$TEST_URL_LOG"
+if [ "$url" = 'http://[::1]:17419/.well-known/oauth-protected-resource' ]; then
+  printf '%s\n' '{"resource":"http://[::1]:17419/mcp"}'
+elif [ "$url" = 'http://[::1]:17419/auth.json' ]; then
+  printf '%s\n' '{"signedIn":false}'
+elif [ "$url" = 'http://[::1]:17419/plugin/nudge?type=signin&client=codex' ]; then
+  printf '%s\n' '{}'
+else
+  printf 'unexpected URL: %s\n' "$url" >&2
+  exit 22
+fi
+EOF
+
+cat >"$root/install/monk-agent" <<'EOF'
+#!/usr/bin/env sh
+exit 0
+EOF
+
+chmod +x "$root/bin/uname" "$root/bin/curl" "$root/install/monk-agent"
+
+PATH="$root/bin:$PATH" \
+HOME="$root/home" \
+MONK_AGENT_HOME="$root/home/.monk" \
+MONK_AGENT_INSTALL_DIR="$root/install" \
+MONK_AGENT_PATH="$root/install/monk-agent" \
+MONK_AGENT_SKIP_ENSURE=1 \
+MONK_AGENT_HOST='::1' \
+MONK_AGENT_PORT=17419 \
+PLUGIN_ROOT="$repo" \
+TEST_URL_LOG="$root/urls" \
+  "$repo/scripts/start-monk-agent.sh" >/dev/null
+
+grep -Fx 'http://[::1]:17419/.well-known/oauth-protected-resource' "$root/urls"
+grep -Fx 'http://[::1]:17419/auth.json' "$root/urls"
+grep -Fx 'http://[::1]:17419/plugin/nudge?type=signin&client=codex' "$root/urls"
+if grep -F 'http://::1:' "$root/urls"; then
+  echo "launcher emitted an unbracketed IPv6 URL" >&2
+  exit 1
+fi
+
+jq -e '.mcpServers.monk.serverUrl == "http://[::1]:17419/mcp"' \
+  "$root/home/.gemini/config/mcp_config.json" >/dev/null
+
+PATH="$root/bin:$PATH" \
+HOME="$root/home" \
+MONK_AGENT_PATH="$root/install/monk-agent" \
+MONK_AGENT_HOST='::1' \
+MONK_AGENT_PORT=17419 \
+TEST_URL_LOG="$root/hook-urls" \
+  "$repo/.antigravity-plugin/hooks/ensure-monk-agent.sh" >/dev/null
+
+grep -Fx 'http://[::1]:17419/.well-known/oauth-protected-resource' "$root/hook-urls"
+
+cmp "$repo/scripts/start-monk-agent.sh" "$repo/plugins/monk/scripts/start-monk-agent.sh"
+cmp "$repo/scripts/start-monk-agent.sh" "$repo/.antigravity-plugin/scripts/start-monk-agent.sh"
+cmp "$repo/scripts/start-monk-agent.ps1" "$repo/plugins/monk/scripts/start-monk-agent.ps1"
+cmp "$repo/scripts/start-monk-agent.ps1" "$repo/.antigravity-plugin/scripts/start-monk-agent.ps1"


### PR DESCRIPTION
## Summary

- format IPv6 literals with brackets when constructing companion URLs
- keep the raw host value for the `monk-agent --host` bind argument
- use the normalized base URL for health, auth, sign-in nudge, and Antigravity MCP registration endpoints
- apply the same behavior to the shipped POSIX, PowerShell, and Antigravity launcher copies
- add a regression that covers the launcher, hook, registration, auth, nudge, and generated-copy parity

## Why

`MONK_AGENT_HOST=::1` currently produces URLs such as `http://::1:7419/...`. URL parsers treat the extra colons as an invalid port, so a companion that successfully binds to IPv6 loopback can never pass the launcher's health check. The launcher may then wait for the full readiness timeout, and the generated Antigravity MCP URL is invalid as well.

The bind argument must remain `::1`, while URL authorities require `[::1]`.

## Impact

IPv4 addresses and hostnames are unchanged. IPv6 literals now produce valid companion URLs across the launchers and hooks.

## Validation

- `./tests/start-monk-agent-ipv6.sh`
- `sh -n` on all shipped POSIX launchers and the Antigravity hook
- real local IPv6 listener: bracketed `::1` health check passed through the updated launcher and hook
- generated POSIX and PowerShell copies verified byte-identical by the regression
- `git diff --check`

Fixes #32
