### PR TITLE
fix: support wget health checks in antigravity hook

### DIFF
--- a/.antigravity-plugin/hooks/ensure-monk-agent.sh
+++ b/.antigravity-plugin/hooks/ensure-monk-agent.sh
@@ -14,8 +14,21 @@ host="${MONK_AGENT_HOST:-127.0.0.1}"
 health_url="http://$host:$port/.well-known/oauth-protected-resource"
 
 is_running() {
-  command -v curl >/dev/null 2>&1 || return 1
-  curl -fsS --max-time 2 "$health_url" 2>/dev/null | grep -q '"resource"'
+  if command -v curl >/dev/null 2>&1; then
+    body="$(curl -fsS --max-time 2 "$health_url" 2>/dev/null || true)"
+    case "$body" in
+      *'"resource"'*) return 0 ;;
+    esac
+  fi
+
+  if command -v wget >/dev/null 2>&1; then
+    body="$(wget -q -T 2 -O - "$health_url" 2>/dev/null || true)"
+    case "$body" in
+      *'"resource"'*) return 0 ;;
+    esac
+  fi
+
+  return 1
 }
 
 # Fast path — already up

--- a/tests/ensure-monk-agent-wget-fallback.sh
+++ b/tests/ensure-monk-agent-wget-fallback.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env sh
+set -eu
+
+repo="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+root="$(mktemp -d)"
+cleanup() { rm -rf "$root"; }
+trap cleanup EXIT HUP INT TERM
+
+hook="$repo/.antigravity-plugin/hooks/ensure-monk-agent.sh"
+
+set +e
+out="$(
+  HOME="$root/home" \
+  MONK_AGENT_HOME="$root/monk" \
+  MONK_AGENT_PATH=/usr/bin/true \
+  PATH=/definitely-no-system-tools \
+  /bin/sh -c '
+    wget() {
+      printf "%s\n" "{\"resource\":\"http://127.0.0.1:7419/mcp\"}"
+    }
+    jq() {
+      printf "%s\n" \
+        "{\"injectSteps\":[{\"ephemeralMessage\":\"monk-agent was not running and has been started.\"}]}"
+    }
+    mkdir() { /bin/mkdir "$@"; }
+    setsid() {
+      printf "%s\n" START_CALLED >&2
+      "$@"
+    }
+
+    . "$0"
+  ' "$hook" 2>&1
+)"
+status=$?
+set -e
+
+log="$root/monk/agent/launcher/logs/monk-agent.log"
+if [ -f "$log" ]; then
+  start_calls="$(grep -c '^START_CALLED$' "$log" || true)"
+else
+  start_calls=0
+fi
+started_notices="$(printf '%s\n' "$out" | grep -c 'has been started' || true)"
+
+printf 'status=%s\n' "$status"
+printf 'start_calls=%s\n' "$start_calls"
+printf 'started_notices=%s\n' "$started_notices"
+printf '%s\n' "$out"
+
+[ "$status" -eq 0 ]
+[ "$start_calls" -eq 0 ]
+[ "$started_notices" -eq 0 ]
+[ "$out" = "{}" ]


### PR DESCRIPTION
## Summary
- allow the Antigravity POSIX ensure hook to detect a healthy monk-agent via wget when curl is unavailable
- avoid relying on grep for health-response matching in minimal PATH environments
- add a shell regression test for the wget-only health fixture

Closes #40

## Validation
- /bin/sh tests/ensure-monk-agent-wget-fallback.sh
- reproduced the issue fixture with two sourced hook invocations: status=0, start_calls=0, started_notices=0
- curl-only fast-path fixture: status=0, start_calls=0
- /bin/sh -n .antigravity-plugin/hooks/ensure-monk-agent.sh
- /bin/sh -n tests/ensure-monk-agent-wget-fallback.sh