### PR TITLE
fix: normalize null mcpServers in Python fallback

### DIFF
--- a/scripts/start-monk-agent.sh
+++ b/scripts/start-monk-agent.sh
@@ -73,7 +73,9 @@ register_antigravity_mcp() {
       python3 -c "
 import json, sys
 cfg = json.load(open('$mcp_cfg'))
-cfg.setdefault('mcpServers', {})['monk'] = {'serverUrl': '$server_url'}
+if not isinstance(cfg.get('mcpServers'), dict):
+    cfg['mcpServers'] = {}
+cfg['mcpServers']['monk'] = {'serverUrl': '$server_url'}
 json.dump(cfg, sys.stdout, indent=2)
 print()
 " >"$tmp"


### PR DESCRIPTION
## Summary

When mcpServers is 
ull in the config JSON, setdefault() returns 
ull instead of creating a new dict. This causes TypeError: 'NoneType' object does not support item assignment when trying to set the monk server entry.

## Fix

Check if mcpServers is a dict, and if not, replace with an empty dict before setting the monk server entry.

## Testing

Reproduction steps from issue #37:
1. Set mcpServers to 
ull in ~/.gemini/config/mcp_config.json
2. Run the script
3. Before: TypeError: 'NoneType' object does not support item assignment
4. After: Config is correctly updated with monk server entry

Fixes #37