### PR TITLE
fix: reuse installed agent when update check fails

### DIFF
--- a/.antigravity-plugin/scripts/ensure-monk-agent.ps1
+++ b/.antigravity-plugin/scripts/ensure-monk-agent.ps1
@@ -111,7 +111,31 @@ $ChecksumTmp = Join-Path $InstallDir ".monk-agent.tmp.sha256"
 $ExtractDir = Join-Path $InstallDir ".monk-agent.extract"
 New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
 
-Invoke-WebRequest -Uri $ChecksumUrl -OutFile $ChecksumTmp
+try {
+  Invoke-WebRequest -Uri $ChecksumUrl -OutFile $ChecksumTmp
+} catch {
+  $Installed = ""
+  if ((Test-Path $Target) -and (Test-Path $ChecksumInstalled)) {
+    try {
+      $Installed = ((Get-Content -Raw $ChecksumInstalled).Trim() -split "\s+")[0].ToLowerInvariant()
+    } catch {
+      $Installed = ""
+    }
+  }
+
+  $TargetSize = if (Test-Path $Target) { (Get-Item $Target).Length } else { 0 }
+  $ActualInstalled = if ($TargetSize -gt 0) { Get-FileSha256 $Target } else { "" }
+  if ($TargetSize -gt 0 -and
+      $Installed -match "^[0-9a-f]{64}$" -and
+      $ActualInstalled -eq $Installed) {
+    Remove-Item -Force $ChecksumTmp -ErrorAction SilentlyContinue
+    Write-Warning "Unable to check for monk-agent updates; using the previously checksummed installation at $Target."
+    Write-Output $Target
+    exit 0
+  }
+
+  throw
+}
 
 $Expected = ((Get-Content -Raw $ChecksumTmp).Trim() -split "\s+")[0].ToLowerInvariant()
 

--- a/.antigravity-plugin/scripts/ensure-monk-agent.sh
+++ b/.antigravity-plugin/scripts/ensure-monk-agent.sh
@@ -73,13 +73,41 @@ if [ "$auto_update" = "0" ] || [ "$auto_update" = "false" ]; then
   fi
 fi
 
-if command -v curl >/dev/null 2>&1; then
-  curl -fL "$checksum_url" -o "$checksum_tmp"
-elif command -v wget >/dev/null 2>&1; then
-  wget -O "$checksum_tmp" "$checksum_url"
-else
-  echo "curl or wget is required to install monk-agent." >&2
-  exit 2
+download_checksum() {
+  if command -v curl >/dev/null 2>&1; then
+    curl -fL "$checksum_url" -o "$checksum_tmp"
+  elif command -v wget >/dev/null 2>&1; then
+    wget -O "$checksum_tmp" "$checksum_url"
+  else
+    echo "curl or wget is required to check for monk-agent updates." >&2
+    return 2
+  fi
+}
+
+if ! download_checksum; then
+  if [ -x "$target" ] && [ -s "$target" ] && [ -f "$checksum_installed" ]; then
+    installed="$(awk '{print $1}' "$checksum_installed")"
+    actual_installed=""
+    if command -v shasum >/dev/null 2>&1; then
+      actual_installed="$(shasum -a 256 "$target" | awk '{print $1}')"
+    elif command -v sha256sum >/dev/null 2>&1; then
+      actual_installed="$(sha256sum "$target" | awk '{print $1}')"
+    fi
+    case "$installed" in
+      *[!0-9a-fA-F]*|'') ;;
+      *)
+        if [ "${#installed}" -eq 64 ] &&
+           [ "$(printf '%s' "$installed" | tr 'A-F' 'a-f')" = "$(printf '%s' "$actual_installed" | tr 'A-F' 'a-f')" ]; then
+          rm -f "$checksum_tmp"
+          echo "Warning: unable to check for monk-agent updates; using the previously checksummed installation at $target." >&2
+          printf '%s\n' "$target"
+          exit 0
+        fi
+        ;;
+    esac
+  fi
+  echo "Unable to check for monk-agent updates and no verified local installation is available." >&2
+  exit 1
 fi
 
 expected="$(awk '{print $1}' "$checksum_tmp")"

--- a/.github/workflows/install-e2e.yml
+++ b/.github/workflows/install-e2e.yml
@@ -38,6 +38,26 @@ jobs:
           test "$installed" = "$MONK_AGENT_INSTALL_DIR/monk-agent"
           test -x "$installed"
 
+      - name: Reuse installed agent when update endpoint is unavailable
+        shell: bash
+        env:
+          MONK_AGENT_INSTALL_DIR: ${{ runner.temp }}/monk-bin
+          MONK_AGENT_DOWNLOAD_BASE: http://127.0.0.1:1
+        run: |
+          set -euo pipefail
+          installed="$(./scripts/ensure-monk-agent.sh)"
+          test "$installed" = "$MONK_AGENT_INSTALL_DIR/monk-agent"
+
+          corrupt="$RUNNER_TEMP/monk-corrupt-bin"
+          mkdir -p "$corrupt"
+          cp "$MONK_AGENT_INSTALL_DIR/monk-agent" "$corrupt/monk-agent"
+          cp "$MONK_AGENT_INSTALL_DIR/monk-agent.sha256" "$corrupt/monk-agent.sha256"
+          printf '\ncorrupt' >> "$corrupt/monk-agent"
+          if MONK_AGENT_INSTALL_DIR="$corrupt" ./scripts/ensure-monk-agent.sh >/dev/null 2>&1; then
+            echo "offline fallback accepted a binary that does not match its stored checksum" >&2
+            exit 1
+          fi
+
       - name: Run monk-agent status
         shell: bash
         env:
@@ -90,6 +110,36 @@ jobs:
           }
           if (-not (Test-Path $installed)) {
             throw "monk-agent.exe was not installed"
+          }
+
+      - name: Reuse installed agent when update endpoint is unavailable
+        shell: pwsh
+        env:
+          MONK_AGENT_INSTALL_DIR: ${{ runner.temp }}\monk-bin
+          MONK_AGENT_DOWNLOAD_BASE: http://127.0.0.1:1
+        run: |
+          $installed = .\scripts\ensure-monk-agent.ps1
+          if ($installed -ne "$env:MONK_AGENT_INSTALL_DIR\monk-agent.exe") {
+            throw "unexpected offline fallback path: $installed"
+          }
+
+          $corrupt = "$env:RUNNER_TEMP\monk-corrupt-bin"
+          New-Item -ItemType Directory -Force -Path $corrupt | Out-Null
+          Copy-Item "$env:MONK_AGENT_INSTALL_DIR\monk-agent.exe" "$corrupt\monk-agent.exe"
+          Copy-Item "$env:MONK_AGENT_INSTALL_DIR\monk-agent.sha256" "$corrupt\monk-agent.sha256"
+          [IO.File]::AppendAllText("$corrupt\monk-agent.exe", "corrupt")
+          $originalInstallDir = $env:MONK_AGENT_INSTALL_DIR
+          $rejected = $false
+          try {
+            $env:MONK_AGENT_INSTALL_DIR = $corrupt
+            .\scripts\ensure-monk-agent.ps1 | Out-Null
+          } catch {
+            $rejected = $true
+          } finally {
+            $env:MONK_AGENT_INSTALL_DIR = $originalInstallDir
+          }
+          if (-not $rejected) {
+            throw "offline fallback accepted a binary that does not match its stored checksum"
           }
 
       - name: Run monk-agent status

--- a/plugins/monk/scripts/ensure-monk-agent.ps1
+++ b/plugins/monk/scripts/ensure-monk-agent.ps1
@@ -111,7 +111,31 @@ $ChecksumTmp = Join-Path $InstallDir ".monk-agent.tmp.sha256"
 $ExtractDir = Join-Path $InstallDir ".monk-agent.extract"
 New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
 
-Invoke-WebRequest -Uri $ChecksumUrl -OutFile $ChecksumTmp
+try {
+  Invoke-WebRequest -Uri $ChecksumUrl -OutFile $ChecksumTmp
+} catch {
+  $Installed = ""
+  if ((Test-Path $Target) -and (Test-Path $ChecksumInstalled)) {
+    try {
+      $Installed = ((Get-Content -Raw $ChecksumInstalled).Trim() -split "\s+")[0].ToLowerInvariant()
+    } catch {
+      $Installed = ""
+    }
+  }
+
+  $TargetSize = if (Test-Path $Target) { (Get-Item $Target).Length } else { 0 }
+  $ActualInstalled = if ($TargetSize -gt 0) { Get-FileSha256 $Target } else { "" }
+  if ($TargetSize -gt 0 -and
+      $Installed -match "^[0-9a-f]{64}$" -and
+      $ActualInstalled -eq $Installed) {
+    Remove-Item -Force $ChecksumTmp -ErrorAction SilentlyContinue
+    Write-Warning "Unable to check for monk-agent updates; using the previously checksummed installation at $Target."
+    Write-Output $Target
+    exit 0
+  }
+
+  throw
+}
 
 $Expected = ((Get-Content -Raw $ChecksumTmp).Trim() -split "\s+")[0].ToLowerInvariant()
 

--- a/plugins/monk/scripts/ensure-monk-agent.sh
+++ b/plugins/monk/scripts/ensure-monk-agent.sh
@@ -73,13 +73,41 @@ if [ "$auto_update" = "0" ] || [ "$auto_update" = "false" ]; then
   fi
 fi
 
-if command -v curl >/dev/null 2>&1; then
-  curl -fL "$checksum_url" -o "$checksum_tmp"
-elif command -v wget >/dev/null 2>&1; then
-  wget -O "$checksum_tmp" "$checksum_url"
-else
-  echo "curl or wget is required to install monk-agent." >&2
-  exit 2
+download_checksum() {
+  if command -v curl >/dev/null 2>&1; then
+    curl -fL "$checksum_url" -o "$checksum_tmp"
+  elif command -v wget >/dev/null 2>&1; then
+    wget -O "$checksum_tmp" "$checksum_url"
+  else
+    echo "curl or wget is required to check for monk-agent updates." >&2
+    return 2
+  fi
+}
+
+if ! download_checksum; then
+  if [ -x "$target" ] && [ -s "$target" ] && [ -f "$checksum_installed" ]; then
+    installed="$(awk '{print $1}' "$checksum_installed")"
+    actual_installed=""
+    if command -v shasum >/dev/null 2>&1; then
+      actual_installed="$(shasum -a 256 "$target" | awk '{print $1}')"
+    elif command -v sha256sum >/dev/null 2>&1; then
+      actual_installed="$(sha256sum "$target" | awk '{print $1}')"
+    fi
+    case "$installed" in
+      *[!0-9a-fA-F]*|'') ;;
+      *)
+        if [ "${#installed}" -eq 64 ] &&
+           [ "$(printf '%s' "$installed" | tr 'A-F' 'a-f')" = "$(printf '%s' "$actual_installed" | tr 'A-F' 'a-f')" ]; then
+          rm -f "$checksum_tmp"
+          echo "Warning: unable to check for monk-agent updates; using the previously checksummed installation at $target." >&2
+          printf '%s\n' "$target"
+          exit 0
+        fi
+        ;;
+    esac
+  fi
+  echo "Unable to check for monk-agent updates and no verified local installation is available." >&2
+  exit 1
 fi
 
 expected="$(awk '{print $1}' "$checksum_tmp")"

--- a/scripts/ensure-monk-agent.ps1
+++ b/scripts/ensure-monk-agent.ps1
@@ -111,7 +111,31 @@ $ChecksumTmp = Join-Path $InstallDir ".monk-agent.tmp.sha256"
 $ExtractDir = Join-Path $InstallDir ".monk-agent.extract"
 New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
 
-Invoke-WebRequest -Uri $ChecksumUrl -OutFile $ChecksumTmp
+try {
+  Invoke-WebRequest -Uri $ChecksumUrl -OutFile $ChecksumTmp
+} catch {
+  $Installed = ""
+  if ((Test-Path $Target) -and (Test-Path $ChecksumInstalled)) {
+    try {
+      $Installed = ((Get-Content -Raw $ChecksumInstalled).Trim() -split "\s+")[0].ToLowerInvariant()
+    } catch {
+      $Installed = ""
+    }
+  }
+
+  $TargetSize = if (Test-Path $Target) { (Get-Item $Target).Length } else { 0 }
+  $ActualInstalled = if ($TargetSize -gt 0) { Get-FileSha256 $Target } else { "" }
+  if ($TargetSize -gt 0 -and
+      $Installed -match "^[0-9a-f]{64}$" -and
+      $ActualInstalled -eq $Installed) {
+    Remove-Item -Force $ChecksumTmp -ErrorAction SilentlyContinue
+    Write-Warning "Unable to check for monk-agent updates; using the previously checksummed installation at $Target."
+    Write-Output $Target
+    exit 0
+  }
+
+  throw
+}
 
 $Expected = ((Get-Content -Raw $ChecksumTmp).Trim() -split "\s+")[0].ToLowerInvariant()
 

--- a/scripts/ensure-monk-agent.sh
+++ b/scripts/ensure-monk-agent.sh
@@ -73,13 +73,41 @@ if [ "$auto_update" = "0" ] || [ "$auto_update" = "false" ]; then
   fi
 fi
 
-if command -v curl >/dev/null 2>&1; then
-  curl -fL "$checksum_url" -o "$checksum_tmp"
-elif command -v wget >/dev/null 2>&1; then
-  wget -O "$checksum_tmp" "$checksum_url"
-else
-  echo "curl or wget is required to install monk-agent." >&2
-  exit 2
+download_checksum() {
+  if command -v curl >/dev/null 2>&1; then
+    curl -fL "$checksum_url" -o "$checksum_tmp"
+  elif command -v wget >/dev/null 2>&1; then
+    wget -O "$checksum_tmp" "$checksum_url"
+  else
+    echo "curl or wget is required to check for monk-agent updates." >&2
+    return 2
+  fi
+}
+
+if ! download_checksum; then
+  if [ -x "$target" ] && [ -s "$target" ] && [ -f "$checksum_installed" ]; then
+    installed="$(awk '{print $1}' "$checksum_installed")"
+    actual_installed=""
+    if command -v shasum >/dev/null 2>&1; then
+      actual_installed="$(shasum -a 256 "$target" | awk '{print $1}')"
+    elif command -v sha256sum >/dev/null 2>&1; then
+      actual_installed="$(sha256sum "$target" | awk '{print $1}')"
+    fi
+    case "$installed" in
+      *[!0-9a-fA-F]*|'') ;;
+      *)
+        if [ "${#installed}" -eq 64 ] &&
+           [ "$(printf '%s' "$installed" | tr 'A-F' 'a-f')" = "$(printf '%s' "$actual_installed" | tr 'A-F' 'a-f')" ]; then
+          rm -f "$checksum_tmp"
+          echo "Warning: unable to check for monk-agent updates; using the previously checksummed installation at $target." >&2
+          printf '%s\n' "$target"
+          exit 0
+        fi
+        ;;
+    esac
+  fi
+  echo "Unable to check for monk-agent updates and no verified local installation is available." >&2
+  exit 1
 fi
 
 expected="$(awk '{print $1}' "$checksum_tmp")"


### PR DESCRIPTION
## Summary

- fall back to a non-empty, previously checksummed local `monk-agent` when update discovery is temporarily unavailable
- keep first installs fail-closed when no valid local installation exists
- apply the behavior consistently to the root, packaged, and Antigravity PowerShell/POSIX scripts
- exercise the offline fallback on Windows, macOS, and Linux in the existing install E2E workflow

## Why

The ensure scripts currently fetch the remote archive checksum before consulting the installed binary and checksum sidecar. A cold start therefore aborts during any transient DNS, TLS, captive-portal, network, or `get.monk.io` failure, even after a successful prior installation.

The fallback only applies when the target is non-empty and the existing sidecar contains a valid 64-character SHA-256 value. An unavailable update endpoint still causes a hard failure when no previously checksummed local installation exists.

## Validation

- reproduced the original Windows failure with an installed v0.1.45 agent and an unreachable update endpoint
- verified the updated PowerShell bootstrap returns the installed agent with the endpoint unavailable
- verified an empty install directory still exits non-zero under the same outage
- verified the normal online checksum/update path still returns the installed agent
- verified all three distributed PowerShell copies and all three POSIX copies are byte-identical
- parsed `.github/workflows/install-e2e.yml` and ran `git diff --check`

Fixes #90
