### PR TITLE
fix: reject zero-byte Windows agent installs

### DIFF
--- a/.antigravity-plugin/scripts/ensure-monk-agent.ps1
+++ b/.antigravity-plugin/scripts/ensure-monk-agent.ps1
@@ -38,6 +38,19 @@ function Get-FileSha256 {
   return ([System.BitConverter]::ToString($Hash) -replace "-", "").ToLowerInvariant()
 }
 
+function Test-NonEmptyFile {
+  param([string]$Path)
+  if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+    return $false
+  }
+
+  try {
+    return ((Get-Item -LiteralPath $Path).Length -gt 0)
+  } catch {
+    return $false
+  }
+}
+
 function Stop-ManagedAgent {
   if (-not (Test-Path $PidFile)) {
     return
@@ -84,12 +97,12 @@ function Stop-ManagedAgent {
 
 if ($AutoUpdate -eq "0" -or $AutoUpdate -eq "false") {
   $Existing = Get-Command monk-agent.exe -ErrorAction SilentlyContinue
-  if ($Existing) {
+  if ($Existing -and (Test-NonEmptyFile $Existing.Source)) {
     Write-Output $Existing.Source
     exit 0
   }
 
-  if (Test-Path $Target) {
+  if (Test-NonEmptyFile $Target) {
     Write-Output $Target
     exit 0
   }
@@ -115,7 +128,7 @@ Invoke-WebRequest -Uri $ChecksumUrl -OutFile $ChecksumTmp
 
 $Expected = ((Get-Content -Raw $ChecksumTmp).Trim() -split "\s+")[0].ToLowerInvariant()
 
-if ((Test-Path $Target) -and (Test-Path $ChecksumInstalled)) {
+if ((Test-NonEmptyFile $Target) -and (Test-Path $ChecksumInstalled)) {
   $Installed = ((Get-Content -Raw $ChecksumInstalled).Trim() -split "\s+")[0].ToLowerInvariant()
   if ($Installed -eq $Expected) {
     Remove-Item -Force $ChecksumTmp
@@ -140,6 +153,10 @@ New-Item -ItemType Directory -Force -Path $ExtractDir | Out-Null
 Expand-Archive -Force -Path $ArchiveTmp -DestinationPath $ExtractDir
 Stop-ManagedAgent
 Move-Item -Force (Join-Path $ExtractDir "monk-agent.exe") $Target
+if (-not (Test-NonEmptyFile $Target)) {
+  Write-Error "Downloaded monk-agent executable is empty or missing after extraction."
+  exit 1
+}
 "$Expected  $Artifact" | Set-Content -NoNewline $ChecksumInstalled
 Remove-Item -Recurse -Force $ExtractDir
 Remove-Item -Force $ArchiveTmp, $ChecksumTmp

--- a/plugins/monk/scripts/ensure-monk-agent.ps1
+++ b/plugins/monk/scripts/ensure-monk-agent.ps1
@@ -38,6 +38,19 @@ function Get-FileSha256 {
   return ([System.BitConverter]::ToString($Hash) -replace "-", "").ToLowerInvariant()
 }
 
+function Test-NonEmptyFile {
+  param([string]$Path)
+  if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+    return $false
+  }
+
+  try {
+    return ((Get-Item -LiteralPath $Path).Length -gt 0)
+  } catch {
+    return $false
+  }
+}
+
 function Stop-ManagedAgent {
   if (-not (Test-Path $PidFile)) {
     return
@@ -84,12 +97,12 @@ function Stop-ManagedAgent {
 
 if ($AutoUpdate -eq "0" -or $AutoUpdate -eq "false") {
   $Existing = Get-Command monk-agent.exe -ErrorAction SilentlyContinue
-  if ($Existing) {
+  if ($Existing -and (Test-NonEmptyFile $Existing.Source)) {
     Write-Output $Existing.Source
     exit 0
   }
 
-  if (Test-Path $Target) {
+  if (Test-NonEmptyFile $Target) {
     Write-Output $Target
     exit 0
   }
@@ -115,7 +128,7 @@ Invoke-WebRequest -Uri $ChecksumUrl -OutFile $ChecksumTmp
 
 $Expected = ((Get-Content -Raw $ChecksumTmp).Trim() -split "\s+")[0].ToLowerInvariant()
 
-if ((Test-Path $Target) -and (Test-Path $ChecksumInstalled)) {
+if ((Test-NonEmptyFile $Target) -and (Test-Path $ChecksumInstalled)) {
   $Installed = ((Get-Content -Raw $ChecksumInstalled).Trim() -split "\s+")[0].ToLowerInvariant()
   if ($Installed -eq $Expected) {
     Remove-Item -Force $ChecksumTmp
@@ -140,6 +153,10 @@ New-Item -ItemType Directory -Force -Path $ExtractDir | Out-Null
 Expand-Archive -Force -Path $ArchiveTmp -DestinationPath $ExtractDir
 Stop-ManagedAgent
 Move-Item -Force (Join-Path $ExtractDir "monk-agent.exe") $Target
+if (-not (Test-NonEmptyFile $Target)) {
+  Write-Error "Downloaded monk-agent executable is empty or missing after extraction."
+  exit 1
+}
 "$Expected  $Artifact" | Set-Content -NoNewline $ChecksumInstalled
 Remove-Item -Recurse -Force $ExtractDir
 Remove-Item -Force $ArchiveTmp, $ChecksumTmp

--- a/scripts/ensure-monk-agent.ps1
+++ b/scripts/ensure-monk-agent.ps1
@@ -38,6 +38,19 @@ function Get-FileSha256 {
   return ([System.BitConverter]::ToString($Hash) -replace "-", "").ToLowerInvariant()
 }
 
+function Test-NonEmptyFile {
+  param([string]$Path)
+  if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+    return $false
+  }
+
+  try {
+    return ((Get-Item -LiteralPath $Path).Length -gt 0)
+  } catch {
+    return $false
+  }
+}
+
 function Stop-ManagedAgent {
   if (-not (Test-Path $PidFile)) {
     return
@@ -84,12 +97,12 @@ function Stop-ManagedAgent {
 
 if ($AutoUpdate -eq "0" -or $AutoUpdate -eq "false") {
   $Existing = Get-Command monk-agent.exe -ErrorAction SilentlyContinue
-  if ($Existing) {
+  if ($Existing -and (Test-NonEmptyFile $Existing.Source)) {
     Write-Output $Existing.Source
     exit 0
   }
 
-  if (Test-Path $Target) {
+  if (Test-NonEmptyFile $Target) {
     Write-Output $Target
     exit 0
   }
@@ -115,7 +128,7 @@ Invoke-WebRequest -Uri $ChecksumUrl -OutFile $ChecksumTmp
 
 $Expected = ((Get-Content -Raw $ChecksumTmp).Trim() -split "\s+")[0].ToLowerInvariant()
 
-if ((Test-Path $Target) -and (Test-Path $ChecksumInstalled)) {
+if ((Test-NonEmptyFile $Target) -and (Test-Path $ChecksumInstalled)) {
   $Installed = ((Get-Content -Raw $ChecksumInstalled).Trim() -split "\s+")[0].ToLowerInvariant()
   if ($Installed -eq $Expected) {
     Remove-Item -Force $ChecksumTmp
@@ -140,6 +153,10 @@ New-Item -ItemType Directory -Force -Path $ExtractDir | Out-Null
 Expand-Archive -Force -Path $ArchiveTmp -DestinationPath $ExtractDir
 Stop-ManagedAgent
 Move-Item -Force (Join-Path $ExtractDir "monk-agent.exe") $Target
+if (-not (Test-NonEmptyFile $Target)) {
+  Write-Error "Downloaded monk-agent executable is empty or missing after extraction."
+  exit 1
+}
 "$Expected  $Artifact" | Set-Content -NoNewline $ChecksumInstalled
 Remove-Item -Recurse -Force $ExtractDir
 Remove-Item -Force $ArchiveTmp, $ChecksumTmp

--- a/tests/ensure-monk-agent-windows-zero-byte.ps1
+++ b/tests/ensure-monk-agent-windows-zero-byte.ps1
@@ -1,0 +1,89 @@
+param(
+  [string]$RepoRoot = (Split-Path -Parent $PSScriptRoot)
+)
+
+$ErrorActionPreference = "Stop"
+$WindowsPowerShell = Join-Path $env:SystemRoot "System32\WindowsPowerShell\v1.0\powershell.exe"
+$EnsureScript = Join-Path $RepoRoot "scripts\ensure-monk-agent.ps1"
+$TempRoot = Join-Path ([IO.Path]::GetTempPath()) ("monk-zero-byte-agent-test-" + [guid]::NewGuid())
+$InstallDir = Join-Path $TempRoot "install"
+$Target = Join-Path $InstallDir "monk-agent.exe"
+$Sidecar = Join-Path $InstallDir "monk-agent.sha256"
+$WrapperScript = Join-Path $TempRoot "run-ensure-with-stubs.ps1"
+$RequestLog = Join-Path $TempRoot "requests.log"
+$ArchiveBytes = [Text.Encoding]::UTF8.GetBytes("fake monk-agent archive")
+$Expected = ([System.BitConverter]::ToString(
+  [System.Security.Cryptography.SHA256]::Create().ComputeHash($ArchiveBytes)
+) -replace "-", "").ToLowerInvariant()
+
+$PreviousInstallDir = $env:MONK_AGENT_INSTALL_DIR
+$PreviousDownloadBase = $env:MONK_AGENT_DOWNLOAD_BASE
+$PreviousPath = $env:Path
+
+try {
+  New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
+  [IO.File]::WriteAllBytes($Target, [byte[]]@())
+  [IO.File]::WriteAllText($Sidecar, ("{0}  monk-agent-windows-latest.zip" -f $Expected))
+
+  @'
+param(
+  [string]$EnsureScript,
+  [string]$RequestLog,
+  [string]$Expected
+)
+
+$ErrorActionPreference = "Stop"
+
+function global:Invoke-WebRequest {
+  param([string]$Uri, [string]$OutFile)
+  Add-Content -Path $RequestLog -Value $Uri
+  if ($Uri.EndsWith(".sha256", [StringComparison]::Ordinal)) {
+    [IO.File]::WriteAllText($OutFile, ("{0}  monk-agent-windows-latest.zip" -f $Expected))
+    return
+  }
+  [IO.File]::WriteAllBytes($OutFile, [Text.Encoding]::UTF8.GetBytes("fake monk-agent archive"))
+}
+
+function global:Expand-Archive {
+  param([string]$Path, [string]$DestinationPath, [switch]$Force)
+  New-Item -ItemType Directory -Force -Path $DestinationPath | Out-Null
+  [IO.File]::WriteAllBytes((Join-Path $DestinationPath "monk-agent.exe"), [Text.Encoding]::UTF8.GetBytes("fake exe"))
+}
+
+& $EnsureScript
+'@ | Set-Content -Encoding UTF8 $WrapperScript
+
+  $env:MONK_AGENT_INSTALL_DIR = $InstallDir
+  $env:MONK_AGENT_DOWNLOAD_BASE = "https://example.invalid/monk"
+  $env:Path = Split-Path -Parent $WindowsPowerShell
+
+  $Output = & $WindowsPowerShell -NoProfile -ExecutionPolicy Bypass -File $WrapperScript `
+    -EnsureScript $EnsureScript `
+    -RequestLog $RequestLog `
+    -Expected $Expected
+  if ($LASTEXITCODE -ne 0) {
+    throw "ensure script exited with code $LASTEXITCODE. Output: $Output"
+  }
+  if (($Output | Select-Object -Last 1) -ne $Target) {
+    throw "Expected ensure script to output target path '$Target'. Output: $Output"
+  }
+
+  $Requests = if (Test-Path $RequestLog) { @(Get-Content -Path $RequestLog) } else { @() }
+  $ArchiveRequests = @($Requests | Where-Object {
+    $_ -like "*/monk-agent-windows-latest.zip"
+  })
+  if ($ArchiveRequests.Count -ne 1) {
+    throw "Expected one archive download after rejecting zero-byte target; saw $($ArchiveRequests.Count). Requests: $($Requests -join ', ')"
+  }
+
+  if ((Get-Item -LiteralPath $Target).Length -le 0) {
+    throw "Expected target to be replaced with a non-empty monk-agent.exe"
+  }
+} finally {
+  $env:MONK_AGENT_INSTALL_DIR = $PreviousInstallDir
+  $env:MONK_AGENT_DOWNLOAD_BASE = $PreviousDownloadBase
+  $env:Path = $PreviousPath
+  Remove-Item -Recurse -Force $TempRoot -ErrorAction SilentlyContinue
+}
+
+Write-Host "Windows zero-byte monk-agent recovery test passed."


### PR DESCRIPTION
## Summary

- Reject zero-byte `monk-agent.exe` files in the Windows PowerShell bootstrap fast paths.
- Require a non-empty target before accepting a matching installed checksum sidecar.
- Verify the extracted Windows agent is non-empty before recording the installed checksum.
- Add a network-free Windows regression test for the zero-byte target + current sidecar case.

## Root cause and impact

The PowerShell installer treated the archive checksum sidecar as sufficient proof that the installed Windows agent was current. If `monk-agent.exe` was truncated to zero bytes while `monk-agent.sha256` still matched the current archive, the bootstrap exited successfully, printed the invalid target path, and never requested the replacement archive.

This leaves the Windows plugin path stuck on a broken managed executable until a checksum changes or the user manually deletes the files.

## Scope

PR #84 addresses the shell implementation for #23. This PR is scoped to the separate PowerShell implementation reported in #115 and keeps the three public PowerShell script copies consistent.

## Validation

- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests\ensure-monk-agent-windows-zero-byte.ps1` — pass
- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests\block-monk-windows.ps1` — pass
- `git diff --check` — pass

Fixes #115

Prepared with Codex assistance and validated locally on Windows.
