### PR TITLE
fix: pass Antigravity MCP fallback inputs as arguments

### DIFF
--- a/.antigravity-plugin/scripts/start-monk-agent.sh
+++ b/.antigravity-plugin/scripts/start-monk-agent.sh
@@ -86,17 +86,18 @@ register_antigravity_mcp() {
     fi
   elif command -v python3 >/dev/null 2>&1; then
     if [ "$has_existing" = "1" ]; then
-      python3 -c "
+      python3 -c '
 import json, sys
-cfg = json.load(open('$mcp_cfg'))
-servers = cfg.get('mcpServers')
+with open(sys.argv[1], encoding="utf-8") as handle:
+    cfg = json.load(handle)
+servers = cfg.get("mcpServers")
 if not isinstance(servers, dict):
     servers = {}
-cfg['mcpServers'] = servers
-servers['monk'] = {'serverUrl': '$server_url'}
+cfg["mcpServers"] = servers
+servers["monk"] = {"serverUrl": sys.argv[2]}
 json.dump(cfg, sys.stdout, indent=2)
 print()
-" >"$tmp"
+' "$mcp_cfg" "$server_url" >"$tmp"
     else
       printf '{"mcpServers":{"monk":{"serverUrl":"%s"}}}\n' "$server_url" >"$tmp"
     fi

--- a/.github/workflows/install-e2e.yml
+++ b/.github/workflows/install-e2e.yml
@@ -27,6 +27,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Test launcher fallbacks
+        shell: bash
+        run: ./tests/start-monk-agent-antigravity-python-path.sh
+
       - name: Install monk-agent
         shell: bash
         env:

--- a/plugins/monk/scripts/start-monk-agent.sh
+++ b/plugins/monk/scripts/start-monk-agent.sh
@@ -86,17 +86,18 @@ register_antigravity_mcp() {
     fi
   elif command -v python3 >/dev/null 2>&1; then
     if [ "$has_existing" = "1" ]; then
-      python3 -c "
+      python3 -c '
 import json, sys
-cfg = json.load(open('$mcp_cfg'))
-servers = cfg.get('mcpServers')
+with open(sys.argv[1], encoding="utf-8") as handle:
+    cfg = json.load(handle)
+servers = cfg.get("mcpServers")
 if not isinstance(servers, dict):
     servers = {}
-cfg['mcpServers'] = servers
-servers['monk'] = {'serverUrl': '$server_url'}
+cfg["mcpServers"] = servers
+servers["monk"] = {"serverUrl": sys.argv[2]}
 json.dump(cfg, sys.stdout, indent=2)
 print()
-" >"$tmp"
+' "$mcp_cfg" "$server_url" >"$tmp"
     else
       printf '{"mcpServers":{"monk":{"serverUrl":"%s"}}}\n' "$server_url" >"$tmp"
     fi

--- a/scripts/start-monk-agent.sh
+++ b/scripts/start-monk-agent.sh
@@ -86,17 +86,18 @@ register_antigravity_mcp() {
     fi
   elif command -v python3 >/dev/null 2>&1; then
     if [ "$has_existing" = "1" ]; then
-      python3 -c "
+      python3 -c '
 import json, sys
-cfg = json.load(open('$mcp_cfg'))
-servers = cfg.get('mcpServers')
+with open(sys.argv[1], encoding="utf-8") as handle:
+    cfg = json.load(handle)
+servers = cfg.get("mcpServers")
 if not isinstance(servers, dict):
     servers = {}
-cfg['mcpServers'] = servers
-servers['monk'] = {'serverUrl': '$server_url'}
+cfg["mcpServers"] = servers
+servers["monk"] = {"serverUrl": sys.argv[2]}
 json.dump(cfg, sys.stdout, indent=2)
 print()
-" >"$tmp"
+' "$mcp_cfg" "$server_url" >"$tmp"
     else
       printf '{"mcpServers":{"monk":{"serverUrl":"%s"}}}\n' "$server_url" >"$tmp"
     fi

--- a/tests/fixtures/start-monk-agent/curl
+++ b/tests/fixtures/start-monk-agent/curl
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+set -eu
+
+printf '%s\n' '{"resource":"http://127.0.0.1:7419/mcp"}'

--- a/tests/fixtures/start-monk-agent/uname
+++ b/tests/fixtures/start-monk-agent/uname
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+set -eu
+
+printf '%s\n' Linux

--- a/tests/start-monk-agent-antigravity-python-path.sh
+++ b/tests/start-monk-agent-antigravity-python-path.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env sh
+set -eu
+
+repo_root="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT HUP INT TERM
+
+fake_bin="$tmp/bin"
+mkdir -p "$fake_bin"
+
+for command_name in dirname grep mkdir mktemp mv python3 sh tr; do
+  command_path="$(command -v "$command_name")"
+  ln -s "$command_path" "$fake_bin/$command_name"
+done
+
+ln -s "$repo_root/tests/fixtures/start-monk-agent/curl" "$fake_bin/curl"
+ln -s "$repo_root/tests/fixtures/start-monk-agent/uname" "$fake_bin/uname"
+
+for launcher in \
+  scripts/start-monk-agent.sh \
+  plugins/monk/scripts/start-monk-agent.sh \
+  .antigravity-plugin/scripts/start-monk-agent.sh
+do
+  launcher_name="$(printf '%s' "$launcher" | tr '/.' '__')"
+  home="$tmp/$launcher_name/O'Connor"
+  config="$home/.gemini/config/mcp_config.json"
+  mkdir -p "$(dirname "$config")"
+  printf '%s\n' '{"mcpServers":{},"preserved":{"value":"still here"}}' >"$config"
+
+  HOME="$home" \
+  PATH="$fake_bin" \
+  MONK_AGENT_HOME="$home/.monk" \
+  MONK_AGENT_PATH=/usr/bin/true \
+  MONK_AGENT_SKIP_SIGNIN_NUDGE=1 \
+    "$repo_root/$launcher"
+
+  python3 - "$config" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    config = json.load(handle)
+
+assert config["mcpServers"]["monk"]["serverUrl"] == "http://127.0.0.1:7419/mcp"
+assert config["preserved"] == {"value": "still here"}
+PY
+done
+
+cmp "$repo_root/scripts/start-monk-agent.sh" \
+  "$repo_root/plugins/monk/scripts/start-monk-agent.sh"
+cmp "$repo_root/scripts/start-monk-agent.sh" \
+  "$repo_root/.antigravity-plugin/scripts/start-monk-agent.sh"
+
+echo "Antigravity Python fallback handles apostrophes in all rendered launchers"


### PR DESCRIPTION
## Summary

- pass the Antigravity config path and server URL to Python through `sys.argv` instead of interpolating them into generated Python source
- apply the fix to all three rendered launcher copies
- add a network-free regression that exercises every rendered launcher with an apostrophe-containing config path and verifies existing JSON is preserved
- run the regression in the Ubuntu/macOS install workflow and enforce rendered-copy parity

Fixes #26

## Validation

- `./tests/start-monk-agent-antigravity-python-path.sh` (5 consecutive passes)
- `sh -n` on the changed launchers and new shell fixtures
- byte-for-byte parity checks for all three rendered launchers
- workflow YAML parse
- `git diff --check`
