### PR TITLE
Ignore stale monk-agent PID files during uninstall

### DIFF
--- a/plugins/monk/scripts/uninstall-monk-agent.sh
+++ b/plugins/monk/scripts/uninstall-monk-agent.sh
@@ -79,6 +79,28 @@ if [ "$assume_yes" != "1" ]; then
   esac
 fi
 
+pid_matches_agent() {
+  pid="$1"
+  if [ ! -e "$target" ]; then
+    return 1
+  fi
+
+  if [ -r "/proc/$pid/exe" ] && command -v readlink >/dev/null 2>&1; then
+    proc_exe="$(readlink "/proc/$pid/exe" 2>/dev/null || true)"
+    case "$proc_exe" in
+      "$target"|"$target (deleted)") return 0 ;;
+      *) return 1 ;;
+    esac
+  fi
+
+  proc_args="$(ps -p "$pid" -o args= 2>/dev/null || true)"
+  case "$proc_args" in
+    "$target"|"$target "*) return 0 ;;
+  esac
+
+  return 1
+}
+
 stop_agent() {
   os="$(uname -s 2>/dev/null || printf unknown)"
   if [ "$os" = "Darwin" ] && command -v launchctl >/dev/null 2>&1; then
@@ -93,7 +115,11 @@ stop_agent() {
       ''|*[!0-9]*) ;;
       *)
         if kill -0 "$pid" >/dev/null 2>&1; then
-          kill "$pid" >/dev/null 2>&1 || true
+          if pid_matches_agent "$pid"; then
+            kill "$pid" >/dev/null 2>&1 || true
+          else
+            echo "Ignoring stale monk-agent PID $pid: process does not match $target." >&2
+          fi
         fi
         ;;
     esac

--- a/scripts/uninstall-monk-agent.sh
+++ b/scripts/uninstall-monk-agent.sh
@@ -79,6 +79,28 @@ if [ "$assume_yes" != "1" ]; then
   esac
 fi
 
+pid_matches_agent() {
+  pid="$1"
+  if [ ! -e "$target" ]; then
+    return 1
+  fi
+
+  if [ -r "/proc/$pid/exe" ] && command -v readlink >/dev/null 2>&1; then
+    proc_exe="$(readlink "/proc/$pid/exe" 2>/dev/null || true)"
+    case "$proc_exe" in
+      "$target"|"$target (deleted)") return 0 ;;
+      *) return 1 ;;
+    esac
+  fi
+
+  proc_args="$(ps -p "$pid" -o args= 2>/dev/null || true)"
+  case "$proc_args" in
+    "$target"|"$target "*) return 0 ;;
+  esac
+
+  return 1
+}
+
 stop_agent() {
   os="$(uname -s 2>/dev/null || printf unknown)"
   if [ "$os" = "Darwin" ] && command -v launchctl >/dev/null 2>&1; then
@@ -93,7 +115,11 @@ stop_agent() {
       ''|*[!0-9]*) ;;
       *)
         if kill -0 "$pid" >/dev/null 2>&1; then
-          kill "$pid" >/dev/null 2>&1 || true
+          if pid_matches_agent "$pid"; then
+            kill "$pid" >/dev/null 2>&1 || true
+          else
+            echo "Ignoring stale monk-agent PID $pid: process does not match $target." >&2
+          fi
         fi
         ;;
     esac

--- a/tests/uninstall-stale-pid.sh
+++ b/tests/uninstall-stale-pid.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env sh
+set -eu
+
+repo="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+root="$(mktemp -d)"
+victim_pid=""
+
+cleanup() {
+  if [ -n "$victim_pid" ]; then
+    kill "$victim_pid" 2>/dev/null || true
+  fi
+  rm -rf "$root"
+}
+trap cleanup EXIT HUP INT TERM
+
+run_stale_pid_case() {
+  script="$1"
+
+  mkdir -p "$root/home/agent/launcher/run" "$root/install" "$root/user"
+  sleep 300 &
+  victim_pid="$!"
+  printf '%s\n' "$victim_pid" > "$root/home/agent/launcher/run/monk-agent.pid"
+
+  MONK_AGENT_HOME="$root/home" \
+    MONK_AGENT_INSTALL_DIR="$root/install" \
+    HOME="$root/user" \
+    sh "$script" --yes >/dev/null
+
+  if ! kill -0 "$victim_pid" 2>/dev/null; then
+    echo "uninstaller terminated unrelated process for $script" >&2
+    exit 1
+  fi
+
+  if [ -e "$root/home/agent/launcher/run/monk-agent.pid" ]; then
+    echo "stale PID file was not removed for $script" >&2
+    exit 1
+  fi
+
+  kill "$victim_pid" 2>/dev/null || true
+  victim_pid=""
+  rm -rf "$root/home" "$root/install" "$root/user"
+}
+
+run_stale_pid_case "$repo/scripts/uninstall-monk-agent.sh"
+run_stale_pid_case "$repo/plugins/monk/scripts/uninstall-monk-agent.sh"
+
+echo "uninstall stale PID protection is correct"


### PR DESCRIPTION
## Summary
- verify a PID-file process belongs to the installed monk-agent before signaling it
- treat live numeric PIDs that cannot be matched to the managed agent as stale and leave the process alone
- keep removing stale PID files so future uninstall/start attempts are not stuck
- add a regression test for both distributed POSIX uninstall script copies

## Tests
- /bin/sh tests/uninstall-stale-pid.sh
- /bin/sh -n scripts/uninstall-monk-agent.sh
- /bin/sh -n plugins/monk/scripts/uninstall-monk-agent.sh
- /bin/sh -n tests/uninstall-stale-pid.sh

Fixes #53