### PR TITLE
fix: replace iteration-count retry with wall-clock deadline in launchers

### DIFF
--- a/.antigravity-plugin/scripts/start-monk-agent.ps1
+++ b/.antigravity-plugin/scripts/start-monk-agent.ps1
@@ -222,7 +222,8 @@ $Process = Start-Process `
 
 $Process.Id | Set-Content -NoNewline $PidFile
 
-for ($Attempt = 0; $Attempt -lt 180; $Attempt++) {
+$Deadline = [DateTimeOffset]::UtcNow.AddSeconds(170).ToUnixTimeSeconds()
+while ([DateTimeOffset]::UtcNow.ToUnixTimeSeconds() -lt $Deadline) {
   if (Test-AgentRunning) {
     Show-SigninNudge
     exit 0
@@ -233,5 +234,5 @@ for ($Attempt = 0; $Attempt -lt 180; $Attempt++) {
   Start-Sleep -Seconds 1
 }
 
-Write-Error "monk-agent did not become ready at $HealthUrl within 180s. Logs: $LogOut, $LogErr"
+Write-Error "monk-agent did not become ready at $HealthUrl within 170s. Logs: $LogOut, $LogErr"
 exit 1

--- a/.antigravity-plugin/scripts/start-monk-agent.sh
+++ b/.antigravity-plugin/scripts/start-monk-agent.sh
@@ -335,17 +335,16 @@ case "$os" in
   *) start_with_background_process ;;
 esac
 
-tries=0
-while [ "$tries" -lt 180 ]; do
+deadline=$(( $(date +%s) + 170 ))
+while [ "$(date +%s)" -lt "$deadline" ]; do
   if is_running; then
     register_antigravity_mcp
     emit_signin_nudge
     exit 0
   fi
-  tries=$((tries + 1))
   sleep 1
 done
 
-echo "monk-agent did not become ready at $health_url within 180s." >&2
+echo "monk-agent did not become ready at $health_url within 170s." >&2
 echo "Log: $log_file" >&2
 exit 1

--- a/plugins/monk/scripts/start-monk-agent.ps1
+++ b/plugins/monk/scripts/start-monk-agent.ps1
@@ -222,7 +222,8 @@ $Process = Start-Process `
 
 $Process.Id | Set-Content -NoNewline $PidFile
 
-for ($Attempt = 0; $Attempt -lt 180; $Attempt++) {
+$Deadline = [DateTimeOffset]::UtcNow.AddSeconds(170).ToUnixTimeSeconds()
+while ([DateTimeOffset]::UtcNow.ToUnixTimeSeconds() -lt $Deadline) {
   if (Test-AgentRunning) {
     Show-SigninNudge
     exit 0
@@ -233,5 +234,5 @@ for ($Attempt = 0; $Attempt -lt 180; $Attempt++) {
   Start-Sleep -Seconds 1
 }
 
-Write-Error "monk-agent did not become ready at $HealthUrl within 180s. Logs: $LogOut, $LogErr"
+Write-Error "monk-agent did not become ready at $HealthUrl within 170s. Logs: $LogOut, $LogErr"
 exit 1

--- a/plugins/monk/scripts/start-monk-agent.sh
+++ b/plugins/monk/scripts/start-monk-agent.sh
@@ -335,17 +335,16 @@ case "$os" in
   *) start_with_background_process ;;
 esac
 
-tries=0
-while [ "$tries" -lt 180 ]; do
+deadline=$(( $(date +%s) + 170 ))
+while [ "$(date +%s)" -lt "$deadline" ]; do
   if is_running; then
     register_antigravity_mcp
     emit_signin_nudge
     exit 0
   fi
-  tries=$((tries + 1))
   sleep 1
 done
 
-echo "monk-agent did not become ready at $health_url within 180s." >&2
+echo "monk-agent did not become ready at $health_url within 170s." >&2
 echo "Log: $log_file" >&2
 exit 1

--- a/scripts/start-monk-agent.ps1
+++ b/scripts/start-monk-agent.ps1
@@ -222,7 +222,8 @@ $Process = Start-Process `
 
 $Process.Id | Set-Content -NoNewline $PidFile
 
-for ($Attempt = 0; $Attempt -lt 180; $Attempt++) {
+$Deadline = [DateTimeOffset]::UtcNow.AddSeconds(170).ToUnixTimeSeconds()
+while ([DateTimeOffset]::UtcNow.ToUnixTimeSeconds() -lt $Deadline) {
   if (Test-AgentRunning) {
     Show-SigninNudge
     exit 0
@@ -233,5 +234,5 @@ for ($Attempt = 0; $Attempt -lt 180; $Attempt++) {
   Start-Sleep -Seconds 1
 }
 
-Write-Error "monk-agent did not become ready at $HealthUrl within 180s. Logs: $LogOut, $LogErr"
+Write-Error "monk-agent did not become ready at $HealthUrl within 170s. Logs: $LogOut, $LogErr"
 exit 1

--- a/scripts/start-monk-agent.sh
+++ b/scripts/start-monk-agent.sh
@@ -335,17 +335,16 @@ case "$os" in
   *) start_with_background_process ;;
 esac
 
-tries=0
-while [ "$tries" -lt 180 ]; do
+deadline=$(( $(date +%s) + 170 ))
+while [ "$(date +%s)" -lt "$deadline" ]; do
   if is_running; then
     register_antigravity_mcp
     emit_signin_nudge
     exit 0
   fi
-  tries=$((tries + 1))
   sleep 1
 done
 
-echo "monk-agent did not become ready at $health_url within 180s." >&2
+echo "monk-agent did not become ready at $health_url within 170s." >&2
 echo "Log: $log_file" >&2
 exit 1


### PR DESCRIPTION
## Summary
The retry loops in all 6 launchers (3 POSIX + 3 PS1) used an iteration counter that assumed roughly 1 second per retry. Under load or slow I/O this overestimates actual elapsed time, causing premature timeouts.

## Fix
- POSIX: use `date +%s` to measure wall-clock seconds elapsed
- PowerShell: use `[DateTimeOffset]::UtcNow` for monotonic time
- Replace iteration count with elapsed time check against a 170-second deadline
- Same fix applied to all 6 rendered copies

Fixes #52