### PR TITLE
fix: verify Monk health resource identity

### DIFF
--- a/.antigravity-plugin/hooks/ensure-monk-agent.ps1
+++ b/.antigravity-plugin/hooks/ensure-monk-agent.ps1
@@ -19,6 +19,7 @@ if (Get-Command bash -ErrorAction SilentlyContinue) { exit 0 }
 $Port = if ($env:MONK_AGENT_PORT) { $env:MONK_AGENT_PORT } else { "7419" }
 $AgentHost = if ($env:MONK_AGENT_HOST) { $env:MONK_AGENT_HOST } else { "127.0.0.1" }
 $HealthUrl = "http://${AgentHost}:$Port/.well-known/oauth-protected-resource"
+$HealthResource = "http://${AgentHost}:$Port/mcp"
 
 function Write-Json {
   param([object]$Object)
@@ -28,7 +29,8 @@ function Write-Json {
 function Test-AgentRunning {
   try {
     $Response = Invoke-WebRequest -Uri $HealthUrl -UseBasicParsing -TimeoutSec 2
-    return $Response.Content -match '"resource"'
+    $Document = $Response.Content | ConvertFrom-Json -ErrorAction Stop
+    return [string]$Document.resource -ceq $HealthResource
   } catch {
     return $false
   }

--- a/.antigravity-plugin/hooks/ensure-monk-agent.sh
+++ b/.antigravity-plugin/hooks/ensure-monk-agent.sh
@@ -12,17 +12,18 @@ set -eu
 port="${MONK_AGENT_PORT:-7419}"
 host="${MONK_AGENT_HOST:-127.0.0.1}"
 health_url="http://$host:$port/.well-known/oauth-protected-resource"
+health_resource="http://$host:$port/mcp"
 
 is_running() {
   if command -v curl >/dev/null 2>&1; then
-    curl -fsS --max-time 2 "$health_url" 2>/dev/null | grep -q '"resource"'
-    return $?
+    response="$(curl -fsS --max-time 2 "$health_url" 2>/dev/null)" || return 1
+  elif command -v wget >/dev/null 2>&1; then
+    response="$(wget -q -T 2 -O - "$health_url" 2>/dev/null)" || return 1
+  else
+    return 1
   fi
-  if command -v wget >/dev/null 2>&1; then
-    wget -q -T 2 -O - "$health_url" 2>/dev/null | grep -q '"resource"'
-    return $?
-  fi
-  return 1
+  resource="$(printf '%s\n' "$response" | sed -n 's/.*"resource"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -n 1)"
+  [ "$resource" = "$health_resource" ]
 }
 
 # Emit an Antigravity injectSteps payload carrying a single ephemeral message.

--- a/.antigravity-plugin/scripts/start-monk-agent.ps1
+++ b/.antigravity-plugin/scripts/start-monk-agent.ps1
@@ -28,6 +28,7 @@ $LogOut = Join-Path $LogDir "monk-agent.out.log"
 $LogErr = Join-Path $LogDir "monk-agent.err.log"
 $PidFile = Join-Path $RunDir "monk-agent.pid"
 $HealthUrl = "http://${AgentHost}:$Port/.well-known/oauth-protected-resource"
+$HealthResource = "http://${AgentHost}:$Port/mcp"
 
 New-Item -ItemType Directory -Force -Path $LogDir, $RunDir | Out-Null
 
@@ -50,7 +51,8 @@ $IdeVersion = if ($env:CURSOR_VERSION) { $env:CURSOR_VERSION } else { "" }
 function Test-AgentRunning {
   try {
     $Response = Invoke-WebRequest -Uri $HealthUrl -UseBasicParsing -TimeoutSec 2
-    return $Response.Content -match '"resource"'
+    $Document = $Response.Content | ConvertFrom-Json -ErrorAction Stop
+    return [string]$Document.resource -ceq $HealthResource
   } catch {
     return $false
   }

--- a/.antigravity-plugin/scripts/start-monk-agent.sh
+++ b/.antigravity-plugin/scripts/start-monk-agent.sh
@@ -64,6 +64,7 @@ fi
 ide_version="${CURSOR_VERSION:-}"
 
 health_url="http://$host:$port/.well-known/oauth-protected-resource"
+health_resource="http://$host:$port/mcp"
 
 # Register monk in Antigravity's global MCP config if ~/.gemini/config/ exists.
 # Idempotent — skips if already registered. Uses jq when available; prints
@@ -172,15 +173,16 @@ emit_signin_nudge() {
 }
 
 is_running() {
+  response=""
   if command -v curl >/dev/null 2>&1; then
-    curl -fsS --max-time 2 "$health_url" 2>/dev/null | grep -q '"resource"'
-    return $?
+    response="$(curl -fsS --max-time 2 "$health_url" 2>/dev/null)" || return 1
+  elif command -v wget >/dev/null 2>&1; then
+    response="$(wget -q -T 2 -O - "$health_url" 2>/dev/null)" || return 1
+  else
+    return 1
   fi
-  if command -v wget >/dev/null 2>&1; then
-    wget -q -T 2 -O - "$health_url" 2>/dev/null | grep -q '"resource"'
-    return $?
-  fi
-  return 1
+  resource="$(printf '%s\n' "$response" | sed -n 's/.*"resource"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -n 1)"
+  [ "$resource" = "$health_resource" ]
 }
 
 hash_file() {

--- a/.github/workflows/install-e2e.yml
+++ b/.github/workflows/install-e2e.yml
@@ -38,6 +38,10 @@ jobs:
           test "$installed" = "$MONK_AGENT_INSTALL_DIR/monk-agent"
           test -x "$installed"
 
+      - name: Verify launcher health resource identity
+        shell: bash
+        run: sh tests/start-monk-agent-health-identity.sh
+
       - name: Run monk-agent status
         shell: bash
         env:
@@ -79,6 +83,10 @@ jobs:
           if (-not (Test-Path $installed)) {
             throw "monk-agent.exe was not installed"
           }
+
+      - name: Verify launcher health resource identity
+        shell: pwsh
+        run: .\tests\start-monk-agent-health-identity.ps1 -AgentPath "$env:RUNNER_TEMP\monk-bin\monk-agent.exe"
 
       - name: Run monk-agent status
         shell: pwsh

--- a/plugins/monk/scripts/start-monk-agent.ps1
+++ b/plugins/monk/scripts/start-monk-agent.ps1
@@ -28,6 +28,7 @@ $LogOut = Join-Path $LogDir "monk-agent.out.log"
 $LogErr = Join-Path $LogDir "monk-agent.err.log"
 $PidFile = Join-Path $RunDir "monk-agent.pid"
 $HealthUrl = "http://${AgentHost}:$Port/.well-known/oauth-protected-resource"
+$HealthResource = "http://${AgentHost}:$Port/mcp"
 
 New-Item -ItemType Directory -Force -Path $LogDir, $RunDir | Out-Null
 
@@ -50,7 +51,8 @@ $IdeVersion = if ($env:CURSOR_VERSION) { $env:CURSOR_VERSION } else { "" }
 function Test-AgentRunning {
   try {
     $Response = Invoke-WebRequest -Uri $HealthUrl -UseBasicParsing -TimeoutSec 2
-    return $Response.Content -match '"resource"'
+    $Document = $Response.Content | ConvertFrom-Json -ErrorAction Stop
+    return [string]$Document.resource -ceq $HealthResource
   } catch {
     return $false
   }

--- a/plugins/monk/scripts/start-monk-agent.sh
+++ b/plugins/monk/scripts/start-monk-agent.sh
@@ -64,6 +64,7 @@ fi
 ide_version="${CURSOR_VERSION:-}"
 
 health_url="http://$host:$port/.well-known/oauth-protected-resource"
+health_resource="http://$host:$port/mcp"
 
 # Register monk in Antigravity's global MCP config if ~/.gemini/config/ exists.
 # Idempotent — skips if already registered. Uses jq when available; prints
@@ -172,15 +173,16 @@ emit_signin_nudge() {
 }
 
 is_running() {
+  response=""
   if command -v curl >/dev/null 2>&1; then
-    curl -fsS --max-time 2 "$health_url" 2>/dev/null | grep -q '"resource"'
-    return $?
+    response="$(curl -fsS --max-time 2 "$health_url" 2>/dev/null)" || return 1
+  elif command -v wget >/dev/null 2>&1; then
+    response="$(wget -q -T 2 -O - "$health_url" 2>/dev/null)" || return 1
+  else
+    return 1
   fi
-  if command -v wget >/dev/null 2>&1; then
-    wget -q -T 2 -O - "$health_url" 2>/dev/null | grep -q '"resource"'
-    return $?
-  fi
-  return 1
+  resource="$(printf '%s\n' "$response" | sed -n 's/.*"resource"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -n 1)"
+  [ "$resource" = "$health_resource" ]
 }
 
 hash_file() {

--- a/scripts/start-monk-agent.ps1
+++ b/scripts/start-monk-agent.ps1
@@ -28,6 +28,7 @@ $LogOut = Join-Path $LogDir "monk-agent.out.log"
 $LogErr = Join-Path $LogDir "monk-agent.err.log"
 $PidFile = Join-Path $RunDir "monk-agent.pid"
 $HealthUrl = "http://${AgentHost}:$Port/.well-known/oauth-protected-resource"
+$HealthResource = "http://${AgentHost}:$Port/mcp"
 
 New-Item -ItemType Directory -Force -Path $LogDir, $RunDir | Out-Null
 
@@ -50,7 +51,8 @@ $IdeVersion = if ($env:CURSOR_VERSION) { $env:CURSOR_VERSION } else { "" }
 function Test-AgentRunning {
   try {
     $Response = Invoke-WebRequest -Uri $HealthUrl -UseBasicParsing -TimeoutSec 2
-    return $Response.Content -match '"resource"'
+    $Document = $Response.Content | ConvertFrom-Json -ErrorAction Stop
+    return [string]$Document.resource -ceq $HealthResource
   } catch {
     return $false
   }

--- a/scripts/start-monk-agent.sh
+++ b/scripts/start-monk-agent.sh
@@ -64,6 +64,7 @@ fi
 ide_version="${CURSOR_VERSION:-}"
 
 health_url="http://$host:$port/.well-known/oauth-protected-resource"
+health_resource="http://$host:$port/mcp"
 
 # Register monk in Antigravity's global MCP config if ~/.gemini/config/ exists.
 # Idempotent — skips if already registered. Uses jq when available; prints
@@ -172,15 +173,16 @@ emit_signin_nudge() {
 }
 
 is_running() {
+  response=""
   if command -v curl >/dev/null 2>&1; then
-    curl -fsS --max-time 2 "$health_url" 2>/dev/null | grep -q '"resource"'
-    return $?
+    response="$(curl -fsS --max-time 2 "$health_url" 2>/dev/null)" || return 1
+  elif command -v wget >/dev/null 2>&1; then
+    response="$(wget -q -T 2 -O - "$health_url" 2>/dev/null)" || return 1
+  else
+    return 1
   fi
-  if command -v wget >/dev/null 2>&1; then
-    wget -q -T 2 -O - "$health_url" 2>/dev/null | grep -q '"resource"'
-    return $?
-  fi
-  return 1
+  resource="$(printf '%s\n' "$response" | sed -n 's/.*"resource"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -n 1)"
+  [ "$resource" = "$health_resource" ]
 }
 
 hash_file() {

--- a/tests/start-monk-agent-health-identity.ps1
+++ b/tests/start-monk-agent-health-identity.ps1
@@ -1,0 +1,107 @@
+param(
+  [Parameter(Mandatory = $true)]
+  [string]$AgentPath,
+  [string]$RepoRoot
+)
+
+$ErrorActionPreference = "Stop"
+if (-not $RepoRoot) {
+  $RepoRoot = Split-Path -Parent $PSScriptRoot
+}
+$TempRoot = Join-Path ([IO.Path]::GetTempPath()) ("monk-health-identity-" + [guid]::NewGuid())
+$InstallDir = Join-Path $TempRoot "bin"
+$AgentHome = Join-Path $TempRoot "home"
+$Launcher = Join-Path $RepoRoot "scripts\start-monk-agent.ps1"
+$ManagedAgent = Join-Path $InstallDir "monk-agent.exe"
+$PidFile = Join-Path $AgentHome "agent\launcher\run\monk-agent.pid"
+$Wrapper = Join-Path $TempRoot "run-launcher.ps1"
+$Port = "17425"
+$ExpectedResource = "http://127.0.0.1:$Port/mcp"
+$Previous = @{}
+$Names = @(
+  "MONK_AGENT_HOME",
+  "MONK_AGENT_INSTALL_DIR",
+  "MONK_AGENT_PORT",
+  "MONK_AGENT_SKIP_ENSURE",
+  "MONK_AGENT_SKIP_SIGNIN_NUDGE",
+  "MONK_AGENT_DEV",
+  "MONK_AGENT_SIMULATE_AUTH",
+  "MONK_AGENT_MOCK_RUNTIME",
+  "MONK_AGENT_VAULT_BACKEND",
+  "MONK_AGENT_STORE",
+  "MONK_AGENT_OPEN_BROWSER",
+  "MONK_TELEMETRY",
+  "TEST_LAUNCHER",
+  "TEST_PID_FILE",
+  "TEST_EXPECTED_RESOURCE"
+)
+
+foreach ($Name in $Names) {
+  $Previous[$Name] = [Environment]::GetEnvironmentVariable($Name)
+}
+
+try {
+  if (-not (Test-Path -LiteralPath $AgentPath)) {
+    throw "monk-agent test executable not found: $AgentPath"
+  }
+
+  New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
+  Copy-Item -LiteralPath $AgentPath -Destination $ManagedAgent
+
+  @'
+$ErrorActionPreference = "Stop"
+$PidFile = $env:TEST_PID_FILE
+function global:Invoke-WebRequest {
+  param(
+    [string]$Uri,
+    [switch]$UseBasicParsing,
+    [int]$TimeoutSec
+  )
+  if (Test-Path -LiteralPath $PidFile) {
+    return [pscustomobject]@{ Content = ('{{"resource":"{0}"}}' -f $env:TEST_EXPECTED_RESOURCE) }
+  }
+  return [pscustomobject]@{ Content = '{"resource":"http://127.0.0.1:9999/not-monk"}' }
+}
+& $env:TEST_LAUNCHER
+'@ | Set-Content -LiteralPath $Wrapper
+
+  $env:MONK_AGENT_HOME = $AgentHome
+  $env:MONK_AGENT_INSTALL_DIR = $InstallDir
+  $env:MONK_AGENT_PORT = $Port
+  $env:MONK_AGENT_SKIP_ENSURE = "1"
+  $env:MONK_AGENT_SKIP_SIGNIN_NUDGE = "1"
+  $env:MONK_AGENT_DEV = "1"
+  $env:MONK_AGENT_SIMULATE_AUTH = "1"
+  $env:MONK_AGENT_MOCK_RUNTIME = "1"
+  $env:MONK_AGENT_VAULT_BACKEND = "file"
+  $env:MONK_AGENT_STORE = "file"
+  $env:MONK_AGENT_OPEN_BROWSER = "0"
+  $env:MONK_TELEMETRY = "0"
+  $env:TEST_LAUNCHER = $Launcher
+  $env:TEST_PID_FILE = $PidFile
+  $env:TEST_EXPECTED_RESOURCE = $ExpectedResource
+
+  & powershell.exe -NoProfile -ExecutionPolicy Bypass -File $Wrapper
+  if ($LASTEXITCODE -ne 0) {
+    throw "launcher subprocess failed with exit code $LASTEXITCODE"
+  }
+  if (-not (Test-Path -LiteralPath $PidFile)) {
+    throw "launcher accepted an unrelated resource without starting monk-agent"
+  }
+
+  $AgentPid = [int](Get-Content -Raw -LiteralPath $PidFile)
+  $Process = Get-Process -Id $AgentPid -ErrorAction Stop
+  if ($Process.HasExited) {
+    throw "launcher-created monk-agent exited before identity validation completed"
+  }
+} finally {
+  if ($AgentPid) {
+    Stop-Process -Id $AgentPid -Force -ErrorAction SilentlyContinue
+  }
+  foreach ($Name in $Names) {
+    [Environment]::SetEnvironmentVariable($Name, $Previous[$Name])
+  }
+  Remove-Item -LiteralPath $TempRoot -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+Write-Host "Windows launcher rejects an unrelated health resource."

--- a/tests/start-monk-agent-health-identity.sh
+++ b/tests/start-monk-agent-health-identity.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env sh
+set -eu
+
+repo_root="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+launcher_root="${MONK_LAUNCHER_ROOT:-$repo_root}"
+tmp="$(mktemp -d)"
+home="$tmp/home"
+fake_bin="$tmp/bin"
+fake_agent="$home/.monk/bin/monk-agent"
+started="$tmp/agent-started"
+pid_file="$home/.monk/agent/launcher/run/monk-agent.pid"
+
+cleanup() {
+  if [ -f "$pid_file" ]; then
+    pid="$(sed -n '1p' "$pid_file" 2>/dev/null || true)"
+    [ -z "$pid" ] || kill "$pid" >/dev/null 2>&1 || true
+  fi
+  rm -rf "$tmp"
+}
+trap cleanup EXIT HUP INT TERM
+
+mkdir -p "$home/.monk/agent/launcher/run" "$home/.monk/bin" "$fake_bin"
+
+{
+  printf '%s\n' '#!/usr/bin/env sh'
+  printf '%s\n' 'printf "%s\n" Linux'
+} >"$fake_bin/uname"
+
+{
+  printf '%s\n' '#!/usr/bin/env sh'
+  printf '%s\n' 'if [ -f "$TEST_AGENT_STARTED" ]; then'
+  printf '%s\n' '  printf "%s\n" "{\"resource\":\"http://127.0.0.1:7419/mcp\"}"'
+  printf '%s\n' 'else'
+  printf '%s\n' '  printf "%s\n" "{\"resource\":\"http://127.0.0.1:9999/not-monk\"}"'
+  printf '%s\n' 'fi'
+} >"$fake_bin/curl"
+
+{
+  printf '%s\n' '#!/usr/bin/env sh'
+  printf '%s\n' ': >"$TEST_AGENT_STARTED"'
+  printf '%s\n' 'trap "exit 0" HUP INT TERM'
+  printf '%s\n' 'while :; do sleep 1; done'
+} >"$fake_agent"
+
+chmod +x "$fake_bin/uname" "$fake_bin/curl" "$fake_agent"
+
+. "$launcher_root/scripts/plugin-version.sh"
+run_dir="$home/.monk/agent/launcher/run"
+printf '%s\n' "$fake_agent" >"$run_dir/monk-agent.path"
+{
+  printf '%s\n' \
+    "MONK_AGENT_PATH=$fake_agent" \
+    "MONK_AGENT_HOST=127.0.0.1" \
+    "MONK_AGENT_PORT=7419" \
+    "MONK_AUTH_URL=https://auth.monk.io" \
+    "MONK_AGENT_AUTH_CLIENT_ID=UW84YWcJME3buMSLfqLX8IbBsYdNWi47" \
+    "MONK_AUTH_AUDIENCE=oaknode.com" \
+    "MONK_AUTOSPIN_URL=wss://api.app.monk.io/autospin/" \
+    "MONK_AGENT_LOCAL=" \
+    "MONK_PLUGIN_VERSION=${MONK_PLUGIN_VERSION:-}"
+} >"$run_dir/monk-agent.config"
+
+PATH="$fake_bin:/usr/bin:/bin" \
+HOME="$home" \
+MONK_AGENT_HOME="$home/.monk" \
+MONK_AGENT_PATH="$fake_agent" \
+MONK_AGENT_SKIP_SIGNIN_NUDGE=1 \
+MONK_TELEMETRY=0 \
+TEST_AGENT_STARTED="$started" \
+  "$launcher_root/scripts/start-monk-agent.sh"
+
+if [ ! -f "$started" ]; then
+  echo "launcher accepted an unrelated health resource as monk-agent" >&2
+  exit 1
+fi
+
+echo "launcher rejects an unrelated health resource before reusing a process"


### PR DESCRIPTION
## Summary

- parse the OAuth protected-resource document instead of accepting any response containing a `resource` key
- require the top-level resource value to equal the configured Monk MCP endpoint on POSIX and Windows
- apply the identity check to all three launcher copies and both Antigravity pre-invocation hooks
- add deterministic POSIX and Windows regressions to the install E2E workflow

## Root cause and impact

The launcher treated any successful local response containing the text `"resource"` as proof that `monk-agent` owned the configured endpoint. An unrelated MCP-style process on the same port could therefore make the startup hook exit successfully without starting Monk, leaving every Monk tool unavailable behind a misleading healthy launch.

The updated checks parse the response and require its top-level `resource` value to equal `http://<configured-host>:<configured-port>/mcp`. Responses naming another service, malformed JSON, and missing resource values all fail closed so the managed companion is started.

## Validation

- both new regressions fail on unmodified v0.1.46: the launcher accepts `http://127.0.0.1:9999/not-monk` and never creates a managed PID
- both regressions pass with this change: the POSIX fake companion and a real isolated Windows companion are started before the exact Monk resource is accepted
- `sh -n` passes for all changed POSIX launchers/hooks and the new regression
- PowerShell AST parsing passes for all changed Windows launchers/hooks and the new regression
- existing `tests/block-monk-windows.ps1` passes
- all three distributed POSIX launcher copies are byte-identical
- all three distributed PowerShell launcher copies are byte-identical
- `.github/workflows/install-e2e.yml` parses successfully
- `git diff --check` passes

Fixes #25.
