### PR TITLE
fix: add newline and brace to PowerShell block-monk prefix class

### DIFF
--- a/.antigravity-plugin/hooks/block-monk.ps1
+++ b/.antigravity-plugin/hooks/block-monk.ps1
@@ -29,7 +29,7 @@ if (Test-Path $agent) {
 try { $command = ($hookInput | ConvertFrom-Json).toolCall.args.CommandLine } catch { exit 0 }
 if (-not $command) { exit 0 }
 
-if ($command -match '(^|[;&|`(])\s*(sudo\s+)?monk(\s|$)') {
+if ($command -match '(^|[;&|`({\n])\s*(sudo\s+)?monk(\s|$)') {
   @{
     decision = "deny"
     reason   = "Blocked: do not shell out to the ``monk`` CLI - it desyncs the cluster state Monk manages. Use the monk-agent MCP tools instead."

--- a/hooks/block-monk.ps1
+++ b/hooks/block-monk.ps1
@@ -19,7 +19,7 @@ if (Test-Path $agent) {
 try { $command = ($hookInput | ConvertFrom-Json).tool_input.command } catch { exit 0 }
 if (-not $command) { exit 0 }
 
-if ($command -match '(^|[;&|`(])\s*(sudo\s+)?monk(\s|$)') {
+if ($command -match '(^|[;&|`({\n])\s*(sudo\s+)?monk(\s|$)') {
   @{
     hookSpecificOutput = @{
       hookEventName            = "PreToolUse"


### PR DESCRIPTION
## Summary
The PowerShell block-monk hook regex used the same prefix character class as the POSIX version, but PowerShell treats the pattern differently. Commands like `npx` were not being captured.

## Fix
- Add a newline + opening brace to the regex prefix class in both hooks/block-monk.ps1 and .antigravity-plugin/hooks/block-monk.ps1

Fixes #34