### PR TITLE
fix: skip managed-agent hash comparison for custom MONK_AGENT_PATH

### DIFF
--- a/scripts/start-monk-agent.ps1
+++ b/scripts/start-monk-agent.ps1
@@ -194,7 +194,15 @@ if (-not (Test-Path $AgentPath)) {
 }
 
 $AgentHashAfter = Get-FileSha256 $AgentPath
-$AgentUpdated = $AgentHashAfter -and ($AgentHashBefore -ne $AgentHashAfter)
+# When using a custom MONK_AGENT_PATH, skip the managed-agent hash comparison
+# entirely. $AgentHashBefore is the managed path hash which is empty when the
+# managed agent is absent, causing a false "updated" result. Trust the health
+# check (Test-AgentRunning) instead.
+if ($env:MONK_AGENT_PATH) {
+  $AgentUpdated = $false
+} else {
+  $AgentUpdated = $AgentHashAfter -and ($AgentHashBefore -ne $AgentHashAfter)
+}
 
 if (-not $AgentUpdated -and (Test-AgentRunning)) {
   Show-SigninNudge


### PR DESCRIPTION
## What this does

Skips the managed-agent hash comparison when `MONK_AGENT_PATH` is set, trusting the health check instead.

## Problem

When `MONK_AGENT_PATH` was set and the managed agent was absent, `$AgentHashBefore` was empty while `$AgentHashAfter` had the custom binary hash. This always evaluated as "updated", bypassing `Test-AgentRunning` and causing unnecessary restarts on every session start.

## How it works

When a custom path is detected, the script now sets `$AgentUpdated = $false` and relies on the existing `Test-AgentRunning` health check to determine if the agent needs to be started. The managed-agent hash comparison is only used when running the standard managed install.

## Testing

Verified with the reproduction script from the issue — custom path agents are no longer restarted when already healthy.

Fixes #36
