### PR TITLE
fix: cover Windows block-monk command boundaries

### DIFF
--- a/.antigravity-plugin/hooks/block-monk.ps1
+++ b/.antigravity-plugin/hooks/block-monk.ps1
@@ -29,7 +29,7 @@ if (Test-Path $agent) {
 try { $command = ($hookInput | ConvertFrom-Json).toolCall.args.CommandLine } catch { exit 0 }
 if (-not $command) { exit 0 }
 
-if ($command -match '(^|[;&|`(])\s*(sudo\s+)?monk(\s|$)') {
+if ($command -match '(^|[\r\n;&|`({])\s*(sudo\s+)?monk(\s|$)') {
   @{
     decision = "deny"
     reason   = "Blocked: do not shell out to the ``monk`` CLI - it desyncs the cluster state Monk manages. Use the monk-agent MCP tools instead."

--- a/.github/workflows/install-e2e.yml
+++ b/.github/workflows/install-e2e.yml
@@ -62,6 +62,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Test Windows block-monk fallbacks
+        shell: pwsh
+        run: .\tests\block-monk-windows.ps1
+
       - name: Install monk-agent
         shell: pwsh
         env:

--- a/hooks/block-monk.ps1
+++ b/hooks/block-monk.ps1
@@ -19,7 +19,7 @@ if (Test-Path $agent) {
 try { $command = ($hookInput | ConvertFrom-Json).tool_input.command } catch { exit 0 }
 if (-not $command) { exit 0 }
 
-if ($command -match '(^|[;&|`(])\s*(sudo\s+)?monk(\s|$)') {
+if ($command -match '(^|[\r\n;&|`({])\s*(sudo\s+)?monk(\s|$)') {
   @{
     hookSpecificOutput = @{
       hookEventName            = "PreToolUse"

--- a/tests/block-monk-windows.ps1
+++ b/tests/block-monk-windows.ps1
@@ -1,0 +1,62 @@
+param(
+  [string]$RepoRoot = (Split-Path -Parent $PSScriptRoot)
+)
+
+$ErrorActionPreference = "Stop"
+$WindowsPowerShell = Join-Path $env:SystemRoot "System32\WindowsPowerShell\v1.0\powershell.exe"
+$RootHook = Join-Path $RepoRoot "hooks\block-monk.ps1"
+$AntigravityHook = Join-Path $RepoRoot ".antigravity-plugin\hooks\block-monk.ps1"
+$MissingAgent = Join-Path $env:TEMP "missing-monk-agent-$PID.exe"
+$PreviousAgentPath = $env:MONK_AGENT_PATH
+$PreviousPath = $env:Path
+
+$Cases = @(
+  @{ Name = "direct"; Command = "monk deploy"; Denied = $true },
+  @{ Name = "newline"; Command = "echo ok`nmonk deploy"; Denied = $true },
+  @{ Name = "crlf"; Command = "echo ok`r`nmonk deploy"; Denied = $true },
+  @{ Name = "brace"; Command = "{ monk deploy; }"; Denied = $true },
+  @{ Name = "newline-sudo"; Command = "echo ok`nsudo monk deploy"; Denied = $true },
+  @{ Name = "similar-command"; Command = "monkey deploy"; Denied = $false },
+  @{ Name = "argument"; Command = "grep monk README.md"; Denied = $false }
+)
+
+function Assert-HookCases {
+  param(
+    [string]$Hook,
+    [ValidateSet("claude", "antigravity")]
+    [string]$Format
+  )
+
+  foreach ($Case in $Cases) {
+    if ($Format -eq "claude") {
+      $Payload = @{ tool_input = @{ command = $Case.Command } } | ConvertTo-Json -Compress
+      $Output = $Payload | & $WindowsPowerShell -NoProfile -ExecutionPolicy Bypass -File $Hook
+      $Denied = [bool]($Output -match '"permissionDecision":"deny"')
+    } else {
+      $Payload = @{ toolCall = @{ name = "run_command"; args = @{ CommandLine = $Case.Command } } } |
+        ConvertTo-Json -Compress -Depth 5
+      $Output = $Payload | & $WindowsPowerShell -NoProfile -ExecutionPolicy Bypass -File $Hook
+      $Denied = [bool]($Output -match '"decision":"deny"')
+    }
+
+    if ($Denied -ne $Case.Denied) {
+      throw "$Format hook case '$($Case.Name)' expected denied=$($Case.Denied), got denied=$Denied. Output: $Output"
+    }
+  }
+}
+
+try {
+  $env:MONK_AGENT_PATH = $MissingAgent
+
+  Assert-HookCases -Hook $RootHook -Format "claude"
+
+  # Antigravity runs both hook siblings when bash is available. Limit PATH so
+  # this test exercises the stock-Windows PowerShell fallback specifically.
+  $env:Path = Split-Path -Parent $WindowsPowerShell
+  Assert-HookCases -Hook $AntigravityHook -Format "antigravity"
+} finally {
+  $env:MONK_AGENT_PATH = $PreviousAgentPath
+  $env:Path = $PreviousPath
+}
+
+Write-Host "Windows block-monk fallback tests passed."


### PR DESCRIPTION
## Summary

- treat CR, LF, and opening braces as shell command boundaries in both Windows PowerShell `block-monk` fallbacks;
- cover the Claude/Codex hook and the Antigravity hook consistently;
- add a reusable Windows regression test and run it in the existing Windows CI job.

## Why this is broader than #49

PR #49 only changes the Antigravity hook and splits on LF. The Claude/Codex hook remains unchanged, and `{ monk deploy; }` still bypasses the proposed regex after trimming. This PR covers both hook formats and all reproduction cases from #34 without changing harmless `monkey` commands or uses of `monk` as an argument.

## Validation

- `.\tests\block-monk-windows.ps1`
- the same test against `upstream/main` fails on the `claude` newline case, confirming the regression is detected;
- `git diff --cached --check`

Fixes #34
