### PR TITLE
fix(launcher): treat malformed Windows PID file as stale state

### DIFF
--- a/scripts/ensure-monk-agent.ps1
+++ b/scripts/ensure-monk-agent.ps1
@@ -48,7 +48,13 @@ function Stop-ManagedAgent {
     return
   }
 
-  $OldProcess = Get-Process -Id ([int]$RawPid) -ErrorAction SilentlyContinue
+  $ParsedPid = 0
+  if (-not [int32]::TryParse($RawPid, [ref]$ParsedPid) -or $ParsedPid -le 0) {
+    Remove-Item -Force $PidFile -ErrorAction SilentlyContinue
+    return
+  }
+
+  $OldProcess = Get-Process -Id $ParsedPid -ErrorAction SilentlyContinue
   if (-not $OldProcess) {
     Remove-Item -Force $PidFile -ErrorAction SilentlyContinue
     return

--- a/scripts/start-monk-agent.ps1
+++ b/scripts/start-monk-agent.ps1
@@ -134,7 +134,13 @@ function Stop-ManagedAgent {
     return
   }
 
-  $OldProcess = Get-Process -Id ([int]$RawPid) -ErrorAction SilentlyContinue
+  $ParsedPid = 0
+  if (-not [int32]::TryParse($RawPid, [ref]$ParsedPid) -or $ParsedPid -le 0) {
+    Remove-Item -Force $PidFile -ErrorAction SilentlyContinue
+    return
+  }
+
+  $OldProcess = Get-Process -Id $ParsedPid -ErrorAction SilentlyContinue
   if (-not $OldProcess) {
     return
   }

--- a/scripts/uninstall-monk-agent.ps1
+++ b/scripts/uninstall-monk-agent.ps1
@@ -49,7 +49,13 @@ function Stop-ManagedAgent {
     return
   }
 
-  $process = Get-Process -Id ([int]$raw) -ErrorAction SilentlyContinue
+  $parsedPid = 0
+  if (-not [int32]::TryParse($raw, [ref]$parsedPid) -or $parsedPid -le 0) {
+    Remove-Item -Force $PidFile -ErrorAction SilentlyContinue
+    return
+  }
+
+  $process = Get-Process -Id $parsedPid -ErrorAction SilentlyContinue
   if ($process) {
     try {
       $name = [IO.Path]::GetFileName($process.Path)


### PR DESCRIPTION
## Problem

A corrupt `monk-agent.pid` file — anything non-empty that isn't a positive integer, e.g. a partial write or stray bytes — aborts both the Windows launcher and the uninstaller before the companion starts or cleanup runs.

`scripts/start-monk-agent.ps1:137` (and the identical blocks in `uninstall-monk-agent.ps1:52` and `ensure-monk-agent.ps1:51`) read the PID with an unchecked cast:

```powershell
$OldProcess = Get-Process -Id ([int]$RawPid) -ErrorAction SilentlyContinue
```

The scripts run with `ErrorActionPreference = "Stop"`, so when `$RawPid` is `"not-a-pid"` the cast throws `InvalidCastFromStringToInteger` as a terminating error. The launcher never starts the companion, and the uninstaller leaves the agent binary and PID file in place. The ensure/update path has the same bug.

## Fix

Replace the cast with `[int32]::TryParse`. If the file content isn't a positive `Int32`, treat it as stale state: remove the PID file and return, so startup and cleanup stay recoverable.

```powershell
$ParsedPid = 0
if (-not [int32]::TryParse($RawPid, [ref]$ParsedPid) -or $ParsedPid -le 0) {
    Remove-Item -Force $PidFile -ErrorAction SilentlyContinue
    return
}

$OldProcess = Get-Process -Id $ParsedPid -ErrorAction SilentlyContinue
```

Applied consistently to all three `Stop-ManagedAgent` implementations (`start`, `uninstall`, `ensure`). The uninstaller used a `$raw`/`$process` naming, which I kept locally.

## Verification

Ran the issue's self-contained repro (PowerShell, temp home + harmless `cmd.exe` fixture, unused port, no install/cloud/secrets). Before: both `start` and `uninstall` threw `InvalidCastFromStringToInteger`. After: both proceed past the stale PID file — the launcher continues to start the companion, and the uninstaller removes the agent binary and cleans up the PID file.

Also confirmed the happy path (valid PID of a live `monk-agent.exe`) is unchanged — `TryParse` accepts it and `Stop-Process` runs as before.
