### PR TITLE
Block quoted monk fallback commands

### DIFF
--- a/.antigravity-plugin/hooks/block-monk.sh
+++ b/.antigravity-plugin/hooks/block-monk.sh
@@ -23,9 +23,12 @@ if [ -x "$agent" ]; then
   fi
 fi
 
-# Fallback: binary unavailable. Grep the raw hook payload for a `monk` command
-# in command position. False positives only ever BLOCK, never allow.
-if printf '%s' "$input" | grep -Eq '(^|["[:space:];&|`(])(sudo[[:space:]]+)?monk([[:space:]"]|$)'; then
+# Fallback: binary unavailable. Normalize common JSON/shell quoting first, then
+# look only at command starts or shell command separators. This catches
+# `"monk"`, `'monk'`, and `\monk` without blocking harmless arguments like
+# `grep monk README.md`.
+fallback_input="$(printf '%s' "$input" | sed "s/\\\\\"/\"/g; s/\\\\\\\\//g; s/[\"']//g")"
+if printf '%s' "$fallback_input" | grep -Eq '(^|CommandLine:[[:space:]]*|command:[[:space:]]*|[;&|`(][[:space:]]*)(sudo[[:space:]]+)?monk([[:space:];&|`)}]|$)'; then
   cat <<'JSON'
 {
   "decision": "deny",

--- a/hooks/block-monk.sh
+++ b/hooks/block-monk.sh
@@ -20,11 +20,12 @@ if [ -x "$agent" ]; then
   fi
 fi
 
-# Fallback: binary unavailable. Grep the raw hook payload for a `monk` command.
-# Matches `monk` only in command position (start, or after a shell separator),
-# optional `sudo`, followed by whitespace/quote/end — so `monkey` is not matched.
-# False positives only ever BLOCK, never allow, which is the safe direction.
-if printf '%s' "$input" | grep -Eq '(^|["[:space:];&|`(])(sudo[[:space:]]+)?monk([[:space:]"]|$)'; then
+# Fallback: binary unavailable. Normalize common JSON/shell quoting first, then
+# look only at command starts or shell command separators. This catches
+# `"monk"`, `'monk'`, and `\monk` without blocking harmless arguments like
+# `grep monk README.md`.
+fallback_input="$(printf '%s' "$input" | sed "s/\\\\\"/\"/g; s/\\\\\\\\//g; s/[\"']//g")"
+if printf '%s' "$fallback_input" | grep -Eq '(^|CommandLine:[[:space:]]*|command:[[:space:]]*|[;&|`(][[:space:]]*)(sudo[[:space:]]+)?monk([[:space:];&|`)}]|$)'; then
   cat <<'JSON'
 {
   "hookSpecificOutput": {

--- a/tests/block-monk-fallback.sh
+++ b/tests/block-monk-fallback.sh
@@ -1,0 +1,74 @@
+#!/bin/sh
+set -eu
+
+repo_root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+missing_agent="$repo_root/.definitely-missing-monk-agent"
+
+run_case() {
+  hook=$1
+  format=$2
+  name=$3
+  command=$4
+  expected=$5
+
+  if [ "$format" = "antigravity" ]; then
+    payload=$(COMMAND="$command" python3 - <<'PY'
+import json
+import os
+
+print(json.dumps({
+    "toolCall": {
+        "name": "run_command",
+        "args": {"CommandLine": os.environ["COMMAND"]},
+    }
+}))
+PY
+)
+  else
+    payload=$(COMMAND="$command" python3 - <<'PY'
+import json
+import os
+
+print(json.dumps({"tool_input": {"command": os.environ["COMMAND"]}}))
+PY
+)
+  fi
+
+  output=$(MONK_AGENT_PATH="$missing_agent" "$repo_root/$hook" <<EOF
+$payload
+EOF
+)
+
+  case "$output" in
+    *deny*) denied=yes ;;
+    *) denied=no ;;
+  esac
+
+  if [ "$denied" != "$expected" ]; then
+    printf '%s\n' "unexpected fallback decision for $hook / $name" >&2
+    printf '%s\n' "command: $command" >&2
+    printf '%s\n' "expected denied=$expected got denied=$denied" >&2
+    printf '%s\n' "output: $output" >&2
+    exit 1
+  fi
+}
+
+for spec in \
+  ".antigravity-plugin/hooks/block-monk.sh antigravity" \
+  "hooks/block-monk.sh claude"
+do
+  set -- $spec
+  hook=$1
+  format=$2
+
+  run_case "$hook" "$format" direct "monk status" yes
+  run_case "$hook" "$format" double_quoted '"monk" status' yes
+  run_case "$hook" "$format" single_quoted "'monk' status" yes
+  run_case "$hook" "$format" backslash_escaped '\monk status' yes
+  run_case "$hook" "$format" sudo "sudo monk status" yes
+  run_case "$hook" "$format" after_separator "echo ok; monk status" yes
+  run_case "$hook" "$format" harmless_argument "grep monk README.md" no
+  run_case "$hook" "$format" harmless_word "monkey status" no
+done
+
+echo "block-monk fallback decisions are correct"


### PR DESCRIPTION
## Summary
- normalize common JSON/shell quoting before the POSIX block-monk fallback regex runs
- block command-position monk forms such as quoted monk, escaped monk, sudo monk, and commands after shell separators
- stop blocking harmless arguments such as grep monk README.md
- add regression coverage for both Antigravity and Claude/Codex POSIX fallback hooks

## Tests
- /bin/sh tests/block-monk-fallback.sh
- /bin/sh -n .antigravity-plugin/hooks/block-monk.sh && /bin/sh -n hooks/block-monk.sh && /bin/sh -n tests/block-monk-fallback.sh

Fixes #55