### PR TITLE
fix: add wget fallback to Antigravity hook is_running()

### DIFF
--- a/.antigravity-plugin/hooks/ensure-monk-agent.sh
+++ b/.antigravity-plugin/hooks/ensure-monk-agent.sh
@@ -14,8 +14,15 @@ host="${MONK_AGENT_HOST:-127.0.0.1}"
 health_url="http://$host:$port/.well-known/oauth-protected-resource"
 
 is_running() {
-  command -v curl >/dev/null 2>&1 || return 1
-  curl -fsS --max-time 2 "$health_url" 2>/dev/null | grep -q '"resource"'
+  if command -v curl >/dev/null 2>&1; then
+    curl -fsS --max-time 2 "$health_url" 2>/dev/null | grep -q '"resource"'
+    return $?
+  fi
+  if command -v wget >/dev/null 2>&1; then
+    wget -q -T 2 -O - "$health_url" 2>/dev/null | grep -q '"resource"'
+    return $?
+  fi
+  return 1
 }
 
 # Fast path — already up


### PR DESCRIPTION
## What this does

Adds curl-then-wget fallback to the is_running() function in .antigravity-plugin/hooks/ensure-monk-agent.sh, matching the same pattern already used in scripts/start-monk-agent.sh (lines 155-165) and scripts/ensure-monk-agent.sh (lines 54-61).

## Problem

The Antigravity PreInvocation hook only checked for curl when probing monk-agent health. On wget-only POSIX systems, command -v curl fails and is_running() returns 1 immediately, causing:

- Duplicate process starts on every invocation
- Misleading 'has been started' context injected
- Port-collision failures and log churn

## How it works

The is_running() function now:
1. Tries curl first (existing behavior)
2. Falls back to wget if curl is unavailable
3. Returns 1 only if neither tool is present

This matches the contract in scripts/start-monk-agent.sh where wget is already a supported health transport.

## Testing

Verified by running the reproduction script from the issue on a system with wget but no curl:
- Before: start_calls=2, started_notices=2 (duplicate starts)
- After: start_calls=0, started_notices=0 (fast path, no starts)

Fixes #40