### PR TITLE
fix: verify agent identity before signaling PID

### DIFF
--- a/.github/workflows/install-e2e.yml
+++ b/.github/workflows/install-e2e.yml
@@ -38,6 +38,64 @@ jobs:
           test "$installed" = "$MONK_AGENT_INSTALL_DIR/monk-agent"
           test -x "$installed"
 
+      - name: Preserve unrelated processes referenced by stale PID files
+        if: runner.os == 'Linux'
+        shell: bash
+        env:
+          MONK_AGENT_INSTALL_DIR: ${{ runner.temp }}/monk-bin
+          MONK_AGENT_HOME: ${{ runner.temp }}/monk-stale-start-home
+          MONK_AGENT_PORT: "17419"
+          MONK_AGENT_DEV: "1"
+          MONK_AGENT_SIMULATE_AUTH: "1"
+          MONK_AGENT_MOCK_RUNTIME: "1"
+          MONK_AGENT_VAULT_BACKEND: file
+          MONK_AGENT_STORE: file
+          MONK_AGENT_OPEN_BROWSER: "0"
+          MONK_AGENT_SKIP_ENSURE: "1"
+          MONK_AGENT_SKIP_SIGNIN_NUDGE: "1"
+          MONK_TELEMETRY: "0"
+        run: |
+          set -euo pipefail
+
+          run_dir="$MONK_AGENT_HOME/agent/launcher/run"
+          pid_file="$run_dir/monk-agent.pid"
+          mkdir -p "$run_dir"
+
+          sleep 300 &
+          victim_pid="$!"
+          printf '%s\n' "$victim_pid" >"$pid_file"
+
+          cleanup() {
+            if [ -f "$pid_file" ]; then
+              agent_pid="$(cat "$pid_file" 2>/dev/null || true)"
+              case "$agent_pid" in
+                ''|*[!0-9]*) ;;
+                *) kill "$agent_pid" >/dev/null 2>&1 || true ;;
+              esac
+            fi
+            kill "$victim_pid" >/dev/null 2>&1 || true
+          }
+          trap cleanup EXIT
+
+          ./scripts/start-monk-agent.sh
+          kill -0 "$victim_pid"
+          test "$(cat "$pid_file")" != "$victim_pid"
+
+          uninstall_dir="$RUNNER_TEMP/monk-stale-uninstall-bin"
+          uninstall_home="$RUNNER_TEMP/monk-stale-uninstall-home"
+          mkdir -p "$uninstall_dir" "$uninstall_home/agent/launcher/run"
+          cp "$MONK_AGENT_INSTALL_DIR/monk-agent" "$uninstall_dir/monk-agent"
+
+          sleep 300 &
+          uninstall_victim_pid="$!"
+          printf '%s\n' "$uninstall_victim_pid" >"$uninstall_home/agent/launcher/run/monk-agent.pid"
+          MONK_AGENT_INSTALL_DIR="$uninstall_dir" MONK_AGENT_HOME="$uninstall_home" \
+            ./scripts/uninstall-monk-agent.sh --yes --keep-data
+          kill -0 "$uninstall_victim_pid"
+          kill "$uninstall_victim_pid"
+          wait "$uninstall_victim_pid" 2>/dev/null || true
+          test ! -e "$uninstall_dir/monk-agent"
+
       - name: Run monk-agent status
         shell: bash
         env:

--- a/plugins/monk/scripts/start-monk-agent.sh
+++ b/plugins/monk/scripts/start-monk-agent.sh
@@ -305,10 +305,35 @@ EOF
   launchctl kickstart -k "gui/$uid/$launchd_label" >/dev/null 2>&1 || true
 }
 
+is_managed_agent_pid() {
+  candidate_pid="$1"
+  case "$candidate_pid" in
+    ''|*[!0-9]*) return 1 ;;
+  esac
+
+  # PID files can outlive the process that created them. On Linux, verify the
+  # executable behind a reused PID before sending a signal; if identity cannot
+  # be proven, leave the process alone and let the new agent handle any bind
+  # conflict itself.
+  [ -L "/proc/$candidate_pid/exe" ] || return 1
+  running_exe="$(readlink "/proc/$candidate_pid/exe" 2>/dev/null || true)"
+  case "$running_exe" in
+    *' (deleted)') running_exe="${running_exe% (deleted)}" ;;
+  esac
+
+  expected_exe="$(readlink -f "$agent_path" 2>/dev/null || true)"
+  if [ -z "$expected_exe" ]; then
+    expected_dir="$(CDPATH= cd -- "$(dirname -- "$agent_path")" 2>/dev/null && pwd -P)" || return 1
+    expected_exe="$expected_dir/$(basename -- "$agent_path")"
+  fi
+
+  [ -n "$running_exe" ] && [ "$running_exe" = "$expected_exe" ]
+}
+
 start_with_background_process() {
   if [ -f "$pid_file" ]; then
     old_pid="$(cat "$pid_file" 2>/dev/null || true)"
-    if [ -n "$old_pid" ]; then
+    if is_managed_agent_pid "$old_pid"; then
       kill "$old_pid" >/dev/null 2>&1 || true
     fi
   fi

--- a/plugins/monk/scripts/uninstall-monk-agent.sh
+++ b/plugins/monk/scripts/uninstall-monk-agent.sh
@@ -79,6 +79,29 @@ if [ "$assume_yes" != "1" ]; then
   esac
 fi
 
+is_managed_agent_pid() {
+  candidate_pid="$1"
+  case "$candidate_pid" in
+    ''|*[!0-9]*) return 1 ;;
+  esac
+
+  # A stale PID can be reused by an unrelated process. Only signal the process
+  # when Linux can prove that it is the installed monk-agent executable.
+  [ -L "/proc/$candidate_pid/exe" ] || return 1
+  running_exe="$(readlink "/proc/$candidate_pid/exe" 2>/dev/null || true)"
+  case "$running_exe" in
+    *' (deleted)') running_exe="${running_exe% (deleted)}" ;;
+  esac
+
+  expected_exe="$(readlink -f "$target" 2>/dev/null || true)"
+  if [ -z "$expected_exe" ]; then
+    expected_dir="$(CDPATH= cd -- "$(dirname -- "$target")" 2>/dev/null && pwd -P)" || return 1
+    expected_exe="$expected_dir/$(basename -- "$target")"
+  fi
+
+  [ -n "$running_exe" ] && [ "$running_exe" = "$expected_exe" ]
+}
+
 stop_agent() {
   os="$(uname -s 2>/dev/null || printf unknown)"
   if [ "$os" = "Darwin" ] && command -v launchctl >/dev/null 2>&1; then
@@ -89,14 +112,9 @@ stop_agent() {
 
   if [ -f "$pid_file" ]; then
     pid="$(cat "$pid_file" 2>/dev/null || true)"
-    case "$pid" in
-      ''|*[!0-9]*) ;;
-      *)
-        if kill -0 "$pid" >/dev/null 2>&1; then
-          kill "$pid" >/dev/null 2>&1 || true
-        fi
-        ;;
-    esac
+    if is_managed_agent_pid "$pid"; then
+      kill "$pid" >/dev/null 2>&1 || true
+    fi
     rm -f "$pid_file"
   fi
 }

--- a/scripts/start-monk-agent.sh
+++ b/scripts/start-monk-agent.sh
@@ -305,10 +305,35 @@ EOF
   launchctl kickstart -k "gui/$uid/$launchd_label" >/dev/null 2>&1 || true
 }
 
+is_managed_agent_pid() {
+  candidate_pid="$1"
+  case "$candidate_pid" in
+    ''|*[!0-9]*) return 1 ;;
+  esac
+
+  # PID files can outlive the process that created them. On Linux, verify the
+  # executable behind a reused PID before sending a signal; if identity cannot
+  # be proven, leave the process alone and let the new agent handle any bind
+  # conflict itself.
+  [ -L "/proc/$candidate_pid/exe" ] || return 1
+  running_exe="$(readlink "/proc/$candidate_pid/exe" 2>/dev/null || true)"
+  case "$running_exe" in
+    *' (deleted)') running_exe="${running_exe% (deleted)}" ;;
+  esac
+
+  expected_exe="$(readlink -f "$agent_path" 2>/dev/null || true)"
+  if [ -z "$expected_exe" ]; then
+    expected_dir="$(CDPATH= cd -- "$(dirname -- "$agent_path")" 2>/dev/null && pwd -P)" || return 1
+    expected_exe="$expected_dir/$(basename -- "$agent_path")"
+  fi
+
+  [ -n "$running_exe" ] && [ "$running_exe" = "$expected_exe" ]
+}
+
 start_with_background_process() {
   if [ -f "$pid_file" ]; then
     old_pid="$(cat "$pid_file" 2>/dev/null || true)"
-    if [ -n "$old_pid" ]; then
+    if is_managed_agent_pid "$old_pid"; then
       kill "$old_pid" >/dev/null 2>&1 || true
     fi
   fi

--- a/scripts/uninstall-monk-agent.sh
+++ b/scripts/uninstall-monk-agent.sh
@@ -79,6 +79,29 @@ if [ "$assume_yes" != "1" ]; then
   esac
 fi
 
+is_managed_agent_pid() {
+  candidate_pid="$1"
+  case "$candidate_pid" in
+    ''|*[!0-9]*) return 1 ;;
+  esac
+
+  # A stale PID can be reused by an unrelated process. Only signal the process
+  # when Linux can prove that it is the installed monk-agent executable.
+  [ -L "/proc/$candidate_pid/exe" ] || return 1
+  running_exe="$(readlink "/proc/$candidate_pid/exe" 2>/dev/null || true)"
+  case "$running_exe" in
+    *' (deleted)') running_exe="${running_exe% (deleted)}" ;;
+  esac
+
+  expected_exe="$(readlink -f "$target" 2>/dev/null || true)"
+  if [ -z "$expected_exe" ]; then
+    expected_dir="$(CDPATH= cd -- "$(dirname -- "$target")" 2>/dev/null && pwd -P)" || return 1
+    expected_exe="$expected_dir/$(basename -- "$target")"
+  fi
+
+  [ -n "$running_exe" ] && [ "$running_exe" = "$expected_exe" ]
+}
+
 stop_agent() {
   os="$(uname -s 2>/dev/null || printf unknown)"
   if [ "$os" = "Darwin" ] && command -v launchctl >/dev/null 2>&1; then
@@ -89,14 +112,9 @@ stop_agent() {
 
   if [ -f "$pid_file" ]; then
     pid="$(cat "$pid_file" 2>/dev/null || true)"
-    case "$pid" in
-      ''|*[!0-9]*) ;;
-      *)
-        if kill -0 "$pid" >/dev/null 2>&1; then
-          kill "$pid" >/dev/null 2>&1 || true
-        fi
-        ;;
-    esac
+    if is_managed_agent_pid "$pid"; then
+      kill "$pid" >/dev/null 2>&1 || true
+    fi
     rm -f "$pid_file"
   fi
 }


### PR DESCRIPTION
## Summary

- verify that a persisted POSIX PID still resolves to the installed `monk-agent` executable before signaling it
- apply the guard consistently to automatic Linux startup and the POSIX uninstaller
- preserve the existing handling of an agent executable that was replaced in place while still running
- add an Ubuntu regression that places unrelated `sleep` PIDs in the launcher and uninstaller PID files and asserts that both processes survive

## Why

The launcher and uninstaller previously treated any numeric value in the persistent PID file as a managed agent process. If the agent exited without removing the file and the OS later reused that PID, the next coding-agent session or plugin uninstall sent `SIGTERM` to an unrelated process.

The new check resolves `/proc/<pid>/exe` and compares it with the canonical installed agent path. Malformed PIDs, missing process metadata, and non-matching executables fail closed without sending a signal. The launcher then relies on the agent's normal port-conflict handling, while the uninstaller removes the stale record.

## Impact

Starting a coding-agent session or uninstalling the plugin can no longer terminate an unrelated editor, database, build, or other user process solely because Linux reused a stale PID.

## Validation

- `sh -n scripts/start-monk-agent.sh`
- `sh -n scripts/uninstall-monk-agent.sh`
- parsed `.github/workflows/install-e2e.yml` with PyYAML
- `git diff --check`
- verified root and packaged launcher copies are byte-identical
- verified root and packaged uninstaller copies are byte-identical
- added live Ubuntu startup and uninstall regression coverage to Install E2E

Fixes #98
