### PR TITLE
fix: harden managed agent bootstrap

### DIFF
--- a/.github/workflows/install-e2e.yml
+++ b/.github/workflows/install-e2e.yml
@@ -38,6 +38,21 @@ jobs:
           test "$installed" = "$MONK_AGENT_INSTALL_DIR/monk-agent"
           test -x "$installed"
 
+      - name: Prefer managed agent when updates are disabled
+        shell: bash
+        env:
+          MONK_AGENT_INSTALL_DIR: ${{ runner.temp }}/monk-bin
+          MONK_AGENT_AUTO_UPDATE: "0"
+        run: |
+          set -euo pipefail
+          other_dir="$RUNNER_TEMP/other-monk-bin"
+          mkdir -p "$other_dir"
+          cp "$MONK_AGENT_INSTALL_DIR/monk-agent" "$other_dir/monk-agent"
+          export PATH="$other_dir:$PATH"
+
+          installed="$(./scripts/ensure-monk-agent.sh)"
+          test "$installed" = "$MONK_AGENT_INSTALL_DIR/monk-agent"
+
       - name: Run monk-agent status
         shell: bash
         env:

--- a/.github/workflows/install-e2e.yml
+++ b/.github/workflows/install-e2e.yml
@@ -118,6 +118,60 @@ jobs:
             throw "disabled-update bootstrap selected PATH agent: $installed"
           }
 
+      - name: Serialize concurrent Windows installers
+        shell: pwsh
+        env:
+          MONK_AGENT_INSTALL_DIR: ${{ runner.temp }}\monk-bin
+        run: |
+          $script = (Resolve-Path ".\scripts\ensure-monk-agent.ps1").Path
+          $checksum = "$env:MONK_AGENT_INSTALL_DIR\monk-agent.sha256"
+          $gate = "$env:RUNNER_TEMP\monk-installer-gate-$([Guid]::NewGuid())"
+
+          $jobs = 1..2 | ForEach-Object {
+            Start-Job -ArgumentList $script, $checksum, $gate, $env:MONK_AGENT_INSTALL_DIR -ScriptBlock {
+              param($script, $checksum, $gate, $installDir)
+              $ErrorActionPreference = "Stop"
+              $env:MONK_AGENT_INSTALL_DIR = $installDir
+
+              New-Item -ItemType File -Path "$gate-$PID" | Out-Null
+              while ((Get-ChildItem "$gate-*" -ErrorAction SilentlyContinue).Count -lt 2) {
+                Start-Sleep -Milliseconds 20
+              }
+
+              function Invoke-WebRequest {
+                param([string]$Uri, [string]$OutFile)
+                $bytes = [IO.File]::ReadAllBytes($checksum)
+                $stream = [IO.File]::Open(
+                  $OutFile,
+                  [IO.FileMode]::Create,
+                  [IO.FileAccess]::Write,
+                  [IO.FileShare]::None
+                )
+                try {
+                  $stream.Write($bytes, 0, $bytes.Length)
+                  $stream.Flush()
+                  Start-Sleep -Milliseconds 750
+                } finally {
+                  $stream.Dispose()
+                }
+              }
+
+              & $script
+            }
+          }
+
+          $jobs | Wait-Job | Out-Null
+          $errors = @()
+          $results = $jobs | Receive-Job -ErrorVariable +errors
+          $states = $jobs.State
+          $jobs | Remove-Job -Force
+          if ($errors -or $states -contains "Failed") {
+            throw "concurrent installer failed: $($errors -join '; ')"
+          }
+          if (@($results | Where-Object { $_ -eq "$env:MONK_AGENT_INSTALL_DIR\monk-agent.exe" }).Count -ne 2) {
+            throw "concurrent installers did not both return the managed agent path"
+          }
+
       - name: Run monk-agent status
         shell: pwsh
         env:

--- a/.github/workflows/install-e2e.yml
+++ b/.github/workflows/install-e2e.yml
@@ -80,6 +80,29 @@ jobs:
             throw "monk-agent.exe was not installed"
           }
 
+      - name: Prefer managed agent when updates are disabled
+        shell: pwsh
+        env:
+          MONK_AGENT_INSTALL_DIR: ${{ runner.temp }}\monk-bin
+          MONK_AGENT_AUTO_UPDATE: "0"
+        run: |
+          $otherDir = "$env:RUNNER_TEMP\other-monk-bin"
+          New-Item -ItemType Directory -Force -Path $otherDir | Out-Null
+          Copy-Item `
+            "$env:MONK_AGENT_INSTALL_DIR\monk-agent.exe" `
+            "$otherDir\monk-agent.exe"
+          $env:PATH = "$otherDir;$env:PATH"
+
+          $installed = .\scripts\ensure-monk-agent.ps1
+          $expected = "$env:MONK_AGENT_INSTALL_DIR\monk-agent.exe"
+          if (-not [string]::Equals(
+            [IO.Path]::GetFullPath($installed),
+            [IO.Path]::GetFullPath($expected),
+            [StringComparison]::OrdinalIgnoreCase
+          )) {
+            throw "disabled-update bootstrap selected PATH agent: $installed"
+          }
+
       - name: Run monk-agent status
         shell: pwsh
         env:

--- a/plugins/monk/scripts/ensure-monk-agent.ps1
+++ b/plugins/monk/scripts/ensure-monk-agent.ps1
@@ -83,14 +83,14 @@ function Stop-ManagedAgent {
 }
 
 if ($AutoUpdate -eq "0" -or $AutoUpdate -eq "false") {
-  $Existing = Get-Command monk-agent.exe -ErrorAction SilentlyContinue
-  if ($Existing) {
-    Write-Output $Existing.Source
+  if (Test-Path $Target) {
+    Write-Output $Target
     exit 0
   }
 
-  if (Test-Path $Target) {
-    Write-Output $Target
+  $Existing = Get-Command monk-agent.exe -ErrorAction SilentlyContinue
+  if ($Existing) {
+    Write-Output $Existing.Source
     exit 0
   }
 }

--- a/plugins/monk/scripts/ensure-monk-agent.ps1
+++ b/plugins/monk/scripts/ensure-monk-agent.ps1
@@ -111,36 +111,54 @@ $ChecksumTmp = Join-Path $InstallDir ".monk-agent.tmp.sha256"
 $ExtractDir = Join-Path $InstallDir ".monk-agent.extract"
 New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
 
-Invoke-WebRequest -Uri $ChecksumUrl -OutFile $ChecksumTmp
-
-$Expected = ((Get-Content -Raw $ChecksumTmp).Trim() -split "\s+")[0].ToLowerInvariant()
-
-if ((Test-Path $Target) -and (Test-Path $ChecksumInstalled)) {
-  $Installed = ((Get-Content -Raw $ChecksumInstalled).Trim() -split "\s+")[0].ToLowerInvariant()
-  if ($Installed -eq $Expected) {
-    Remove-Item -Force $ChecksumTmp
-    Write-Output $Target
-    exit 0
+# Launchers on different ports hold different launcher mutexes but still share
+# these installer paths, so serialize the complete update transaction here.
+$InstallerMutex = New-Object System.Threading.Mutex($false, "Local\monk-agent-installer")
+$InstallerMutexOwned = $false
+try {
+  try {
+    $InstallerMutexOwned = $InstallerMutex.WaitOne()
+  } catch [System.Threading.AbandonedMutexException] {
+    # A previous installer died while holding the mutex; ownership transfers to us.
+    $InstallerMutexOwned = $true
   }
-}
 
-Write-Host "Installing monk-agent from $Url"
-Invoke-WebRequest -Uri $Url -OutFile $ArchiveTmp
+  Invoke-WebRequest -Uri $ChecksumUrl -OutFile $ChecksumTmp
 
-$Actual = Get-FileSha256 $ArchiveTmp
-if ($Actual -ne $Expected) {
-  Write-Error "Checksum verification failed for monk-agent."
-  exit 1
-}
+  $Expected = ((Get-Content -Raw $ChecksumTmp).Trim() -split "\s+")[0].ToLowerInvariant()
 
-if (Test-Path $ExtractDir) {
+  if ((Test-Path $Target) -and (Test-Path $ChecksumInstalled)) {
+    $Installed = ((Get-Content -Raw $ChecksumInstalled).Trim() -split "\s+")[0].ToLowerInvariant()
+    if ($Installed -eq $Expected) {
+      Remove-Item -Force $ChecksumTmp
+      Write-Output $Target
+      exit 0
+    }
+  }
+
+  Write-Host "Installing monk-agent from $Url"
+  Invoke-WebRequest -Uri $Url -OutFile $ArchiveTmp
+
+  $Actual = Get-FileSha256 $ArchiveTmp
+  if ($Actual -ne $Expected) {
+    Write-Error "Checksum verification failed for monk-agent."
+    exit 1
+  }
+
+  if (Test-Path $ExtractDir) {
+    Remove-Item -Recurse -Force $ExtractDir
+  }
+  New-Item -ItemType Directory -Force -Path $ExtractDir | Out-Null
+  Expand-Archive -Force -Path $ArchiveTmp -DestinationPath $ExtractDir
+  Stop-ManagedAgent
+  Move-Item -Force (Join-Path $ExtractDir "monk-agent.exe") $Target
+  "$Expected  $Artifact" | Set-Content -NoNewline $ChecksumInstalled
   Remove-Item -Recurse -Force $ExtractDir
+  Remove-Item -Force $ArchiveTmp, $ChecksumTmp
+  Write-Output $Target
+} finally {
+  if ($InstallerMutexOwned) {
+    $InstallerMutex.ReleaseMutex()
+  }
+  $InstallerMutex.Dispose()
 }
-New-Item -ItemType Directory -Force -Path $ExtractDir | Out-Null
-Expand-Archive -Force -Path $ArchiveTmp -DestinationPath $ExtractDir
-Stop-ManagedAgent
-Move-Item -Force (Join-Path $ExtractDir "monk-agent.exe") $Target
-"$Expected  $Artifact" | Set-Content -NoNewline $ChecksumInstalled
-Remove-Item -Recurse -Force $ExtractDir
-Remove-Item -Force $ArchiveTmp, $ChecksumTmp
-Write-Output $Target

--- a/plugins/monk/scripts/ensure-monk-agent.sh
+++ b/plugins/monk/scripts/ensure-monk-agent.sh
@@ -45,12 +45,12 @@ extract_dir="$install_dir/.monk-agent.extract"
 mkdir -p "$install_dir"
 
 if [ "$auto_update" = "0" ] || [ "$auto_update" = "false" ]; then
-  if command -v monk-agent >/dev/null 2>&1; then
-    command -v monk-agent
-    exit 0
-  fi
   if [ -x "$target" ]; then
     printf '%s\n' "$target"
+    exit 0
+  fi
+  if command -v monk-agent >/dev/null 2>&1; then
+    command -v monk-agent
     exit 0
   fi
 fi

--- a/scripts/ensure-monk-agent.ps1
+++ b/scripts/ensure-monk-agent.ps1
@@ -83,14 +83,14 @@ function Stop-ManagedAgent {
 }
 
 if ($AutoUpdate -eq "0" -or $AutoUpdate -eq "false") {
-  $Existing = Get-Command monk-agent.exe -ErrorAction SilentlyContinue
-  if ($Existing) {
-    Write-Output $Existing.Source
+  if (Test-Path $Target) {
+    Write-Output $Target
     exit 0
   }
 
-  if (Test-Path $Target) {
-    Write-Output $Target
+  $Existing = Get-Command monk-agent.exe -ErrorAction SilentlyContinue
+  if ($Existing) {
+    Write-Output $Existing.Source
     exit 0
   }
 }

--- a/scripts/ensure-monk-agent.ps1
+++ b/scripts/ensure-monk-agent.ps1
@@ -111,36 +111,54 @@ $ChecksumTmp = Join-Path $InstallDir ".monk-agent.tmp.sha256"
 $ExtractDir = Join-Path $InstallDir ".monk-agent.extract"
 New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
 
-Invoke-WebRequest -Uri $ChecksumUrl -OutFile $ChecksumTmp
-
-$Expected = ((Get-Content -Raw $ChecksumTmp).Trim() -split "\s+")[0].ToLowerInvariant()
-
-if ((Test-Path $Target) -and (Test-Path $ChecksumInstalled)) {
-  $Installed = ((Get-Content -Raw $ChecksumInstalled).Trim() -split "\s+")[0].ToLowerInvariant()
-  if ($Installed -eq $Expected) {
-    Remove-Item -Force $ChecksumTmp
-    Write-Output $Target
-    exit 0
+# Launchers on different ports hold different launcher mutexes but still share
+# these installer paths, so serialize the complete update transaction here.
+$InstallerMutex = New-Object System.Threading.Mutex($false, "Local\monk-agent-installer")
+$InstallerMutexOwned = $false
+try {
+  try {
+    $InstallerMutexOwned = $InstallerMutex.WaitOne()
+  } catch [System.Threading.AbandonedMutexException] {
+    # A previous installer died while holding the mutex; ownership transfers to us.
+    $InstallerMutexOwned = $true
   }
-}
 
-Write-Host "Installing monk-agent from $Url"
-Invoke-WebRequest -Uri $Url -OutFile $ArchiveTmp
+  Invoke-WebRequest -Uri $ChecksumUrl -OutFile $ChecksumTmp
 
-$Actual = Get-FileSha256 $ArchiveTmp
-if ($Actual -ne $Expected) {
-  Write-Error "Checksum verification failed for monk-agent."
-  exit 1
-}
+  $Expected = ((Get-Content -Raw $ChecksumTmp).Trim() -split "\s+")[0].ToLowerInvariant()
 
-if (Test-Path $ExtractDir) {
+  if ((Test-Path $Target) -and (Test-Path $ChecksumInstalled)) {
+    $Installed = ((Get-Content -Raw $ChecksumInstalled).Trim() -split "\s+")[0].ToLowerInvariant()
+    if ($Installed -eq $Expected) {
+      Remove-Item -Force $ChecksumTmp
+      Write-Output $Target
+      exit 0
+    }
+  }
+
+  Write-Host "Installing monk-agent from $Url"
+  Invoke-WebRequest -Uri $Url -OutFile $ArchiveTmp
+
+  $Actual = Get-FileSha256 $ArchiveTmp
+  if ($Actual -ne $Expected) {
+    Write-Error "Checksum verification failed for monk-agent."
+    exit 1
+  }
+
+  if (Test-Path $ExtractDir) {
+    Remove-Item -Recurse -Force $ExtractDir
+  }
+  New-Item -ItemType Directory -Force -Path $ExtractDir | Out-Null
+  Expand-Archive -Force -Path $ArchiveTmp -DestinationPath $ExtractDir
+  Stop-ManagedAgent
+  Move-Item -Force (Join-Path $ExtractDir "monk-agent.exe") $Target
+  "$Expected  $Artifact" | Set-Content -NoNewline $ChecksumInstalled
   Remove-Item -Recurse -Force $ExtractDir
+  Remove-Item -Force $ArchiveTmp, $ChecksumTmp
+  Write-Output $Target
+} finally {
+  if ($InstallerMutexOwned) {
+    $InstallerMutex.ReleaseMutex()
+  }
+  $InstallerMutex.Dispose()
 }
-New-Item -ItemType Directory -Force -Path $ExtractDir | Out-Null
-Expand-Archive -Force -Path $ArchiveTmp -DestinationPath $ExtractDir
-Stop-ManagedAgent
-Move-Item -Force (Join-Path $ExtractDir "monk-agent.exe") $Target
-"$Expected  $Artifact" | Set-Content -NoNewline $ChecksumInstalled
-Remove-Item -Recurse -Force $ExtractDir
-Remove-Item -Force $ArchiveTmp, $ChecksumTmp
-Write-Output $Target

--- a/scripts/ensure-monk-agent.sh
+++ b/scripts/ensure-monk-agent.sh
@@ -45,12 +45,12 @@ extract_dir="$install_dir/.monk-agent.extract"
 mkdir -p "$install_dir"
 
 if [ "$auto_update" = "0" ] || [ "$auto_update" = "false" ]; then
-  if command -v monk-agent >/dev/null 2>&1; then
-    command -v monk-agent
-    exit 0
-  fi
   if [ -x "$target" ]; then
     printf '%s\n' "$target"
+    exit 0
+  fi
+  if command -v monk-agent >/dev/null 2>&1; then
+    command -v monk-agent
     exit 0
   fi
 fi


### PR DESCRIPTION
## Summary

- prefer the plugin-managed `monk-agent` when automatic updates are disabled on Windows, Linux, and macOS
- retain the existing `PATH` lookup as a fallback when the managed target is absent
- serialize the complete Windows checksum/download/extract/move transaction independently of the agent port
- add end-to-end regressions for managed-path precedence and concurrent PowerShell installers

## Why

The disabled-update branches checked `PATH` before their managed targets. An unrelated or older executable earlier on `PATH` therefore won even when the plugin's managed installation existed.

Separately, the Windows launcher's mutex is scoped to `MONK_AGENT_PORT`, but every launcher shares fixed installer scratch paths. Launchers using different valid ports therefore bypassed each other's mutex and raced on the checksum, archive, and extraction directory. One legitimate startup failed with a file-in-use error.

Fixes #105.
Fixes #109.

## Validation

- reproduced #109 on exact public commit `1e14687724cf5dbcf5a2ac80339d3927d3922d60` with a forced two-process overlap: one failed and one completed
- reproduced the real launcher path with ports `17431` and `17432`: one exited `1` on the shared archive and one exited `0`
- verified the fixed deterministic regression returns the managed executable from both installers with zero errors
- verified a fixed cold install against the real 65 MB stable Windows artifact: both installers exited `0`, the executable and checksum were present, and no scratch paths remained
- reproduced the Windows managed-vs-`PATH` precedence behavior with the real v0.1.45 executable
- verified the fixed managed-present case returns the managed target and the managed-missing case retains the `PATH` fallback
- added the equivalent managed-path regression to the Ubuntu/macOS install matrix
- parsed both changed PowerShell scripts with the PowerShell AST parser
- confirmed the root and packaged bootstrap scripts remain identical
- parsed `.github/workflows/install-e2e.yml` with PyYAML
- `git diff --check`
