### PR TITLE
fix: hash resolved agent path for update detection

### DIFF
--- a/scripts/ensure-monk-agent.sh
+++ b/scripts/ensure-monk-agent.sh
@@ -35,10 +35,27 @@ esac
 
 url="$download_base/$platform_path/$artifact"
 checksum_url="$url.sha256"
-archive_tmp="$install_dir/.monk-agent.tmp.tar.gz"
-checksum_tmp="$install_dir/.monk-agent.tmp.sha256"
-extract_dir="$install_dir/.monk-agent.extract"
+archive_tmp="$install_dir/.monk-agent.tmp.$$.tar.gz"
+checksum_tmp="$install_dir/.monk-agent.tmp.$$.sha256"
+extract_dir="$install_dir/.monk-agent.extract.$$"
+lock_file="$install_dir/.monk-agent.lock"
 mkdir -p "$install_dir"
+
+cleanup() {
+  rm -rf "$extract_dir" "$archive_tmp" "$checksum_tmp"
+}
+trap cleanup EXIT
+
+# Acquire exclusive lock to prevent concurrent installs.
+# flock is available on Linux and recent macOS; skip locking if absent.
+lock_fd=3
+if command -v flock >/dev/null 2>&1; then
+  exec 3>"$lock_file"
+  if ! flock -n 3; then
+    echo "Another monk-agent install is running; waiting..." >&2
+    flock 3
+  fi
+fi
 
 if [ "$auto_update" = "0" ] || [ "$auto_update" = "false" ]; then
   if command -v monk-agent >/dev/null 2>&1; then
@@ -98,5 +115,6 @@ tar -xzf "$archive_tmp" -C "$extract_dir"
 chmod 0755 "$extract_dir/monk-agent"
 mv "$extract_dir/monk-agent" "$target"
 printf '%s  %s\n' "$expected" "$artifact" >"$checksum_installed"
-rm -rf "$extract_dir" "$archive_tmp" "$checksum_tmp"
+rm -f "$archive_tmp" "$checksum_tmp"
+# extract_dir cleaned by trap
 printf '%s\n' "$target"

--- a/scripts/start-monk-agent.ps1
+++ b/scripts/start-monk-agent.ps1
@@ -172,13 +172,19 @@ try {
 }
 
 $ManagedAgentPath = Join-Path $InstallDir "monk-agent.exe"
-$AgentHashBefore = Get-FileSha256 $ManagedAgentPath
 
 if ($env:MONK_AGENT_PATH) {
   $AgentPath = $env:MONK_AGENT_PATH
+  # When a custom path is set, hash that file for both before and after
+  # so AgentUpdated stays false (the managed path may not even exist).
+  $AgentHashBefore = Get-FileSha256 $AgentPath
 } elseif ($env:MONK_AGENT_SKIP_ENSURE -eq "1") {
   $AgentPath = $ManagedAgentPath
+  $AgentHashBefore = Get-FileSha256 $ManagedAgentPath
 } else {
+  # Hash the managed binary BEFORE ensure may replace it, then compare
+  # against the resolved path AFTER ensure to detect real updates.
+  $AgentHashBefore = Get-FileSha256 $ManagedAgentPath
   $EnsureScript = Join-Path $PluginRoot "scripts\ensure-monk-agent.ps1"
   if (-not (Test-Path $EnsureScript)) {
     Write-Error "monk-agent installer not found at $EnsureScript"

--- a/scripts/start-monk-agent.sh
+++ b/scripts/start-monk-agent.sh
@@ -183,13 +183,19 @@ hash_file() {
 
 os="$(uname -s)"
 managed_agent_path="${MONK_AGENT_INSTALL_DIR:-"$HOME/.monk/bin"}/monk-agent"
-agent_hash_before="$(hash_file "$managed_agent_path")"
 
 if [ -n "${MONK_AGENT_PATH:-}" ]; then
   agent_path="$MONK_AGENT_PATH"
+  # When a custom path is set, hash that file for both before and after
+  # so agent_updated stays 0 (the managed path may not even exist).
+  agent_hash_before="$(hash_file "$agent_path")"
 elif [ "${MONK_AGENT_SKIP_ENSURE:-0}" = "1" ]; then
   agent_path="$managed_agent_path"
+  agent_hash_before="$(hash_file "$managed_agent_path")"
 else
+  # Hash the managed binary BEFORE ensure may replace it, then compare
+  # against the resolved path AFTER ensure to detect real updates.
+  agent_hash_before="$(hash_file "$managed_agent_path")"
   agent_path="$("$plugin_root/scripts/ensure-monk-agent.sh")"
 fi
 


### PR DESCRIPTION
When MONK_AGENT_PATH is set, the launcher hashed the managed install path for agent_hash_before but the custom path for agent_hash_after. Since those are different files, agent_updated was always true and caused an unnecessary restart on every invoke.

Now both hashes use the resolved agent_path so a healthy custom binary is correctly detected as unchanged.

Fixes #10