### PR TITLE
fix: handle whitespace in signedIn check and break early on process exit

### DIFF
--- a/scripts/start-monk-agent.sh
+++ b/scripts/start-monk-agent.sh
@@ -126,7 +126,7 @@ emit_signin_nudge() {
     [ "$attempt" -lt 3 ] && sleep 1
   done
   case "$body" in
-    *'"signedIn":true'*) return 0 ;;
+    *'"signedIn":'*true*) return 0 ;;
   esac
   # Empty body = read error / 500 / timeout, NOT a confirmed signed-out state —
   # suppress the nudge. Only an affirmative signedIn:false reaches the nudge below.
@@ -341,6 +341,13 @@ while [ "$tries" -lt 180 ]; do
     register_antigravity_mcp
     emit_signin_nudge
     exit 0
+  fi
+  # Break early if the background process has exited — no point waiting 180s.
+  if [ -f "$pid_file" ]; then
+    pid="$(cat "$pid_file" 2>/dev/null || true)"
+    if [ -n "$pid" ] && ! kill -0 "$pid" 2>/dev/null; then
+      break
+    fi
   fi
   tries=$((tries + 1))
   sleep 1


### PR DESCRIPTION
## What this does

- **Issue #56**: Fixes the  pattern match in  to handle any whitespace after the colon (e.g.  vs ). The previous exact-match pattern failed when the JSON response included spaces, causing the launcher to treat a signed-in user as signed out.
- **Issue #39**: The 180-retry health check loop now breaks early if the background  process has exited, instead of waiting the full 180 seconds. This prevents a 3-minute hang when the companion crashes on startup.

## Problem

1. **Issue #56**: The  check used  which required no whitespace. JSON serializers commonly produce  (with a space), so the nudge fires incorrectly on every session start even when the user is signed in.

2. **Issue #39**: When the companion process exits during startup (e.g. port conflict, missing binary), the launcher loop waited the full 180 seconds before timing out, even though the process was already dead.

## Testing

- Verified the signedIn pattern now matches both  and 
- Verified the early-exit check correctly detects a dead process and breaks the loop

Fixes #56
Fixes #39