### PR TITLE
Verify ingress status after ensure

### DIFF
--- a/agents/monk-deployer.md
+++ b/agents/monk-deployer.md
@@ -150,6 +150,14 @@ with no local build), skip this section and continue from step 5 above.
   on a bare IP:port without HTTPS or a domain. The enable typically succeeds once
   the cluster's system templates finish syncing: surface the pending state to
   the user, retry enabling ingress, and verify the routes serve on 80/443.
+- After calling `monk.cluster.ingress.ensure`, treat the action result as
+  provisional. Always re-read `monk.cluster.ingress.status` and verify ingress
+  is enabled/healthy with ready instances or usable route/endpoint data before
+  saying ingress is ready. If the ensure action says it succeeded but the status
+  still shows `enabled=false`, unhealthy, zero ready instances, missing
+  routes/endpoints, or logs such as "Failed to enable ingress plugin", report the
+  operation as not enabled and keep retry/remediation visible instead of
+  claiming success.
 - Use `monk.cluster.peer.remove` and
   `monk.cluster.peer.tag` only when the user asks for capacity or placement
   changes, or when deployment remediation clearly requires it.

--- a/agents/monk-editor.md
+++ b/agents/monk-editor.md
@@ -252,6 +252,11 @@ report the problem in your summary — never rewrite a web-facing service to
 plain `ports` as a workaround. Re-enabling the plugin later (`monk plugins
 enable ingress`) picks up the declared routes without any template changes,
 while a ports rewrite strands the app on a firewalled IP:port.
+If `monk.cluster.ingress.ensure` reports a succeeded action but
+`monk.cluster.ingress.status` still shows disabled/unhealthy ingress, zero ready
+instances, missing route/endpoint data, or logs such as "Failed to enable
+ingress plugin", treat ingress as disabled. Keep the route template intact and
+make the retry/remediation state explicit instead of saying the route is ready.
 
 ## Secrets and generated values
 

--- a/plugins/monk/skills/monk/references/agent-workflow.md
+++ b/plugins/monk/skills/monk/references/agent-workflow.md
@@ -52,6 +52,13 @@ automatically selects the created cluster on success. Use
 `monk://workspace/clusters` or `monk.cluster.list` to inspect saved clusters,
 `monk.cluster.switch` to select one logically, and `monk.cluster.exit` to clear
 selection and return to local mode without deleting infrastructure.
+When enabling ingress, do not treat `monk.cluster.ingress.ensure` or its
+terminal action status as proof that ingress is enabled. After the action
+finishes, call `monk.cluster.ingress.status` and require enabled/healthy status
+with ready instances or usable route/endpoint data. If status still reports
+`enabled=false`, unhealthy, zero ready instances, missing routes/endpoints, or
+logs such as "Failed to enable ingress plugin", surface that ingress remains
+disabled and continue retry/remediation rather than reporting success.
 
 For workload lifecycle cleanup, use `monk.workload.status` to inspect first,
 then `monk.workload.stop`, `monk.workload.delete`/`purge`, or

--- a/skills/monk/references/agent-workflow.md
+++ b/skills/monk/references/agent-workflow.md
@@ -52,6 +52,13 @@ automatically selects the created cluster on success. Use
 `monk://workspace/clusters` or `monk.cluster.list` to inspect saved clusters,
 `monk.cluster.switch` to select one logically, and `monk.cluster.exit` to clear
 selection and return to local mode without deleting infrastructure.
+When enabling ingress, do not treat `monk.cluster.ingress.ensure` or its
+terminal action status as proof that ingress is enabled. After the action
+finishes, call `monk.cluster.ingress.status` and require enabled/healthy status
+with ready instances or usable route/endpoint data. If status still reports
+`enabled=false`, unhealthy, zero ready instances, missing routes/endpoints, or
+logs such as "Failed to enable ingress plugin", surface that ingress remains
+disabled and continue retry/remediation rather than reporting success.
 
 For workload lifecycle cleanup, use `monk.workload.status` to inspect first,
 then `monk.workload.stop`, `monk.workload.delete`/`purge`, or

--- a/tests/ingress-ensure-guidance.sh
+++ b/tests/ingress-ensure-guidance.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+set -eu
+
+repo_root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+
+check_contains() {
+  file=$1
+  pattern=$2
+
+  if ! grep -Fq "$pattern" "$repo_root/$file"; then
+    echo "missing expected ingress guidance in $file: $pattern" >&2
+    exit 1
+  fi
+}
+
+check_contains "agents/monk-deployer.md" "After calling \`monk.cluster.ingress.ensure\`, treat the action result as"
+check_contains "agents/monk-deployer.md" "still shows \`enabled=false\`, unhealthy, zero ready instances"
+check_contains "agents/monk-editor.md" "reports a succeeded action but"
+check_contains "agents/monk-editor.md" "treat ingress as disabled"
+
+for file in \
+  "skills/monk/references/agent-workflow.md" \
+  "plugins/monk/skills/monk/references/agent-workflow.md"
+do
+  check_contains "$file" "do not treat \`monk.cluster.ingress.ensure\`"
+  check_contains "$file" "call \`monk.cluster.ingress.status\`"
+  check_contains "$file" "surface that ingress remains"
+done
+
+echo "ingress ensure guidance is present"


### PR DESCRIPTION
## Summary
- require agents to treat `monk.cluster.ingress.ensure` action success as provisional
- require a follow-up `monk.cluster.ingress.status` check before reporting ingress ready
- keep route configuration intact and surface disabled/unhealthy ingress when status remains `enabled=false`, lacks ready instances/endpoints, or logs enable failures
- add a regression script that checks the deployer/editor/workflow guidance stays present in both skill copies

## Tests
- `/bin/sh tests/ingress-ensure-guidance.sh`

Fixes #64