### PR TITLE
fix: escape apostrophes in Python fallback MCP registration

### DIFF
--- a/scripts/start-monk-agent.sh
+++ b/scripts/start-monk-agent.sh
@@ -72,11 +72,11 @@ register_antigravity_mcp() {
     if [ "$has_existing" = "1" ]; then
       python3 -c "
 import json, sys
-cfg = json.load(open('$mcp_cfg'))
-cfg.setdefault('mcpServers', {})['monk'] = {'serverUrl': '$server_url'}
+cfg = json.load(open(sys.argv[1]))
+cfg.setdefault('mcpServers', {})['monk'] = {'serverUrl': sys.argv[2]}
 json.dump(cfg, sys.stdout, indent=2)
 print()
-" >"$tmp"
+" "$mcp_cfg" "$server_url" >"$tmp"
     else
       printf '{"mcpServers":{"monk":{"serverUrl":"%s"}}}\n' "$server_url" >"$tmp"
     fi


### PR DESCRIPTION
## What this does

Passes config path and server URL as sys.argv instead of interpolating them into Python source code, fixing a syntax error when the path contains apostrophes.

## Problem

The Python fallback in egister_antigravity_mcp() interpolated $mcp_cfg and $server_url directly into Python source. Paths containing apostrophes (e.g. /O'Connor/) broke Python syntax and aborted session startup under set -e.

## How it works

Both values are now passed as sys.argv[1] and sys.argv[2], matching the pattern already used by the jq code path.

## Testing

Verified with the reproduction script from the issue — session completes successfully with apostrophe-containing paths.

Fixes #26