### PR TITLE
Fix Windows WSL uninstall failure reporting

### DIFF
--- a/.antigravity-plugin/scripts/uninstall-monk-agent.ps1
+++ b/.antigravity-plugin/scripts/uninstall-monk-agent.ps1
@@ -96,6 +96,17 @@ function Get-WslDistros {
   }
 }
 
+function Assert-NativeCommandSucceeded {
+  param(
+    [string]$Operation,
+    [int]$ExitCode
+  )
+
+  if ($ExitCode -ne 0) {
+    throw "$Operation failed with exit code $ExitCode."
+  }
+}
+
 function Remove-MonkRuntime {
   $distros = @(Get-WslDistros)
   if (-not $distros.Length) {
@@ -117,6 +128,7 @@ function Remove-MonkRuntime {
   if ($distro -eq "Ubuntu-Monk") {
     wsl.exe --terminate Ubuntu-Monk 2>$null
     wsl.exe --unregister Ubuntu-Monk
+    Assert-NativeCommandSucceeded "Unregistering WSL distro 'Ubuntu-Monk'" $LASTEXITCODE
     return
   }
 
@@ -133,6 +145,7 @@ elif command -v dnf >/dev/null 2>&1 && rpm -q monk >/dev/null 2>&1; then
 fi
 '@
   wsl.exe -d $distro --user root -- sh -lc $script
+  Assert-NativeCommandSucceeded "Removing Monk runtime from WSL distro '$distro'" $LASTEXITCODE
 }
 
 Stop-ManagedAgent

--- a/.github/workflows/install-e2e.yml
+++ b/.github/workflows/install-e2e.yml
@@ -78,6 +78,10 @@ jobs:
         shell: pwsh
         run: .\tests\start-monk-agent-readiness-timeout.ps1
 
+      - name: Test Windows uninstaller WSL failure handling
+        shell: pwsh
+        run: .\tests\uninstall-monk-agent-native-exit.ps1
+
       - name: Install monk-agent
         shell: pwsh
         env:

--- a/plugins/monk/scripts/uninstall-monk-agent.ps1
+++ b/plugins/monk/scripts/uninstall-monk-agent.ps1
@@ -96,6 +96,17 @@ function Get-WslDistros {
   }
 }
 
+function Assert-NativeCommandSucceeded {
+  param(
+    [string]$Operation,
+    [int]$ExitCode
+  )
+
+  if ($ExitCode -ne 0) {
+    throw "$Operation failed with exit code $ExitCode."
+  }
+}
+
 function Remove-MonkRuntime {
   $distros = @(Get-WslDistros)
   if (-not $distros.Length) {
@@ -117,6 +128,7 @@ function Remove-MonkRuntime {
   if ($distro -eq "Ubuntu-Monk") {
     wsl.exe --terminate Ubuntu-Monk 2>$null
     wsl.exe --unregister Ubuntu-Monk
+    Assert-NativeCommandSucceeded "Unregistering WSL distro 'Ubuntu-Monk'" $LASTEXITCODE
     return
   }
 
@@ -133,6 +145,7 @@ elif command -v dnf >/dev/null 2>&1 && rpm -q monk >/dev/null 2>&1; then
 fi
 '@
   wsl.exe -d $distro --user root -- sh -lc $script
+  Assert-NativeCommandSucceeded "Removing Monk runtime from WSL distro '$distro'" $LASTEXITCODE
 }
 
 Stop-ManagedAgent

--- a/scripts/uninstall-monk-agent.ps1
+++ b/scripts/uninstall-monk-agent.ps1
@@ -96,6 +96,17 @@ function Get-WslDistros {
   }
 }
 
+function Assert-NativeCommandSucceeded {
+  param(
+    [string]$Operation,
+    [int]$ExitCode
+  )
+
+  if ($ExitCode -ne 0) {
+    throw "$Operation failed with exit code $ExitCode."
+  }
+}
+
 function Remove-MonkRuntime {
   $distros = @(Get-WslDistros)
   if (-not $distros.Length) {
@@ -117,6 +128,7 @@ function Remove-MonkRuntime {
   if ($distro -eq "Ubuntu-Monk") {
     wsl.exe --terminate Ubuntu-Monk 2>$null
     wsl.exe --unregister Ubuntu-Monk
+    Assert-NativeCommandSucceeded "Unregistering WSL distro 'Ubuntu-Monk'" $LASTEXITCODE
     return
   }
 
@@ -133,6 +145,7 @@ elif command -v dnf >/dev/null 2>&1 && rpm -q monk >/dev/null 2>&1; then
 fi
 '@
   wsl.exe -d $distro --user root -- sh -lc $script
+  Assert-NativeCommandSucceeded "Removing Monk runtime from WSL distro '$distro'" $LASTEXITCODE
 }
 
 Stop-ManagedAgent

--- a/tests/uninstall-monk-agent-native-exit.ps1
+++ b/tests/uninstall-monk-agent-native-exit.ps1
@@ -1,0 +1,112 @@
+$ErrorActionPreference = "Stop"
+
+$RepoRoot = Split-Path -Parent $PSScriptRoot
+$Uninstaller = Join-Path $RepoRoot "scripts\uninstall-monk-agent.ps1"
+
+function Restore-EnvironmentValue {
+  param(
+    [string]$Name,
+    [AllowNull()][string]$Value
+  )
+
+  if ($null -eq $Value) {
+    Remove-Item "Env:\$Name" -ErrorAction SilentlyContinue
+  } else {
+    Set-Item "Env:\$Name" $Value
+  }
+}
+
+function Test-WslFailure {
+  param(
+    [string]$Distro,
+    [string]$FailingCall,
+    [int]$ExitCode,
+    [string]$ExpectedError
+  )
+
+  $TempRoot = Join-Path ([IO.Path]::GetTempPath()) ("monk-uninstall-test-" + [guid]::NewGuid())
+  $OutputPath = Join-Path $TempRoot "output.txt"
+  New-Item -ItemType Directory -Force $TempRoot | Out-Null
+
+  $PreviousInstallDir = $env:MONK_AGENT_INSTALL_DIR
+  $PreviousHome = $env:MONK_AGENT_HOME
+  $global:FakeWslDistro = $Distro
+  $global:FakeWslFailingCall = $FailingCall
+  $global:FakeWslExitCode = $ExitCode
+  $global:FakeWslCalls = [System.Collections.Generic.List[string]]::new()
+
+  function global:wsl.exe {
+    $Call = $args -join " "
+    $global:FakeWslCalls.Add($Call)
+
+    if ($Call -eq "-l -q") {
+      Write-Output $global:FakeWslDistro
+      $global:LASTEXITCODE = 0
+      return
+    }
+
+    if ($Call.StartsWith($global:FakeWslFailingCall, [StringComparison]::Ordinal)) {
+      $global:LASTEXITCODE = $global:FakeWslExitCode
+      return
+    }
+
+    $global:LASTEXITCODE = 0
+  }
+
+  try {
+    $env:MONK_AGENT_INSTALL_DIR = Join-Path $TempRoot "bin"
+    $env:MONK_AGENT_HOME = Join-Path $TempRoot "home"
+    $Caught = $null
+
+    try {
+      & $Uninstaller -Runtime -Yes *> $OutputPath
+    } catch {
+      $Caught = $_
+    }
+
+    if (-not $Caught) {
+      throw "Expected WSL failure for $Distro, but uninstall succeeded. Calls: $($global:FakeWslCalls -join ' | ')"
+    }
+    if ($Caught.Exception.Message -notlike "*$ExpectedError*") {
+      throw "Unexpected error for ${Distro}: $($Caught.Exception.Message)"
+    }
+
+    $Output = if (Test-Path $OutputPath) { Get-Content -Raw $OutputPath } else { "" }
+    if ($Output -match "monk-agent uninstall complete") {
+      throw "Uninstaller printed a success message after WSL failure for $Distro."
+    }
+    if (-not ($global:FakeWslCalls | Where-Object { $_.StartsWith($FailingCall, [StringComparison]::Ordinal) })) {
+      throw "Expected fake WSL call '$FailingCall' was not made."
+    }
+  } finally {
+    Remove-Item Function:\wsl.exe -ErrorAction SilentlyContinue
+    Restore-EnvironmentValue "MONK_AGENT_INSTALL_DIR" $PreviousInstallDir
+    Restore-EnvironmentValue "MONK_AGENT_HOME" $PreviousHome
+    Remove-Item -Recurse -Force $TempRoot -ErrorAction SilentlyContinue
+    Remove-Variable FakeWslDistro, FakeWslFailingCall, FakeWslExitCode, FakeWslCalls -Scope Global -ErrorAction SilentlyContinue
+  }
+}
+
+Test-WslFailure `
+  -Distro "Ubuntu-Monk" `
+  -FailingCall "--unregister Ubuntu-Monk" `
+  -ExitCode 43 `
+  -ExpectedError "Unregistering WSL distro 'Ubuntu-Monk' failed with exit code 43."
+
+Test-WslFailure `
+  -Distro "Ubuntu-24.04" `
+  -FailingCall "-d Ubuntu-24.04 --user root sh -lc" `
+  -ExitCode 44 `
+  -ExpectedError "Removing Monk runtime from WSL distro 'Ubuntu-24.04' failed with exit code 44."
+
+$PackagedCopies = @(
+  (Join-Path $RepoRoot "scripts\uninstall-monk-agent.ps1"),
+  (Join-Path $RepoRoot "plugins\monk\scripts\uninstall-monk-agent.ps1"),
+  (Join-Path $RepoRoot ".antigravity-plugin\scripts\uninstall-monk-agent.ps1")
+)
+$CopyHashes = $PackagedCopies | ForEach-Object { (Get-FileHash -Algorithm SHA256 $_).Hash }
+if (@($CopyHashes | Select-Object -Unique).Count -ne 1) {
+  throw "Packaged PowerShell uninstallers are not identical."
+}
+
+Write-Host "Windows uninstaller native exit tests passed."


### PR DESCRIPTION
## Summary

- fail the Windows uninstaller when `wsl.exe --unregister Ubuntu-Monk` returns a nonzero exit code
- fail the generic Ubuntu runtime-removal path when its `wsl.exe` command returns a nonzero exit code
- keep the three distributed PowerShell uninstallers byte-identical
- add deterministic fake-WSL regression coverage to the Windows CI job

## Root cause

`$ErrorActionPreference = "Stop"` does not make a nonzero native-process exit code a terminating error when PowerShell 7 uses its default `$PSNativeCommandUseErrorActionPreference = $false`. The uninstaller never checked `$LASTEXITCODE`, so failed WSL removal commands fell through to the unconditional success message.

The dedicated-distro path treats `--unregister` as the definitive removal operation. A failed `--terminate` remains best-effort because unregistering an already-stopped distro can still succeed.

## Impact

Windows users and automation now receive a nonzero uninstaller result with the failed operation and native exit code. `monk-agent uninstall complete.` is no longer printed when required WSL runtime removal fails.

## Validation

- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests/uninstall-monk-agent-native-exit.ps1`
- PowerShell parser reports zero errors for all four changed `.ps1` files
- all three packaged uninstallers have identical SHA-256 hashes
- `git diff --check`

The regression test uses a scoped fake `wsl.exe`, disposable agent directories, and failure codes 43/44. It does not touch real WSL distributions or Monk data.

Fixes #131
