### PR TITLE
fix: normalize quoted/escaped commands in block-monk hook fallback

### DIFF
--- a/.antigravity-plugin/hooks/block-monk.sh
+++ b/.antigravity-plugin/hooks/block-monk.sh
@@ -25,7 +25,10 @@ fi
 
 # Fallback: binary unavailable. Grep the raw hook payload for a `monk` command
 # in command position. False positives only ever BLOCK, never allow.
-if printf '%s' "$input" | grep -Eq '(^|["[:space:];&|`(])(sudo[[:space:]]+)?monk([[:space:]"]|$)'; then
+#
+# Strip double and single quotes first so `"monk"`, `'monk'`, and `\"monk\"`
+# (JSON-escaped quotes) are all normalized to bare monk before matching.
+if printf '%s' "$input" | tr -d '"'"'" | grep -Eq '(^|[:[:space:];&|`\\])(sudo[[:space:]]+)?monk([[:space:]]|$)'; then
   cat <<'JSON'
 {
   "decision": "deny",

--- a/hooks/block-monk.sh
+++ b/hooks/block-monk.sh
@@ -24,7 +24,10 @@ fi
 # Matches `monk` only in command position (start, or after a shell separator),
 # optional `sudo`, followed by whitespace/quote/end — so `monkey` is not matched.
 # False positives only ever BLOCK, never allow, which is the safe direction.
-if printf '%s' "$input" | grep -Eq '(^|["[:space:];&|`(])(sudo[[:space:]]+)?monk([[:space:]"]|$)'; then
+#
+# Strip double and single quotes first so `"monk"`, `'monk'`, and `\"monk\"`
+# (JSON-escaped quotes) are all normalized to bare monk before matching.
+if printf '%s' "$input" | tr -d '"'"'" | grep -Eq '(^|[:[:space:];&|`\\])(sudo[[:space:]]+)?monk([[:space:]]|$)'; then
   cat <<'JSON'
 {
   "hookSpecificOutput": {


### PR DESCRIPTION
## Summary
The block-monk hook regex only matched raw command names but failed when commands were quoted or escaped by the shell. This let forbidden commands bypass the blocklist.

## Fix
- Strip all quotes from payload before matching (`tr -d "'\"'`)
- Add colon and backslash to the prefix character class
- Apply identical fix to both hooks/block-monk.sh and .antigravity-plugin/hooks/block-monk.sh

Fixes #55