### PR TITLE
fix: bound launcher readiness by wall clock

### DIFF
--- a/.antigravity-plugin/scripts/start-monk-agent.ps1
+++ b/.antigravity-plugin/scripts/start-monk-agent.ps1
@@ -7,6 +7,15 @@ $AuthClientId = if ($env:MONK_AGENT_AUTH_CLIENT_ID) { $env:MONK_AGENT_AUTH_CLIEN
 $AuthAudience = if ($env:MONK_AUTH_AUDIENCE) { $env:MONK_AUTH_AUDIENCE } else { "oaknode.com" }
 $AutospinUrl = if ($env:MONK_AUTOSPIN_URL) { $env:MONK_AUTOSPIN_URL } else { "wss://api.app.monk.io/autospin/" }
 
+# Host hooks terminate this launcher after 180 seconds. Reserve enough time for
+# this script to emit its own startup diagnostics instead of being killed first.
+$ReadyTimeoutSec = 150
+$RequestedReadyTimeout = 0
+if ($env:MONK_AGENT_READY_TIMEOUT -and
+    [int]::TryParse($env:MONK_AGENT_READY_TIMEOUT, [ref]$RequestedReadyTimeout)) {
+  $ReadyTimeoutSec = [Math]::Max(1, [Math]::Min(150, $RequestedReadyTimeout))
+}
+
 $ScriptDir = if ($PSScriptRoot) { $PSScriptRoot } else { Split-Path -Parent $MyInvocation.MyCommand.Path }
 $PluginRoot = if ($env:CLAUDE_PLUGIN_ROOT) { $env:CLAUDE_PLUGIN_ROOT } else { Split-Path -Parent $ScriptDir }
 $InstallDir = if ($env:MONK_AGENT_INSTALL_DIR) { $env:MONK_AGENT_INSTALL_DIR } else { Join-Path $HOME ".monk\bin" }
@@ -271,7 +280,8 @@ $Process = Start-Process `
 
 $Process.Id | Set-Content -NoNewline $PidFile
 
-for ($Attempt = 0; $Attempt -lt 180; $Attempt++) {
+$ReadyTimer = [System.Diagnostics.Stopwatch]::StartNew()
+while ($ReadyTimer.Elapsed.TotalSeconds -lt $ReadyTimeoutSec) {
   if (Test-AgentRunning) {
     Show-SigninNudge
     exit 0
@@ -279,8 +289,11 @@ for ($Attempt = 0; $Attempt -lt 180; $Attempt++) {
   if ($Process.HasExited) {
     break
   }
+  if ($ReadyTimer.Elapsed.TotalSeconds -ge $ReadyTimeoutSec) {
+    break
+  }
   Start-Sleep -Seconds 1
 }
 
-Write-Error "monk-agent did not become ready at $HealthUrl within 180s. Logs: $LogOut, $LogErr"
+Write-Error "monk-agent did not become ready at $HealthUrl within ${ReadyTimeoutSec}s. Logs: $LogOut, $LogErr"
 exit 1

--- a/.antigravity-plugin/scripts/start-monk-agent.sh
+++ b/.antigravity-plugin/scripts/start-monk-agent.sh
@@ -10,6 +10,18 @@ autospin_url="${MONK_AUTOSPIN_URL:-wss://api.app.monk.io/autospin/}"
 agent_path_env="${PATH:-/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin}"
 script_dir="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
 
+# Host hooks terminate this launcher after 180 seconds. Keep readiness work
+# below that deadline so startup failures can print their own diagnostics.
+ready_timeout="${MONK_AGENT_READY_TIMEOUT:-150}"
+case "$ready_timeout" in
+  ''|*[!0-9]*) ready_timeout=150 ;;
+esac
+if [ "$ready_timeout" -lt 1 ]; then
+  ready_timeout=1
+elif [ "$ready_timeout" -gt 150 ]; then
+  ready_timeout=150
+fi
+
 # Rendered at plugin build time; carries MONK_PLUGIN_VERSION so the agent can
 # report the real plugin version in telemetry. Guarded: an older rendered
 # plugin without the file must still launch (the agent falls back to a labeled
@@ -368,24 +380,25 @@ case "$os" in
   *) start_with_background_process ;;
 esac
 
-tries=0
-while [ "$tries" -lt 180 ]; do
+ready_deadline=$(( $(date +%s) + ready_timeout ))
+while [ "$(date +%s)" -lt "$ready_deadline" ]; do
   if is_running; then
     register_antigravity_mcp
     emit_signin_nudge
     exit 0
   fi
-  # Break early if the background process has exited -- no point waiting 180s.
+  # Break early if the background process has exited -- no point waiting for
+  # the readiness deadline.
   if [ -f "$pid_file" ]; then
     _pid="$(cat "$pid_file" 2>/dev/null || true)"
     if [ -n "$_pid" ] && ! kill -0 "$_pid" 2>/dev/null; then
       break
     fi
   fi
-  tries=$((tries + 1))
+  [ "$(date +%s)" -lt "$ready_deadline" ] || break
   sleep 1
 done
 
-echo "monk-agent did not become ready at $health_url within 180s." >&2
+echo "monk-agent did not become ready at $health_url within ${ready_timeout}s." >&2
 echo "Log: $log_file" >&2
 exit 1

--- a/.github/workflows/install-e2e.yml
+++ b/.github/workflows/install-e2e.yml
@@ -54,6 +54,10 @@ jobs:
           grep '"version"' "$RUNNER_TEMP/status.json"
           grep '"signedIn": true' "$RUNNER_TEMP/status.json"
 
+      - name: Check launcher readiness deadline
+        shell: bash
+        run: ./tests/start-monk-agent-readiness-timeout.sh
+
   windows:
     name: windows-latest
     runs-on: windows-latest
@@ -105,6 +109,10 @@ jobs:
           if (-not $status.auth.signedIn) {
             throw "expected simulated auth to be signed in"
           }
+
+      - name: Check launcher readiness deadline
+        shell: pwsh
+        run: .\tests\start-monk-agent-readiness-timeout.ps1
 
       - name: Start monk-agent
         shell: pwsh

--- a/plugins/monk/scripts/start-monk-agent.ps1
+++ b/plugins/monk/scripts/start-monk-agent.ps1
@@ -7,6 +7,15 @@ $AuthClientId = if ($env:MONK_AGENT_AUTH_CLIENT_ID) { $env:MONK_AGENT_AUTH_CLIEN
 $AuthAudience = if ($env:MONK_AUTH_AUDIENCE) { $env:MONK_AUTH_AUDIENCE } else { "oaknode.com" }
 $AutospinUrl = if ($env:MONK_AUTOSPIN_URL) { $env:MONK_AUTOSPIN_URL } else { "wss://api.app.monk.io/autospin/" }
 
+# Host hooks terminate this launcher after 180 seconds. Reserve enough time for
+# this script to emit its own startup diagnostics instead of being killed first.
+$ReadyTimeoutSec = 150
+$RequestedReadyTimeout = 0
+if ($env:MONK_AGENT_READY_TIMEOUT -and
+    [int]::TryParse($env:MONK_AGENT_READY_TIMEOUT, [ref]$RequestedReadyTimeout)) {
+  $ReadyTimeoutSec = [Math]::Max(1, [Math]::Min(150, $RequestedReadyTimeout))
+}
+
 $ScriptDir = if ($PSScriptRoot) { $PSScriptRoot } else { Split-Path -Parent $MyInvocation.MyCommand.Path }
 $PluginRoot = if ($env:CLAUDE_PLUGIN_ROOT) { $env:CLAUDE_PLUGIN_ROOT } else { Split-Path -Parent $ScriptDir }
 $InstallDir = if ($env:MONK_AGENT_INSTALL_DIR) { $env:MONK_AGENT_INSTALL_DIR } else { Join-Path $HOME ".monk\bin" }
@@ -271,7 +280,8 @@ $Process = Start-Process `
 
 $Process.Id | Set-Content -NoNewline $PidFile
 
-for ($Attempt = 0; $Attempt -lt 180; $Attempt++) {
+$ReadyTimer = [System.Diagnostics.Stopwatch]::StartNew()
+while ($ReadyTimer.Elapsed.TotalSeconds -lt $ReadyTimeoutSec) {
   if (Test-AgentRunning) {
     Show-SigninNudge
     exit 0
@@ -279,8 +289,11 @@ for ($Attempt = 0; $Attempt -lt 180; $Attempt++) {
   if ($Process.HasExited) {
     break
   }
+  if ($ReadyTimer.Elapsed.TotalSeconds -ge $ReadyTimeoutSec) {
+    break
+  }
   Start-Sleep -Seconds 1
 }
 
-Write-Error "monk-agent did not become ready at $HealthUrl within 180s. Logs: $LogOut, $LogErr"
+Write-Error "monk-agent did not become ready at $HealthUrl within ${ReadyTimeoutSec}s. Logs: $LogOut, $LogErr"
 exit 1

--- a/plugins/monk/scripts/start-monk-agent.sh
+++ b/plugins/monk/scripts/start-monk-agent.sh
@@ -10,6 +10,18 @@ autospin_url="${MONK_AUTOSPIN_URL:-wss://api.app.monk.io/autospin/}"
 agent_path_env="${PATH:-/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin}"
 script_dir="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
 
+# Host hooks terminate this launcher after 180 seconds. Keep readiness work
+# below that deadline so startup failures can print their own diagnostics.
+ready_timeout="${MONK_AGENT_READY_TIMEOUT:-150}"
+case "$ready_timeout" in
+  ''|*[!0-9]*) ready_timeout=150 ;;
+esac
+if [ "$ready_timeout" -lt 1 ]; then
+  ready_timeout=1
+elif [ "$ready_timeout" -gt 150 ]; then
+  ready_timeout=150
+fi
+
 # Rendered at plugin build time; carries MONK_PLUGIN_VERSION so the agent can
 # report the real plugin version in telemetry. Guarded: an older rendered
 # plugin without the file must still launch (the agent falls back to a labeled
@@ -368,24 +380,25 @@ case "$os" in
   *) start_with_background_process ;;
 esac
 
-tries=0
-while [ "$tries" -lt 180 ]; do
+ready_deadline=$(( $(date +%s) + ready_timeout ))
+while [ "$(date +%s)" -lt "$ready_deadline" ]; do
   if is_running; then
     register_antigravity_mcp
     emit_signin_nudge
     exit 0
   fi
-  # Break early if the background process has exited -- no point waiting 180s.
+  # Break early if the background process has exited -- no point waiting for
+  # the readiness deadline.
   if [ -f "$pid_file" ]; then
     _pid="$(cat "$pid_file" 2>/dev/null || true)"
     if [ -n "$_pid" ] && ! kill -0 "$_pid" 2>/dev/null; then
       break
     fi
   fi
-  tries=$((tries + 1))
+  [ "$(date +%s)" -lt "$ready_deadline" ] || break
   sleep 1
 done
 
-echo "monk-agent did not become ready at $health_url within 180s." >&2
+echo "monk-agent did not become ready at $health_url within ${ready_timeout}s." >&2
 echo "Log: $log_file" >&2
 exit 1

--- a/scripts/start-monk-agent.ps1
+++ b/scripts/start-monk-agent.ps1
@@ -7,6 +7,15 @@ $AuthClientId = if ($env:MONK_AGENT_AUTH_CLIENT_ID) { $env:MONK_AGENT_AUTH_CLIEN
 $AuthAudience = if ($env:MONK_AUTH_AUDIENCE) { $env:MONK_AUTH_AUDIENCE } else { "oaknode.com" }
 $AutospinUrl = if ($env:MONK_AUTOSPIN_URL) { $env:MONK_AUTOSPIN_URL } else { "wss://api.app.monk.io/autospin/" }
 
+# Host hooks terminate this launcher after 180 seconds. Reserve enough time for
+# this script to emit its own startup diagnostics instead of being killed first.
+$ReadyTimeoutSec = 150
+$RequestedReadyTimeout = 0
+if ($env:MONK_AGENT_READY_TIMEOUT -and
+    [int]::TryParse($env:MONK_AGENT_READY_TIMEOUT, [ref]$RequestedReadyTimeout)) {
+  $ReadyTimeoutSec = [Math]::Max(1, [Math]::Min(150, $RequestedReadyTimeout))
+}
+
 $ScriptDir = if ($PSScriptRoot) { $PSScriptRoot } else { Split-Path -Parent $MyInvocation.MyCommand.Path }
 $PluginRoot = if ($env:CLAUDE_PLUGIN_ROOT) { $env:CLAUDE_PLUGIN_ROOT } else { Split-Path -Parent $ScriptDir }
 $InstallDir = if ($env:MONK_AGENT_INSTALL_DIR) { $env:MONK_AGENT_INSTALL_DIR } else { Join-Path $HOME ".monk\bin" }
@@ -271,7 +280,8 @@ $Process = Start-Process `
 
 $Process.Id | Set-Content -NoNewline $PidFile
 
-for ($Attempt = 0; $Attempt -lt 180; $Attempt++) {
+$ReadyTimer = [System.Diagnostics.Stopwatch]::StartNew()
+while ($ReadyTimer.Elapsed.TotalSeconds -lt $ReadyTimeoutSec) {
   if (Test-AgentRunning) {
     Show-SigninNudge
     exit 0
@@ -279,8 +289,11 @@ for ($Attempt = 0; $Attempt -lt 180; $Attempt++) {
   if ($Process.HasExited) {
     break
   }
+  if ($ReadyTimer.Elapsed.TotalSeconds -ge $ReadyTimeoutSec) {
+    break
+  }
   Start-Sleep -Seconds 1
 }
 
-Write-Error "monk-agent did not become ready at $HealthUrl within 180s. Logs: $LogOut, $LogErr"
+Write-Error "monk-agent did not become ready at $HealthUrl within ${ReadyTimeoutSec}s. Logs: $LogOut, $LogErr"
 exit 1

--- a/scripts/start-monk-agent.sh
+++ b/scripts/start-monk-agent.sh
@@ -10,6 +10,18 @@ autospin_url="${MONK_AUTOSPIN_URL:-wss://api.app.monk.io/autospin/}"
 agent_path_env="${PATH:-/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin}"
 script_dir="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
 
+# Host hooks terminate this launcher after 180 seconds. Keep readiness work
+# below that deadline so startup failures can print their own diagnostics.
+ready_timeout="${MONK_AGENT_READY_TIMEOUT:-150}"
+case "$ready_timeout" in
+  ''|*[!0-9]*) ready_timeout=150 ;;
+esac
+if [ "$ready_timeout" -lt 1 ]; then
+  ready_timeout=1
+elif [ "$ready_timeout" -gt 150 ]; then
+  ready_timeout=150
+fi
+
 # Rendered at plugin build time; carries MONK_PLUGIN_VERSION so the agent can
 # report the real plugin version in telemetry. Guarded: an older rendered
 # plugin without the file must still launch (the agent falls back to a labeled
@@ -368,24 +380,25 @@ case "$os" in
   *) start_with_background_process ;;
 esac
 
-tries=0
-while [ "$tries" -lt 180 ]; do
+ready_deadline=$(( $(date +%s) + ready_timeout ))
+while [ "$(date +%s)" -lt "$ready_deadline" ]; do
   if is_running; then
     register_antigravity_mcp
     emit_signin_nudge
     exit 0
   fi
-  # Break early if the background process has exited -- no point waiting 180s.
+  # Break early if the background process has exited -- no point waiting for
+  # the readiness deadline.
   if [ -f "$pid_file" ]; then
     _pid="$(cat "$pid_file" 2>/dev/null || true)"
     if [ -n "$_pid" ] && ! kill -0 "$_pid" 2>/dev/null; then
       break
     fi
   fi
-  tries=$((tries + 1))
+  [ "$(date +%s)" -lt "$ready_deadline" ] || break
   sleep 1
 done
 
-echo "monk-agent did not become ready at $health_url within 180s." >&2
+echo "monk-agent did not become ready at $health_url within ${ready_timeout}s." >&2
 echo "Log: $log_file" >&2
 exit 1

--- a/tests/start-monk-agent-readiness-timeout.ps1
+++ b/tests/start-monk-agent-readiness-timeout.ps1
@@ -1,0 +1,96 @@
+$ErrorActionPreference = "Stop"
+
+$Repo = Split-Path -Parent (Split-Path -Parent $MyInvocation.MyCommand.Path)
+$Root = Join-Path ([IO.Path]::GetTempPath()) ("monk-readiness-" + [guid]::NewGuid().ToString("N"))
+$AgentPath = Join-Path $Root "monk-agent.exe"
+$MonkHome = Join-Path $Root "home"
+$StdoutPath = Join-Path $Root "launcher.out.log"
+$StderrPath = Join-Path $Root "launcher.err.log"
+$PidFile = Join-Path $MonkHome "agent\launcher\run\monk-agent.pid"
+
+$EnvironmentNames = @(
+  "MONK_AGENT_HOME",
+  "MONK_AGENT_INSTALL_DIR",
+  "MONK_AGENT_PATH",
+  "MONK_AGENT_PORT",
+  "MONK_AGENT_READY_TIMEOUT",
+  "MONK_AGENT_SKIP_ENSURE",
+  "MONK_AGENT_SKIP_SIGNIN_NUDGE"
+)
+$OriginalEnvironment = @{}
+foreach ($Name in $EnvironmentNames) {
+  $OriginalEnvironment[$Name] = [Environment]::GetEnvironmentVariable($Name, "Process")
+}
+
+try {
+  New-Item -ItemType Directory -Force -Path $Root | Out-Null
+  Add-Type -TypeDefinition @"
+using System;
+using System.Threading;
+
+public static class Program
+{
+    public static void Main(string[] args)
+    {
+        Thread.Sleep(TimeSpan.FromSeconds(30));
+    }
+}
+"@ -Language CSharp -OutputAssembly $AgentPath -OutputType ConsoleApplication
+
+  $env:MONK_AGENT_HOME = $MonkHome
+  $env:MONK_AGENT_INSTALL_DIR = $Root
+  $env:MONK_AGENT_PATH = $AgentPath
+  $env:MONK_AGENT_PORT = "57419"
+  $env:MONK_AGENT_READY_TIMEOUT = "2"
+  $env:MONK_AGENT_SKIP_ENSURE = "1"
+  $env:MONK_AGENT_SKIP_SIGNIN_NUDGE = "1"
+
+  $PowerShellPath = (Get-Process -Id $PID).Path
+  $LauncherPath = Join-Path $Repo "scripts\start-monk-agent.ps1"
+  $Timer = [Diagnostics.Stopwatch]::StartNew()
+  $Launcher = Start-Process `
+    -FilePath $PowerShellPath `
+    -ArgumentList @("-NoLogo", "-NoProfile", "-File", $LauncherPath) `
+    -PassThru `
+    -Wait `
+    -RedirectStandardOutput $StdoutPath `
+    -RedirectStandardError $StderrPath
+  $Timer.Stop()
+
+  $Output = (Get-Content -Raw $StdoutPath -ErrorAction SilentlyContinue) +
+    (Get-Content -Raw $StderrPath -ErrorAction SilentlyContinue)
+  if ($Launcher.ExitCode -ne 1) {
+    throw "expected launcher exit 1, got $($Launcher.ExitCode): $Output"
+  }
+  if ($Output -notmatch "within 2s") {
+    throw "launcher did not report the configured deadline: $Output"
+  }
+  if ($Timer.Elapsed.TotalSeconds -gt 5) {
+    throw "launcher exceeded bounded test time: $($Timer.Elapsed.TotalSeconds)s"
+  }
+
+  $ShippedCopies = @(
+    ".antigravity-plugin\scripts\start-monk-agent.ps1",
+    "plugins\monk\scripts\start-monk-agent.ps1"
+  )
+  $ExpectedHash = (Get-FileHash -Algorithm SHA256 $LauncherPath).Hash
+  foreach ($RelativePath in $ShippedCopies) {
+    $CopyHash = (Get-FileHash -Algorithm SHA256 (Join-Path $Repo $RelativePath)).Hash
+    if ($CopyHash -ne $ExpectedHash) {
+      throw "generated PowerShell launcher differs: $RelativePath"
+    }
+  }
+
+  Write-Output "readiness_timeout_status=pass elapsed=$([Math]::Round($Timer.Elapsed.TotalSeconds, 2))s"
+} finally {
+  if (Test-Path $PidFile) {
+    $AgentPid = (Get-Content -Raw $PidFile).Trim()
+    if ($AgentPid -match "^[0-9]+$") {
+      Stop-Process -Id ([int]$AgentPid) -Force -ErrorAction SilentlyContinue
+    }
+  }
+  foreach ($Name in $EnvironmentNames) {
+    [Environment]::SetEnvironmentVariable($Name, $OriginalEnvironment[$Name], "Process")
+  }
+  Remove-Item -LiteralPath $Root -Recurse -Force -ErrorAction SilentlyContinue
+}

--- a/tests/start-monk-agent-readiness-timeout.sh
+++ b/tests/start-monk-agent-readiness-timeout.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env sh
+set -eu
+
+repo="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+root="$(mktemp -d)"
+cleanup() {
+  rm -rf "$root"
+}
+trap cleanup EXIT HUP INT TERM
+
+started="$(date +%s)"
+set +e
+output="$(
+  HOME="$root/home" \
+  MONK_AGENT_HOME="$root/monk" \
+  MONK_AGENT_PATH=/usr/bin/true \
+  MONK_AGENT_READY_TIMEOUT=2 \
+  MONK_AGENT_SKIP_SIGNIN_NUDGE=1 \
+  TEST_ROOT="$root" \
+  /bin/sh -c '
+    sleep_calls=0
+    cleanup() {
+      pid_file="$TEST_ROOT/monk/agent/launcher/run/monk-agent.pid"
+      if [ -f "$pid_file" ]; then
+        IFS= read -r child_pid <"$pid_file" || true
+        [ -z "${child_pid:-}" ] || kill "$child_pid" 2>/dev/null || true
+      fi
+      printf "sleep_calls=%s\n" "$sleep_calls"
+    }
+    trap cleanup EXIT HUP INT TERM
+    uname() { printf "%s\n" Linux; }
+    curl() { return 7; }
+    setsid() { /bin/sleep 1000; }
+    sleep() {
+      sleep_calls=$((sleep_calls + 1))
+      /bin/sleep "$1"
+    }
+    . "$0"
+  ' "$repo/scripts/start-monk-agent.sh" 2>&1
+)"
+status=$?
+set -e
+elapsed=$(( $(date +%s) - started ))
+
+[ "$status" -eq 1 ]
+printf '%s\n' "$output" | grep -q 'within 2s'
+sleep_calls="$(printf '%s\n' "$output" | sed -n 's/^sleep_calls=//p')"
+[ -n "$sleep_calls" ]
+[ "$sleep_calls" -le 2 ]
+[ "$elapsed" -le 5 ]
+
+cmp scripts/start-monk-agent.sh plugins/monk/scripts/start-monk-agent.sh
+cmp scripts/start-monk-agent.sh .antigravity-plugin/scripts/start-monk-agent.sh
+cmp scripts/start-monk-agent.ps1 plugins/monk/scripts/start-monk-agent.ps1
+cmp scripts/start-monk-agent.ps1 .antigravity-plugin/scripts/start-monk-agent.ps1
+
+grep -q '\$ReadyTimeoutSec = 150' scripts/start-monk-agent.ps1
+grep -q 'Stopwatch.*StartNew' scripts/start-monk-agent.ps1
+
+printf 'readiness_timeout_status=pass elapsed=%ss sleeps=%s\n' "$elapsed" "$sleep_calls"


### PR DESCRIPTION
## Summary

- bound launcher readiness waits to 150 seconds so the launchers can report their own diagnostics before the 180-second host hook timeout
- measure elapsed time with a PowerShell monotonic `Stopwatch` and a POSIX wall-clock deadline instead of treating retry count as seconds
- clamp the optional `MONK_AGENT_READY_TIMEOUT` override to 1–150 seconds, enabling fast deterministic tests without weakening the production ceiling
- keep all three POSIX and all three PowerShell launcher copies byte-identical
- add isolated readiness-deadline regressions to the existing macOS, Ubuntu, and Windows CI jobs

## Why

Each retry includes a health request that can take up to two seconds plus a one-second sleep. The prior 180-iteration loop therefore consumed at least the entire host timeout and could take roughly 540 seconds when the local endpoint accepted connections but did not respond. The host could terminate SessionStart before users saw the launcher's actionable log paths.

The new loop checks elapsed time again before sleeping, so a live-but-unhealthy companion exits within the configured wall-clock budget and preserves time for the diagnostic to reach the host.

## Validation

- `./tests/start-monk-agent-readiness-timeout.sh` (repeated passes on macOS; 2-second deadline, at most two sleeps, under five seconds total)
- `/bin/sh -n` on the three shipped POSIX launchers and the POSIX regression
- byte parity checks across all generated POSIX and PowerShell launcher copies
- workflow YAML parse
- `git diff --check`
- Windows-native regression added to the `windows-latest` job; it builds an isolated sleeping fixture, asserts exit 1 and the 2-second diagnostic, and cleans up the child process and temporary state

Fixes #52
