### PR TITLE
fix: harden startup/shutdown scripts across all rendered copies

### DIFF
--- a/.antigravity-plugin/scripts/start-monk-agent.ps1
+++ b/.antigravity-plugin/scripts/start-monk-agent.ps1
@@ -134,7 +134,14 @@ function Stop-ManagedAgent {
     return
   }
 
-  $OldProcess = Get-Process -Id ([int]$RawPid) -ErrorAction SilentlyContinue
+  # Validate PID is numeric before casting to avoid terminating error
+  # on malformed PID files (e.g. containing text or whitespace).
+  $ParsedPid = 0
+  if (-not [int]::TryParse($RawPid, [ref]$ParsedPid)) {
+    return
+  }
+
+  $OldProcess = Get-Process -Id $ParsedPid -ErrorAction SilentlyContinue
   if (-not $OldProcess) {
     return
   }

--- a/.antigravity-plugin/scripts/start-monk-agent.sh
+++ b/.antigravity-plugin/scripts/start-monk-agent.sh
@@ -73,7 +73,11 @@ register_antigravity_mcp() {
       python3 -c "
 import json, sys
 cfg = json.load(open('$mcp_cfg'))
-cfg.setdefault('mcpServers', {})['monk'] = {'serverUrl': '$server_url'}
+servers = cfg.get('mcpServers')
+if not isinstance(servers, dict):
+    servers = {}
+cfg['mcpServers'] = servers
+servers['monk'] = {'serverUrl': '$server_url'}
 json.dump(cfg, sys.stdout, indent=2)
 print()
 " >"$tmp"
@@ -341,6 +345,13 @@ while [ "$tries" -lt 180 ]; do
     register_antigravity_mcp
     emit_signin_nudge
     exit 0
+  fi
+  # Break early if the background process has exited — no point waiting 180s.
+  if [ -f "$pid_file" ]; then
+    _pid="$(cat "$pid_file" 2>/dev/null || true)"
+    if [ -n "$_pid" ] && ! kill -0 "$_pid" 2>/dev/null; then
+      break
+    fi
   fi
   tries=$((tries + 1))
   sleep 1

--- a/.antigravity-plugin/scripts/uninstall-monk-agent.ps1
+++ b/.antigravity-plugin/scripts/uninstall-monk-agent.ps1
@@ -49,7 +49,15 @@ function Stop-ManagedAgent {
     return
   }
 
-  $process = Get-Process -Id ([int]$raw) -ErrorAction SilentlyContinue
+  # Validate PID is numeric before casting to avoid terminating error
+  # on malformed PID files (e.g. containing text or whitespace).
+  $ParsedPid = 0
+  if (-not [int]::TryParse($raw, [ref]$ParsedPid)) {
+    Remove-Item -Force $PidFile -ErrorAction SilentlyContinue
+    return
+  }
+
+  $process = Get-Process -Id $ParsedPid -ErrorAction SilentlyContinue
   if ($process) {
     try {
       $name = [IO.Path]::GetFileName($process.Path)

--- a/.antigravity-plugin/scripts/uninstall-monk-agent.sh
+++ b/.antigravity-plugin/scripts/uninstall-monk-agent.sh
@@ -93,7 +93,18 @@ stop_agent() {
       ''|*[!0-9]*) ;;
       *)
         if kill -0 "$pid" >/dev/null 2>&1; then
-          kill "$pid" >/dev/null 2>&1 || true
+          # Verify the process is actually monk-agent before killing to
+          # avoid terminating an unrelated process that reused the stale PID.
+          proc_name=""
+          if [ -f "/proc/$pid/comm" ]; then
+            proc_name="$(tr -d '\n' < "/proc/$pid/comm" 2>/dev/null || true)"
+          fi
+          if [ -z "$proc_name" ] && command -v ps >/dev/null 2>&1; then
+            proc_name="$(ps -p "$pid" -o comm= 2>/dev/null || true)"
+          fi
+          if [ -z "$proc_name" ] || [ "$proc_name" = "monk-agent" ]; then
+            kill "$pid" >/dev/null 2>&1 || true
+          fi
         fi
         ;;
     esac

--- a/plugins/monk/scripts/start-monk-agent.ps1
+++ b/plugins/monk/scripts/start-monk-agent.ps1
@@ -134,7 +134,14 @@ function Stop-ManagedAgent {
     return
   }
 
-  $OldProcess = Get-Process -Id ([int]$RawPid) -ErrorAction SilentlyContinue
+  # Validate PID is numeric before casting to avoid terminating error
+  # on malformed PID files (e.g. containing text or whitespace).
+  $ParsedPid = 0
+  if (-not [int]::TryParse($RawPid, [ref]$ParsedPid)) {
+    return
+  }
+
+  $OldProcess = Get-Process -Id $ParsedPid -ErrorAction SilentlyContinue
   if (-not $OldProcess) {
     return
   }

--- a/plugins/monk/scripts/start-monk-agent.sh
+++ b/plugins/monk/scripts/start-monk-agent.sh
@@ -73,7 +73,11 @@ register_antigravity_mcp() {
       python3 -c "
 import json, sys
 cfg = json.load(open('$mcp_cfg'))
-cfg.setdefault('mcpServers', {})['monk'] = {'serverUrl': '$server_url'}
+servers = cfg.get('mcpServers')
+if not isinstance(servers, dict):
+    servers = {}
+cfg['mcpServers'] = servers
+servers['monk'] = {'serverUrl': '$server_url'}
 json.dump(cfg, sys.stdout, indent=2)
 print()
 " >"$tmp"
@@ -341,6 +345,13 @@ while [ "$tries" -lt 180 ]; do
     register_antigravity_mcp
     emit_signin_nudge
     exit 0
+  fi
+  # Break early if the background process has exited — no point waiting 180s.
+  if [ -f "$pid_file" ]; then
+    _pid="$(cat "$pid_file" 2>/dev/null || true)"
+    if [ -n "$_pid" ] && ! kill -0 "$_pid" 2>/dev/null; then
+      break
+    fi
   fi
   tries=$((tries + 1))
   sleep 1

--- a/plugins/monk/scripts/uninstall-monk-agent.ps1
+++ b/plugins/monk/scripts/uninstall-monk-agent.ps1
@@ -49,7 +49,15 @@ function Stop-ManagedAgent {
     return
   }
 
-  $process = Get-Process -Id ([int]$raw) -ErrorAction SilentlyContinue
+  # Validate PID is numeric before casting to avoid terminating error
+  # on malformed PID files (e.g. containing text or whitespace).
+  $ParsedPid = 0
+  if (-not [int]::TryParse($raw, [ref]$ParsedPid)) {
+    Remove-Item -Force $PidFile -ErrorAction SilentlyContinue
+    return
+  }
+
+  $process = Get-Process -Id $ParsedPid -ErrorAction SilentlyContinue
   if ($process) {
     try {
       $name = [IO.Path]::GetFileName($process.Path)

--- a/plugins/monk/scripts/uninstall-monk-agent.sh
+++ b/plugins/monk/scripts/uninstall-monk-agent.sh
@@ -93,7 +93,18 @@ stop_agent() {
       ''|*[!0-9]*) ;;
       *)
         if kill -0 "$pid" >/dev/null 2>&1; then
-          kill "$pid" >/dev/null 2>&1 || true
+          # Verify the process is actually monk-agent before killing to
+          # avoid terminating an unrelated process that reused the stale PID.
+          proc_name=""
+          if [ -f "/proc/$pid/comm" ]; then
+            proc_name="$(tr -d '\n' < "/proc/$pid/comm" 2>/dev/null || true)"
+          fi
+          if [ -z "$proc_name" ] && command -v ps >/dev/null 2>&1; then
+            proc_name="$(ps -p "$pid" -o comm= 2>/dev/null || true)"
+          fi
+          if [ -z "$proc_name" ] || [ "$proc_name" = "monk-agent" ]; then
+            kill "$pid" >/dev/null 2>&1 || true
+          fi
         fi
         ;;
     esac

--- a/scripts/start-monk-agent.ps1
+++ b/scripts/start-monk-agent.ps1
@@ -134,7 +134,14 @@ function Stop-ManagedAgent {
     return
   }
 
-  $OldProcess = Get-Process -Id ([int]$RawPid) -ErrorAction SilentlyContinue
+  # Validate PID is numeric before casting to avoid terminating error
+  # on malformed PID files (e.g. containing text or whitespace).
+  $ParsedPid = 0
+  if (-not [int]::TryParse($RawPid, [ref]$ParsedPid)) {
+    return
+  }
+
+  $OldProcess = Get-Process -Id $ParsedPid -ErrorAction SilentlyContinue
   if (-not $OldProcess) {
     return
   }

--- a/scripts/start-monk-agent.sh
+++ b/scripts/start-monk-agent.sh
@@ -73,7 +73,11 @@ register_antigravity_mcp() {
       python3 -c "
 import json, sys
 cfg = json.load(open('$mcp_cfg'))
-cfg.setdefault('mcpServers', {})['monk'] = {'serverUrl': '$server_url'}
+servers = cfg.get('mcpServers')
+if not isinstance(servers, dict):
+    servers = {}
+cfg['mcpServers'] = servers
+servers['monk'] = {'serverUrl': '$server_url'}
 json.dump(cfg, sys.stdout, indent=2)
 print()
 " >"$tmp"
@@ -341,6 +345,13 @@ while [ "$tries" -lt 180 ]; do
     register_antigravity_mcp
     emit_signin_nudge
     exit 0
+  fi
+  # Break early if the background process has exited — no point waiting 180s.
+  if [ -f "$pid_file" ]; then
+    _pid="$(cat "$pid_file" 2>/dev/null || true)"
+    if [ -n "$_pid" ] && ! kill -0 "$_pid" 2>/dev/null; then
+      break
+    fi
   fi
   tries=$((tries + 1))
   sleep 1

--- a/scripts/uninstall-monk-agent.ps1
+++ b/scripts/uninstall-monk-agent.ps1
@@ -49,7 +49,15 @@ function Stop-ManagedAgent {
     return
   }
 
-  $process = Get-Process -Id ([int]$raw) -ErrorAction SilentlyContinue
+  # Validate PID is numeric before casting to avoid terminating error
+  # on malformed PID files (e.g. containing text or whitespace).
+  $ParsedPid = 0
+  if (-not [int]::TryParse($raw, [ref]$ParsedPid)) {
+    Remove-Item -Force $PidFile -ErrorAction SilentlyContinue
+    return
+  }
+
+  $process = Get-Process -Id $ParsedPid -ErrorAction SilentlyContinue
   if ($process) {
     try {
       $name = [IO.Path]::GetFileName($process.Path)

--- a/scripts/uninstall-monk-agent.sh
+++ b/scripts/uninstall-monk-agent.sh
@@ -93,7 +93,18 @@ stop_agent() {
       ''|*[!0-9]*) ;;
       *)
         if kill -0 "$pid" >/dev/null 2>&1; then
-          kill "$pid" >/dev/null 2>&1 || true
+          # Verify the process is actually monk-agent before killing to
+          # avoid terminating an unrelated process that reused the stale PID.
+          proc_name=""
+          if [ -f "/proc/$pid/comm" ]; then
+            proc_name="$(tr -d '\n' < "/proc/$pid/comm" 2>/dev/null || true)"
+          fi
+          if [ -z "$proc_name" ] && command -v ps >/dev/null 2>&1; then
+            proc_name="$(ps -p "$pid" -o comm= 2>/dev/null || true)"
+          fi
+          if [ -z "$proc_name" ] || [ "$proc_name" = "monk-agent" ]; then
+            kill "$pid" >/dev/null 2>&1 || true
+          fi
         fi
         ;;
     esac


### PR DESCRIPTION
This PR fixes 4 issues across all 3 rendered copies of each script (scripts/, plugins/monk/scripts/, .antigravity-plugin/scripts/):

**Issue #39** — POSIX launcher waits 180 retries after companion exits: The health-check loop now breaks early if the background monk-agent process has exited, instead of waiting the full 180 seconds.

**Issue #37** — Python fallback aborts on valid null mcpServers: Replaced setdefault (which returns None on null values) with explicit get + isinstance check.

**Issue #53** — POSIX uninstaller kills unrelated process via stale PID: Added process name verification via /proc/PID/comm (Linux) or ps (macOS) before sending kill.

**Issue #57** — Malformed Windows PID file blocks launcher/uninstaller: Uses [int]::TryParse() before Get-Process, gracefully handling non-numeric PID content.

Fixes #39
Fixes #37
Fixes #53
Fixes #57