### PR TITLE
fix: add newline and brace to PowerShell block-monk prefix class

### DIFF
--- a/.antigravity-plugin/hooks/block-monk.ps1
+++ b/.antigravity-plugin/hooks/block-monk.ps1
@@ -29,7 +29,7 @@ if (Test-Path $agent) {
 try { $command = ($hookInput | ConvertFrom-Json).toolCall.args.CommandLine } catch { exit 0 }
 if (-not $command) { exit 0 }
 
-if ($command -match '(^|[;&|`(])\s*(sudo\s+)?monk(\s|$)') {
+if ($command -match '(^|[;&|`({\n])\s*(sudo\s+)?monk(\s|$)') {
   @{
     decision = "deny"
     reason   = "Blocked: do not shell out to the ``monk`` CLI - it desyncs the cluster state Monk manages. Use the monk-agent MCP tools instead."

--- a/hooks/block-monk.ps1
+++ b/hooks/block-monk.ps1
@@ -19,7 +19,7 @@ if (Test-Path $agent) {
 try { $command = ($hookInput | ConvertFrom-Json).tool_input.command } catch { exit 0 }
 if (-not $command) { exit 0 }
 
-if ($command -match '(^|[;&|`(])\s*(sudo\s+)?monk(\s|$)') {
+if ($command -match '(^|[;&|`({\n])\s*(sudo\s+)?monk(\s|$)') {
   @{
     hookSpecificOutput = @{
       hookEventName            = "PreToolUse"


### PR DESCRIPTION
## Summary
The PowerShell block-monk regex missed valid command-position invocations after a newline or opening brace block, allowing shell commands to run monk even though the hook is intended to deny shelling out to the Monk CLI.

## Problem
The regex prefix class matched spaces, backslashes, forward slashes, quotes, and hyphens — but NOT newlines or opening braces. A payload like:

```powershell
{
  monk status
}
```

bypasses the hook because monk appears at the start of a line after a newline.

## Fix
Added newline and opening brace to the prefix character class in both:
- hooks/block-monk.ps1
- .antigravity-plugin/hooks/block-monk.ps1

Fixes #34