### PR TITLE
fix: propagate plugin version on Windows

### DIFF
--- a/.antigravity-plugin/scripts/start-monk-agent.ps1
+++ b/.antigravity-plugin/scripts/start-monk-agent.ps1
@@ -8,6 +8,20 @@ $AuthAudience = if ($env:MONK_AUTH_AUDIENCE) { $env:MONK_AUTH_AUDIENCE } else { 
 $AutospinUrl = if ($env:MONK_AUTOSPIN_URL) { $env:MONK_AUTOSPIN_URL } else { "wss://api.app.monk.io/autospin/" }
 
 $ScriptDir = if ($PSScriptRoot) { $PSScriptRoot } else { Split-Path -Parent $MyInvocation.MyCommand.Path }
+# Rendered at plugin build time; carries MONK_PLUGIN_VERSION so the Windows
+# agent reports the plugin release rather than falling back to its binary
+# version. Guarded so older rendered plugins without the file still launch.
+$PluginVersionFile = Join-Path $ScriptDir "plugin-version.sh"
+if (Test-Path -LiteralPath $PluginVersionFile) {
+  $PluginVersionMatch = [regex]::Match(
+    (Get-Content -Raw -LiteralPath $PluginVersionFile),
+    '(?m)^MONK_PLUGIN_VERSION="([^"\r\n]+)"\s*$'
+  )
+  if ($PluginVersionMatch.Success) {
+    $env:MONK_PLUGIN_VERSION = $PluginVersionMatch.Groups[1].Value
+  }
+}
+
 $PluginRoot = if ($env:CLAUDE_PLUGIN_ROOT) { $env:CLAUDE_PLUGIN_ROOT } else { Split-Path -Parent $ScriptDir }
 $InstallDir = if ($env:MONK_AGENT_INSTALL_DIR) { $env:MONK_AGENT_INSTALL_DIR } else { Join-Path $HOME ".monk\bin" }
 $MonkHome = if ($env:MONK_AGENT_HOME) { $env:MONK_AGENT_HOME } else { Join-Path $HOME ".monk" }

--- a/.github/workflows/install-e2e.yml
+++ b/.github/workflows/install-e2e.yml
@@ -116,7 +116,16 @@ jobs:
           MONK_AGENT_SKIP_ENSURE: "1"
           MONK_TELEMETRY: "0"
         run: |
+          Remove-Item Env:MONK_PLUGIN_VERSION -ErrorAction SilentlyContinue
           .\scripts\start-monk-agent.ps1
+          $versionSource = Get-Content -Raw .\scripts\plugin-version.sh
+          $versionMatch = [regex]::Match($versionSource, '(?m)^MONK_PLUGIN_VERSION="([^"\r\n]+)"\s*$')
+          if (-not $versionMatch.Success) {
+            throw "plugin-version.sh did not contain MONK_PLUGIN_VERSION"
+          }
+          if ($env:MONK_PLUGIN_VERSION -ne $versionMatch.Groups[1].Value) {
+            throw "Windows launcher did not propagate the rendered plugin version"
+          }
           $pidPath = Join-Path $env:MONK_AGENT_HOME "agent\launcher\run\monk-agent.pid"
           if (-not (Test-Path $pidPath)) {
             throw "monk-agent pid file was not created"

--- a/plugins/monk/scripts/start-monk-agent.ps1
+++ b/plugins/monk/scripts/start-monk-agent.ps1
@@ -8,6 +8,20 @@ $AuthAudience = if ($env:MONK_AUTH_AUDIENCE) { $env:MONK_AUTH_AUDIENCE } else { 
 $AutospinUrl = if ($env:MONK_AUTOSPIN_URL) { $env:MONK_AUTOSPIN_URL } else { "wss://api.app.monk.io/autospin/" }
 
 $ScriptDir = if ($PSScriptRoot) { $PSScriptRoot } else { Split-Path -Parent $MyInvocation.MyCommand.Path }
+# Rendered at plugin build time; carries MONK_PLUGIN_VERSION so the Windows
+# agent reports the plugin release rather than falling back to its binary
+# version. Guarded so older rendered plugins without the file still launch.
+$PluginVersionFile = Join-Path $ScriptDir "plugin-version.sh"
+if (Test-Path -LiteralPath $PluginVersionFile) {
+  $PluginVersionMatch = [regex]::Match(
+    (Get-Content -Raw -LiteralPath $PluginVersionFile),
+    '(?m)^MONK_PLUGIN_VERSION="([^"\r\n]+)"\s*$'
+  )
+  if ($PluginVersionMatch.Success) {
+    $env:MONK_PLUGIN_VERSION = $PluginVersionMatch.Groups[1].Value
+  }
+}
+
 $PluginRoot = if ($env:CLAUDE_PLUGIN_ROOT) { $env:CLAUDE_PLUGIN_ROOT } else { Split-Path -Parent $ScriptDir }
 $InstallDir = if ($env:MONK_AGENT_INSTALL_DIR) { $env:MONK_AGENT_INSTALL_DIR } else { Join-Path $HOME ".monk\bin" }
 $MonkHome = if ($env:MONK_AGENT_HOME) { $env:MONK_AGENT_HOME } else { Join-Path $HOME ".monk" }

--- a/scripts/start-monk-agent.ps1
+++ b/scripts/start-monk-agent.ps1
@@ -8,6 +8,20 @@ $AuthAudience = if ($env:MONK_AUTH_AUDIENCE) { $env:MONK_AUTH_AUDIENCE } else { 
 $AutospinUrl = if ($env:MONK_AUTOSPIN_URL) { $env:MONK_AUTOSPIN_URL } else { "wss://api.app.monk.io/autospin/" }
 
 $ScriptDir = if ($PSScriptRoot) { $PSScriptRoot } else { Split-Path -Parent $MyInvocation.MyCommand.Path }
+# Rendered at plugin build time; carries MONK_PLUGIN_VERSION so the Windows
+# agent reports the plugin release rather than falling back to its binary
+# version. Guarded so older rendered plugins without the file still launch.
+$PluginVersionFile = Join-Path $ScriptDir "plugin-version.sh"
+if (Test-Path -LiteralPath $PluginVersionFile) {
+  $PluginVersionMatch = [regex]::Match(
+    (Get-Content -Raw -LiteralPath $PluginVersionFile),
+    '(?m)^MONK_PLUGIN_VERSION="([^"\r\n]+)"\s*$'
+  )
+  if ($PluginVersionMatch.Success) {
+    $env:MONK_PLUGIN_VERSION = $PluginVersionMatch.Groups[1].Value
+  }
+}
+
 $PluginRoot = if ($env:CLAUDE_PLUGIN_ROOT) { $env:CLAUDE_PLUGIN_ROOT } else { Split-Path -Parent $ScriptDir }
 $InstallDir = if ($env:MONK_AGENT_INSTALL_DIR) { $env:MONK_AGENT_INSTALL_DIR } else { Join-Path $HOME ".monk\bin" }
 $MonkHome = if ($env:MONK_AGENT_HOME) { $env:MONK_AGENT_HOME } else { Join-Path $HOME ".monk" }


### PR DESCRIPTION
## Summary

- load the build-rendered plugin version in the native Windows launcher
- pass `MONK_PLUGIN_VERSION` to the companion through its inherited process environment
- keep older rendered packages without `plugin-version.sh` backward compatible
- assert the Windows launcher exports the exact rendered version in install E2E CI

## Why

The POSIX launcher sources `plugin-version.sh` before starting `monk-agent`, but the PowerShell launcher did not. Native Windows companions therefore received no `MONK_PLUGIN_VERSION` and fell back to their agent-binary version, so telemetry could not attribute Windows sessions to the plugin release that launched them.

The fix parses only the generated `MONK_PLUGIN_VERSION="..."` assignment beside the launcher and exports it before the existing `Start-Process` call. All three rendered PowerShell copies remain identical.

Fixes #110.

## Impact

Native Windows usage and diagnostics now carry the same plugin-release identity as Unix launches. This makes rollout regressions and field reports attributable to the actual plugin version.

## Validation

- reproduced the unpatched launcher through its real `Start-Process` boundary: an isolated capture child received `MONK_PLUGIN_VERSION=<missing>`
- reran the same reproduction after the patch: the child received `MONK_PLUGIN_VERSION=0.1.45` and the unchanged `serve --host ... --port ...` arguments
- launched the real v0.1.45 Windows companion on an isolated port and home, verified HTTP 200 health metadata containing `resource`, then stopped the exact launched process
- parsed all three changed PowerShell launchers with the PowerShell AST parser (zero errors)
- verified the root, packaged Monk, and Antigravity PowerShell launchers are byte-identical
- parsed `.github/workflows/install-e2e.yml` with PyYAML
- `git diff --cached --check`
