### PR TITLE
fix: reject zero-byte monk-agent executable in ensure script

### DIFF
--- a/.antigravity-plugin/scripts/ensure-monk-agent.sh
+++ b/.antigravity-plugin/scripts/ensure-monk-agent.sh
@@ -62,7 +62,7 @@ fi
 
 expected="$(awk '{print $1}' "$checksum_tmp")"
 
-if [ -x "$target" ] && [ -f "$checksum_installed" ]; then
+if [ -x "$target" ] && [ -s "$target" ] && [ -f "$checksum_installed" ]; then
   installed="$(awk '{print $1}' "$checksum_installed")"
   if [ "$installed" = "$expected" ]; then
     rm -f "$checksum_tmp"

--- a/plugins/monk/scripts/ensure-monk-agent.sh
+++ b/plugins/monk/scripts/ensure-monk-agent.sh
@@ -62,7 +62,7 @@ fi
 
 expected="$(awk '{print $1}' "$checksum_tmp")"
 
-if [ -x "$target" ] && [ -f "$checksum_installed" ]; then
+if [ -x "$target" ] && [ -s "$target" ] && [ -f "$checksum_installed" ]; then
   installed="$(awk '{print $1}' "$checksum_installed")"
   if [ "$installed" = "$expected" ]; then
     rm -f "$checksum_tmp"

--- a/scripts/ensure-monk-agent.sh
+++ b/scripts/ensure-monk-agent.sh
@@ -62,7 +62,7 @@ fi
 
 expected="$(awk '{print $1}' "$checksum_tmp")"
 
-if [ -x "$target" ] && [ -f "$checksum_installed" ]; then
+if [ -x "$target" ] && [ -s "$target" ] && [ -f "$checksum_installed" ]; then
   installed="$(awk '{print $1}' "$checksum_installed")"
   if [ "$installed" = "$expected" ]; then
     rm -f "$checksum_tmp"


### PR DESCRIPTION
## Summary
The fast path in ensure-monk-agent.sh compared archive checksums but never validated the installed target was non-empty. A truncated zero-byte executable was accepted as current, suppressing automatic recovery.

## Fix
Add `-s "$target"` check to the existing fast path so empty files trigger re-download.

## Files
- `scripts/ensure-monk-agent.sh`
- `plugins/monk/scripts/ensure-monk-agent.sh`
- `.antigravity-plugin/scripts/ensure-monk-agent.sh`

Fixes #23