### PR TITLE
fix: verify readiness before reporting started in Windows Antigravity hook

### DIFF
--- a/.antigravity-plugin/hooks/ensure-monk-agent.ps1
+++ b/.antigravity-plugin/hooks/ensure-monk-agent.ps1
@@ -67,19 +67,36 @@ $env:MONK_AGENT_AUTH_CLIENT_ID = if ($env:MONK_AGENT_AUTH_CLIENT_ID) { $env:MONK
 $env:MONK_AUTH_AUDIENCE = if ($env:MONK_AUTH_AUDIENCE) { $env:MONK_AUTH_AUDIENCE } else { "oaknode.com" }
 $env:MONK_AUTOSPIN_URL = if ($env:MONK_AUTOSPIN_URL) { $env:MONK_AUTOSPIN_URL } else { "wss://api.app.monk.io/autospin/" }
 
+$Process = $null
 try {
-  Start-Process `
+  $Process = Start-Process `
     -FilePath $AgentPath `
     -ArgumentList @("serve", "--host", $AgentHost, "--port", $Port) `
     -WindowStyle Hidden `
     -RedirectStandardOutput $LogOut `
-    -RedirectStandardError $LogErr | Out-Null
+    -RedirectStandardError $LogErr `
+    -PassThru
 } catch {
+}
+
+if ($Process -and -not $Process.HasExited) {
+  for ($i = 0; $i -lt 10; $i++) {
+    Start-Sleep -Seconds 1
+    if ($Process.HasExited) { break }
+    if (Test-AgentRunning) {
+      Write-Json @{
+        injectSteps = @(
+          @{ ephemeralMessage = "monk-agent was not running and has been started. It may take a few seconds to initialize - use monk.install.status or monk.runtime.status to check readiness before issuing Monk operations." }
+        )
+      }
+      exit 0
+    }
+  }
 }
 
 Write-Json @{
   injectSteps = @(
-    @{ ephemeralMessage = "monk-agent was not running and has been started. It may take a few seconds to initialize - use monk.install.status or monk.runtime.status to check readiness before issuing Monk operations." }
+    @{ ephemeralMessage = "monk-agent was started but did not become ready within 10 seconds. Check monk.install.status or monk.runtime.status for details." }
   )
 }
 exit 0


### PR DESCRIPTION
## What this does

Adds a health probe loop to the Windows Antigravity hook that verifies monk-agent is actually listening before reporting it as started.

## Problem

The Windows PowerShell Antigravity hook reported monk-agent has been started immediately after Start-Process, even if the process exited right away. This could mislead users into thinking Monk is ready when the companion is not listening.

## How it works

After Start-Process, the hook now probes the health endpoint up to 10 times with 1-second sleeps. If the process exits during the loop (checked via HasExited), it fails immediately. Only a successful health response reports the started notice.

## Testing

Verified with the reproduction scenario from the issue - if the companion exits immediately, the hook now reports failure instead of false success.

Fixes #35