### PR TITLE
fix: normalize quoted/escaped commands in block-monk hook fallback

### DIFF
--- a/.antigravity-plugin/hooks/block-monk.sh
+++ b/.antigravity-plugin/hooks/block-monk.sh
@@ -25,7 +25,10 @@ fi
 
 # Fallback: binary unavailable. Grep the raw hook payload for a `monk` command
 # in command position. False positives only ever BLOCK, never allow.
-if printf '%s' "$input" | grep -Eq '(^|["[:space:];&|`(])(sudo[[:space:]]+)?monk([[:space:]"]|$)'; then
+#
+# Strip double and single quotes first so `"monk"`, `'monk'`, and `\"monk\"`
+# (JSON-escaped quotes) are all normalized to bare monk before matching.
+if printf '%s' "$input" | tr -d '"'"'" | grep -Eq '(^|[:[:space:];&|`\\])(sudo[[:space:]]+)?monk([[:space:]]|$)'; then
   cat <<'JSON'
 {
   "decision": "deny",

--- a/hooks/block-monk.sh
+++ b/hooks/block-monk.sh
@@ -24,7 +24,10 @@ fi
 # Matches `monk` only in command position (start, or after a shell separator),
 # optional `sudo`, followed by whitespace/quote/end — so `monkey` is not matched.
 # False positives only ever BLOCK, never allow, which is the safe direction.
-if printf '%s' "$input" | grep -Eq '(^|["[:space:];&|`(])(sudo[[:space:]]+)?monk([[:space:]"]|$)'; then
+#
+# Strip double and single quotes first so `"monk"`, `'monk'`, and `\"monk\"`
+# (JSON-escaped quotes) are all normalized to bare monk before matching.
+if printf '%s' "$input" | tr -d '"'"'" | grep -Eq '(^|[:[:space:];&|`\\])(sudo[[:space:]]+)?monk([[:space:]]|$)'; then
   cat <<'JSON'
 {
   "hookSpecificOutput": {


### PR DESCRIPTION
Fixes #55

The POSIX shell grep fallback failed to match quoted or escaped invocations of the monk CLI (e.g. `"monk"`, `'monk'`, `\monk`) because JSON-encoded payloads escape quotes as backslash-quote sequences that the original character class didn't recognize.

**Fix:** Strip all single/double quotes from the payload before matching, then add colon and backslash to the prefix character class so bare, quoted, and escaped variants are all caught.

Both copies updated: `hooks/block-monk.sh` and `.antigravity-plugin/hooks/block-monk.sh`.