### PR TITLE
fix: validate PID is numeric before casting in Windows scripts

### DIFF
--- a/scripts/start-monk-agent.ps1
+++ b/scripts/start-monk-agent.ps1
@@ -134,7 +134,14 @@ function Stop-ManagedAgent {
     return
   }
 
-  $OldProcess = Get-Process -Id ([int]$RawPid) -ErrorAction SilentlyContinue
+  # Validate PID is numeric before casting to avoid terminating error
+  # on malformed PID files (e.g. containing text or whitespace).
+  $ParsedPid = 0
+  if (-not [int]::TryParse($RawPid, [ref]$ParsedPid)) {
+    return
+  }
+
+  $OldProcess = Get-Process -Id $ParsedPid -ErrorAction SilentlyContinue
   if (-not $OldProcess) {
     return
   }

--- a/scripts/uninstall-monk-agent.ps1
+++ b/scripts/uninstall-monk-agent.ps1
@@ -49,7 +49,15 @@ function Stop-ManagedAgent {
     return
   }
 
-  $process = Get-Process -Id ([int]$raw) -ErrorAction SilentlyContinue
+  # Validate PID is numeric before casting to avoid terminating error
+  # on malformed PID files (e.g. containing text or whitespace).
+  $ParsedPid = 0
+  if (-not [int]::TryParse($raw, [ref]$ParsedPid)) {
+    Remove-Item -Force $PidFile -ErrorAction SilentlyContinue
+    return
+  }
+
+  $process = Get-Process -Id $ParsedPid -ErrorAction SilentlyContinue
   if ($process) {
     try {
       $name = [IO.Path]::GetFileName($process.Path)


### PR DESCRIPTION
Malformed PID files cause a terminating error on the [int] cast, blocking both the launcher and uninstaller.

## What changes

- **start-monk-agent.ps1**: Uses [int]::TryParse() before Get-Process, gracefully returning on non-numeric PIDs
- **uninstall-monk-agent.ps1**: Same TryParse guard, plus cleans up the stale PID file

## Problem

If the PID file contains non-numeric content (BOM artifacts, text corruption, whitespace), the hard [int] cast throws a terminating error. The launcher skips the nudge but the agent itself still starts; the uninstaller fails to kill the old process entirely.

## Testing

- Verified non-numeric PID content no longer throws
- Verified valid numeric PIDs still trigger proper cleanup

Fixes #57