### PR TITLE
fix: fail fast when companion process exits during startup

### DIFF
--- a/scripts/start-monk-agent.sh
+++ b/scripts/start-monk-agent.sh
@@ -330,6 +330,15 @@ while [ "$tries" -lt 180 ]; do
     emit_signin_nudge
     exit 0
   fi
+  # Fail fast: if the companion process exited, stop waiting immediately.
+  if [ -f "$pid_file" ]; then
+    pid="$(cat "$pid_file" 2>/dev/null || true)"
+    if [ -n "$pid" ] && ! kill -0 "$pid" 2>/dev/null; then
+      echo "monk-agent process $pid exited before becoming ready." >&2
+      echo "Log: $log_file" >&2
+      exit 1
+    fi
+  fi
   tries=$((tries + 1))
   sleep 1
 done


### PR DESCRIPTION
## What this does

Adds a PID liveness check to the POSIX launcher's health retry loop. When the companion process exits before becoming ready, the launcher now fails immediately with a diagnostic message instead of waiting the full 180 seconds.

## Problem

The 180-iteration health loop in scripts/start-monk-agent.sh never checked whether the companion PID was still alive. When the process exited early (invalid config, port collision, missing dependency), the loop continued retrying for up to 180 seconds before reporting a generic timeout.

The Windows sibling already has this behavior via \$Process.HasExited\ in its retry loop.

## How it works

After each failed health probe, the fix checks if the PID recorded in \$pid_file\ is still running via \kill -0\. If the process has exited, the launcher breaks immediately with a message like:

\\\
monk-agent process 12345 exited before becoming ready.
Log: /path/to/monk-agent.log
\\\

This matches the Windows behavior and gives users an immediate, actionable error instead of a 3-minute hang.

## Testing

Verified with the reproduction script from the issue:
- Before: 180 dead sleep calls, 3-minute wait
- After: 1 dead sleep call, immediate exit with diagnostic

Fixes #39