### PR TITLE
Restart healthy launcher when configuration changes

### DIFF
--- a/.antigravity-plugin/scripts/start-monk-agent.ps1
+++ b/.antigravity-plugin/scripts/start-monk-agent.ps1
@@ -27,6 +27,7 @@ $RunDir = Join-Path $DataDir "run"
 $LogOut = Join-Path $LogDir "monk-agent.out.log"
 $LogErr = Join-Path $LogDir "monk-agent.err.log"
 $PidFile = Join-Path $RunDir "monk-agent.pid"
+$ConfigFile = Join-Path $RunDir "monk-agent.config"
 $HealthUrl = "http://${AgentHost}:$Port/.well-known/oauth-protected-resource"
 
 New-Item -ItemType Directory -Force -Path $LogDir, $RunDir | Out-Null
@@ -149,6 +150,29 @@ function Get-FileSha256 {
   return ([System.BitConverter]::ToString($Hash) -replace "-", "").ToLowerInvariant()
 }
 
+function Get-LauncherConfigFingerprint {
+  param([string]$AgentPath)
+
+  $Values = @(
+    $AgentPath,
+    $AgentHost,
+    $Port,
+    $AuthUrl,
+    $AuthClientId,
+    $AuthAudience,
+    $AutospinUrl,
+    $(if ($env:MONK_AGENT_LOCAL) { $env:MONK_AGENT_LOCAL } else { "" }),
+    $(if ($env:MONK_PLUGIN_VERSION) { $env:MONK_PLUGIN_VERSION } else { "" })
+  )
+  $Bytes = [Text.Encoding]::UTF8.GetBytes(($Values -join [char]0))
+  $Sha256 = [Security.Cryptography.SHA256]::Create()
+  try {
+    return ([BitConverter]::ToString($Sha256.ComputeHash($Bytes)) -replace "-", "").ToLowerInvariant()
+  } finally {
+    $Sha256.Dispose()
+  }
+}
+
 function Stop-ManagedAgent {
   if (-not (Test-Path $PidFile)) {
     return
@@ -243,8 +267,10 @@ if (-not (Test-Path $AgentPath)) {
 
 $AgentHashAfter = Get-FileSha256 $AgentPath
 $AgentUpdated = $AgentHashAfter -and ($AgentHashBefore -ne $AgentHashAfter)
+$LauncherConfigFingerprint = Get-LauncherConfigFingerprint -AgentPath $AgentPath
+$LauncherConfigMatches = (Test-Path $ConfigFile) -and ((Get-Content -Raw $ConfigFile).Trim() -eq $LauncherConfigFingerprint)
 
-if (-not $AgentUpdated -and (Test-AgentRunning)) {
+if (-not $AgentUpdated -and $LauncherConfigMatches -and (Test-AgentRunning)) {
   Show-SigninNudge
   exit 0
 }
@@ -273,6 +299,7 @@ $Process.Id | Set-Content -NoNewline $PidFile
 
 for ($Attempt = 0; $Attempt -lt 180; $Attempt++) {
   if (Test-AgentRunning) {
+    $LauncherConfigFingerprint | Set-Content -NoNewline $ConfigFile
     Show-SigninNudge
     exit 0
   }

--- a/.antigravity-plugin/scripts/start-monk-agent.sh
+++ b/.antigravity-plugin/scripts/start-monk-agent.sh
@@ -38,6 +38,7 @@ log_dir="$data_dir/logs"
 run_dir="$data_dir/run"
 log_file="$log_dir/monk-agent.log"
 pid_file="$run_dir/monk-agent.pid"
+config_file="$run_dir/monk-agent.config"
 launchd_label="io.monk.agent"
 launchd_plist="$HOME/Library/LaunchAgents/$launchd_label.plist"
 
@@ -230,6 +231,27 @@ if [ -n "$agent_hash_after" ] && [ "$agent_hash_before" != "$agent_hash_after" ]
   agent_updated=1
 fi
 
+launcher_config_fingerprint() {
+  for value in \
+    "$agent_path" "$host" "$port" "$auth_url" "$auth_client_id" \
+    "$auth_audience" "$autospin_url" "${MONK_AGENT_LOCAL:-}" \
+    "${MONK_PLUGIN_VERSION:-}"
+  do
+    printf '%s:%s\n' "${#value}" "$value"
+  done | cksum | awk '{print $1 ":" $2}'
+}
+
+config_fingerprint="$(launcher_config_fingerprint)"
+launcher_configured() {
+  [ -f "$config_file" ] && [ "$(cat "$config_file" 2>/dev/null || true)" = "$config_fingerprint" ]
+}
+
+record_launcher_config() {
+  config_tmp="$config_file.tmp.$$"
+  printf '%s\n' "$config_fingerprint" >"$config_tmp"
+  mv "$config_tmp" "$config_file"
+}
+
 launchd_configured() {
   # Deliberately excludes PATH: it is derived from the invoking shell/app and
   # legitimately differs across hosts (Claude Code, VS Code, plain terminal) and
@@ -252,7 +274,7 @@ launchd_configured() {
 }
 
 if [ "${MONK_AGENT_SKIP_ENSURE:-0}" != "1" ]; then
-  if [ "$os" != "Darwin" ] && [ "$agent_updated" = "0" ] && is_running; then
+  if [ "$os" != "Darwin" ] && [ "$agent_updated" = "0" ] && launcher_configured && is_running; then
     register_antigravity_mcp
     emit_signin_nudge
     exit 0
@@ -371,6 +393,7 @@ esac
 tries=0
 while [ "$tries" -lt 180 ]; do
   if is_running; then
+    record_launcher_config
     register_antigravity_mcp
     emit_signin_nudge
     exit 0

--- a/.github/workflows/install-e2e.yml
+++ b/.github/workflows/install-e2e.yml
@@ -27,6 +27,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Test launcher configuration changes
+        shell: bash
+        run: sh ./tests/start-monk-agent-config-change.sh
+
       - name: Install monk-agent
         shell: bash
         env:
@@ -65,6 +69,10 @@ jobs:
       - name: Test Windows block-monk fallbacks
         shell: pwsh
         run: .\tests\block-monk-windows.ps1
+
+      - name: Test launcher configuration changes
+        shell: pwsh
+        run: .\tests\start-monk-agent-config-change-windows.ps1
 
       - name: Install monk-agent
         shell: pwsh

--- a/plugins/monk/scripts/start-monk-agent.ps1
+++ b/plugins/monk/scripts/start-monk-agent.ps1
@@ -27,6 +27,7 @@ $RunDir = Join-Path $DataDir "run"
 $LogOut = Join-Path $LogDir "monk-agent.out.log"
 $LogErr = Join-Path $LogDir "monk-agent.err.log"
 $PidFile = Join-Path $RunDir "monk-agent.pid"
+$ConfigFile = Join-Path $RunDir "monk-agent.config"
 $HealthUrl = "http://${AgentHost}:$Port/.well-known/oauth-protected-resource"
 
 New-Item -ItemType Directory -Force -Path $LogDir, $RunDir | Out-Null
@@ -149,6 +150,29 @@ function Get-FileSha256 {
   return ([System.BitConverter]::ToString($Hash) -replace "-", "").ToLowerInvariant()
 }
 
+function Get-LauncherConfigFingerprint {
+  param([string]$AgentPath)
+
+  $Values = @(
+    $AgentPath,
+    $AgentHost,
+    $Port,
+    $AuthUrl,
+    $AuthClientId,
+    $AuthAudience,
+    $AutospinUrl,
+    $(if ($env:MONK_AGENT_LOCAL) { $env:MONK_AGENT_LOCAL } else { "" }),
+    $(if ($env:MONK_PLUGIN_VERSION) { $env:MONK_PLUGIN_VERSION } else { "" })
+  )
+  $Bytes = [Text.Encoding]::UTF8.GetBytes(($Values -join [char]0))
+  $Sha256 = [Security.Cryptography.SHA256]::Create()
+  try {
+    return ([BitConverter]::ToString($Sha256.ComputeHash($Bytes)) -replace "-", "").ToLowerInvariant()
+  } finally {
+    $Sha256.Dispose()
+  }
+}
+
 function Stop-ManagedAgent {
   if (-not (Test-Path $PidFile)) {
     return
@@ -243,8 +267,10 @@ if (-not (Test-Path $AgentPath)) {
 
 $AgentHashAfter = Get-FileSha256 $AgentPath
 $AgentUpdated = $AgentHashAfter -and ($AgentHashBefore -ne $AgentHashAfter)
+$LauncherConfigFingerprint = Get-LauncherConfigFingerprint -AgentPath $AgentPath
+$LauncherConfigMatches = (Test-Path $ConfigFile) -and ((Get-Content -Raw $ConfigFile).Trim() -eq $LauncherConfigFingerprint)
 
-if (-not $AgentUpdated -and (Test-AgentRunning)) {
+if (-not $AgentUpdated -and $LauncherConfigMatches -and (Test-AgentRunning)) {
   Show-SigninNudge
   exit 0
 }
@@ -273,6 +299,7 @@ $Process.Id | Set-Content -NoNewline $PidFile
 
 for ($Attempt = 0; $Attempt -lt 180; $Attempt++) {
   if (Test-AgentRunning) {
+    $LauncherConfigFingerprint | Set-Content -NoNewline $ConfigFile
     Show-SigninNudge
     exit 0
   }

--- a/plugins/monk/scripts/start-monk-agent.sh
+++ b/plugins/monk/scripts/start-monk-agent.sh
@@ -38,6 +38,7 @@ log_dir="$data_dir/logs"
 run_dir="$data_dir/run"
 log_file="$log_dir/monk-agent.log"
 pid_file="$run_dir/monk-agent.pid"
+config_file="$run_dir/monk-agent.config"
 launchd_label="io.monk.agent"
 launchd_plist="$HOME/Library/LaunchAgents/$launchd_label.plist"
 
@@ -230,6 +231,27 @@ if [ -n "$agent_hash_after" ] && [ "$agent_hash_before" != "$agent_hash_after" ]
   agent_updated=1
 fi
 
+launcher_config_fingerprint() {
+  for value in \
+    "$agent_path" "$host" "$port" "$auth_url" "$auth_client_id" \
+    "$auth_audience" "$autospin_url" "${MONK_AGENT_LOCAL:-}" \
+    "${MONK_PLUGIN_VERSION:-}"
+  do
+    printf '%s:%s\n' "${#value}" "$value"
+  done | cksum | awk '{print $1 ":" $2}'
+}
+
+config_fingerprint="$(launcher_config_fingerprint)"
+launcher_configured() {
+  [ -f "$config_file" ] && [ "$(cat "$config_file" 2>/dev/null || true)" = "$config_fingerprint" ]
+}
+
+record_launcher_config() {
+  config_tmp="$config_file.tmp.$$"
+  printf '%s\n' "$config_fingerprint" >"$config_tmp"
+  mv "$config_tmp" "$config_file"
+}
+
 launchd_configured() {
   # Deliberately excludes PATH: it is derived from the invoking shell/app and
   # legitimately differs across hosts (Claude Code, VS Code, plain terminal) and
@@ -252,7 +274,7 @@ launchd_configured() {
 }
 
 if [ "${MONK_AGENT_SKIP_ENSURE:-0}" != "1" ]; then
-  if [ "$os" != "Darwin" ] && [ "$agent_updated" = "0" ] && is_running; then
+  if [ "$os" != "Darwin" ] && [ "$agent_updated" = "0" ] && launcher_configured && is_running; then
     register_antigravity_mcp
     emit_signin_nudge
     exit 0
@@ -371,6 +393,7 @@ esac
 tries=0
 while [ "$tries" -lt 180 ]; do
   if is_running; then
+    record_launcher_config
     register_antigravity_mcp
     emit_signin_nudge
     exit 0

--- a/scripts/start-monk-agent.ps1
+++ b/scripts/start-monk-agent.ps1
@@ -27,6 +27,7 @@ $RunDir = Join-Path $DataDir "run"
 $LogOut = Join-Path $LogDir "monk-agent.out.log"
 $LogErr = Join-Path $LogDir "monk-agent.err.log"
 $PidFile = Join-Path $RunDir "monk-agent.pid"
+$ConfigFile = Join-Path $RunDir "monk-agent.config"
 $HealthUrl = "http://${AgentHost}:$Port/.well-known/oauth-protected-resource"
 
 New-Item -ItemType Directory -Force -Path $LogDir, $RunDir | Out-Null
@@ -149,6 +150,29 @@ function Get-FileSha256 {
   return ([System.BitConverter]::ToString($Hash) -replace "-", "").ToLowerInvariant()
 }
 
+function Get-LauncherConfigFingerprint {
+  param([string]$AgentPath)
+
+  $Values = @(
+    $AgentPath,
+    $AgentHost,
+    $Port,
+    $AuthUrl,
+    $AuthClientId,
+    $AuthAudience,
+    $AutospinUrl,
+    $(if ($env:MONK_AGENT_LOCAL) { $env:MONK_AGENT_LOCAL } else { "" }),
+    $(if ($env:MONK_PLUGIN_VERSION) { $env:MONK_PLUGIN_VERSION } else { "" })
+  )
+  $Bytes = [Text.Encoding]::UTF8.GetBytes(($Values -join [char]0))
+  $Sha256 = [Security.Cryptography.SHA256]::Create()
+  try {
+    return ([BitConverter]::ToString($Sha256.ComputeHash($Bytes)) -replace "-", "").ToLowerInvariant()
+  } finally {
+    $Sha256.Dispose()
+  }
+}
+
 function Stop-ManagedAgent {
   if (-not (Test-Path $PidFile)) {
     return
@@ -243,8 +267,10 @@ if (-not (Test-Path $AgentPath)) {
 
 $AgentHashAfter = Get-FileSha256 $AgentPath
 $AgentUpdated = $AgentHashAfter -and ($AgentHashBefore -ne $AgentHashAfter)
+$LauncherConfigFingerprint = Get-LauncherConfigFingerprint -AgentPath $AgentPath
+$LauncherConfigMatches = (Test-Path $ConfigFile) -and ((Get-Content -Raw $ConfigFile).Trim() -eq $LauncherConfigFingerprint)
 
-if (-not $AgentUpdated -and (Test-AgentRunning)) {
+if (-not $AgentUpdated -and $LauncherConfigMatches -and (Test-AgentRunning)) {
   Show-SigninNudge
   exit 0
 }
@@ -273,6 +299,7 @@ $Process.Id | Set-Content -NoNewline $PidFile
 
 for ($Attempt = 0; $Attempt -lt 180; $Attempt++) {
   if (Test-AgentRunning) {
+    $LauncherConfigFingerprint | Set-Content -NoNewline $ConfigFile
     Show-SigninNudge
     exit 0
   }

--- a/scripts/start-monk-agent.sh
+++ b/scripts/start-monk-agent.sh
@@ -38,6 +38,7 @@ log_dir="$data_dir/logs"
 run_dir="$data_dir/run"
 log_file="$log_dir/monk-agent.log"
 pid_file="$run_dir/monk-agent.pid"
+config_file="$run_dir/monk-agent.config"
 launchd_label="io.monk.agent"
 launchd_plist="$HOME/Library/LaunchAgents/$launchd_label.plist"
 
@@ -230,6 +231,27 @@ if [ -n "$agent_hash_after" ] && [ "$agent_hash_before" != "$agent_hash_after" ]
   agent_updated=1
 fi
 
+launcher_config_fingerprint() {
+  for value in \
+    "$agent_path" "$host" "$port" "$auth_url" "$auth_client_id" \
+    "$auth_audience" "$autospin_url" "${MONK_AGENT_LOCAL:-}" \
+    "${MONK_PLUGIN_VERSION:-}"
+  do
+    printf '%s:%s\n' "${#value}" "$value"
+  done | cksum | awk '{print $1 ":" $2}'
+}
+
+config_fingerprint="$(launcher_config_fingerprint)"
+launcher_configured() {
+  [ -f "$config_file" ] && [ "$(cat "$config_file" 2>/dev/null || true)" = "$config_fingerprint" ]
+}
+
+record_launcher_config() {
+  config_tmp="$config_file.tmp.$$"
+  printf '%s\n' "$config_fingerprint" >"$config_tmp"
+  mv "$config_tmp" "$config_file"
+}
+
 launchd_configured() {
   # Deliberately excludes PATH: it is derived from the invoking shell/app and
   # legitimately differs across hosts (Claude Code, VS Code, plain terminal) and
@@ -252,7 +274,7 @@ launchd_configured() {
 }
 
 if [ "${MONK_AGENT_SKIP_ENSURE:-0}" != "1" ]; then
-  if [ "$os" != "Darwin" ] && [ "$agent_updated" = "0" ] && is_running; then
+  if [ "$os" != "Darwin" ] && [ "$agent_updated" = "0" ] && launcher_configured && is_running; then
     register_antigravity_mcp
     emit_signin_nudge
     exit 0
@@ -371,6 +393,7 @@ esac
 tries=0
 while [ "$tries" -lt 180 ]; do
   if is_running; then
+    record_launcher_config
     register_antigravity_mcp
     emit_signin_nudge
     exit 0

--- a/tests/start-monk-agent-config-change-windows.ps1
+++ b/tests/start-monk-agent-config-change-windows.ps1
@@ -1,0 +1,121 @@
+$ErrorActionPreference = "Stop"
+
+$RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+$Launcher = Join-Path $RepoRoot "scripts\start-monk-agent.ps1"
+$TestRoot = Join-Path ([IO.Path]::GetTempPath()) ("monk-launcher-config-" + [guid]::NewGuid().ToString("N"))
+$InstallDir = Join-Path $TestRoot "install"
+$MonkHome = Join-Path $TestRoot "home"
+$CapturePath = Join-Path $TestRoot "starts.log"
+$Port = Get-Random -Minimum 20000 -Maximum 45000
+$ServerJob = $null
+$Previous = @{}
+
+try {
+  New-Item -ItemType Directory -Force -Path $InstallDir, $MonkHome | Out-Null
+
+  $AgentPath = Join-Path $InstallDir "monk-agent.exe"
+  $AgentSource = @'
+using System;
+using System.IO;
+
+public static class FakeMonkAgent
+{
+    public static int Main()
+    {
+        var capture = Environment.GetEnvironmentVariable("MONK_CAPTURE_PATH");
+        File.AppendAllText(capture,
+            "auth=" + Environment.GetEnvironmentVariable("MONK_AUTH_URL") + Environment.NewLine);
+        return 0;
+    }
+}
+'@
+  Add-Type -TypeDefinition $AgentSource -OutputAssembly $AgentPath -OutputType ConsoleApplication
+
+  $ServerJob = Start-Job -ArgumentList $Port -ScriptBlock {
+    param($ListenPort)
+    $Listener = [Net.HttpListener]::new()
+    $Listener.Prefixes.Add("http://127.0.0.1:$ListenPort/")
+    $Listener.Start()
+    try {
+      while ($true) {
+        $Context = $Listener.GetContext()
+        $Body = '{"resource":"http://127.0.0.1:' + $ListenPort + '/mcp","signedIn":true}'
+        $Bytes = [Text.Encoding]::UTF8.GetBytes($Body)
+        $Context.Response.StatusCode = 200
+        $Context.Response.ContentType = "application/json"
+        $Context.Response.OutputStream.Write($Bytes, 0, $Bytes.Length)
+        $Context.Response.Close()
+      }
+    } finally {
+      $Listener.Close()
+    }
+  }
+
+  $HealthUrl = "http://127.0.0.1:$Port/.well-known/oauth-protected-resource"
+  $Ready = $false
+  for ($Attempt = 0; $Attempt -lt 50; $Attempt++) {
+    try {
+      Invoke-WebRequest -UseBasicParsing -TimeoutSec 1 -Uri $HealthUrl | Out-Null
+      $Ready = $true
+      break
+    } catch {
+      Start-Sleep -Milliseconds 100
+    }
+  }
+  if (-not $Ready) { throw "Health fixture did not start." }
+
+  $Names = @(
+    "MONK_AGENT_INSTALL_DIR", "MONK_AGENT_HOME", "MONK_AGENT_PORT",
+    "MONK_AGENT_SKIP_ENSURE", "MONK_AGENT_SKIP_SIGNIN_NUDGE",
+    "MONK_DISABLE_ANALYTICS", "MONK_CAPTURE_PATH", "MONK_AUTH_URL"
+  )
+  foreach ($Name in $Names) { $Previous[$Name] = [Environment]::GetEnvironmentVariable($Name, "Process") }
+
+  $env:MONK_AGENT_INSTALL_DIR = $InstallDir
+  $env:MONK_AGENT_HOME = $MonkHome
+  $env:MONK_AGENT_PORT = [string]$Port
+  $env:MONK_AGENT_SKIP_ENSURE = "1"
+  $env:MONK_AGENT_SKIP_SIGNIN_NUDGE = "1"
+  $env:MONK_DISABLE_ANALYTICS = "1"
+  $env:MONK_CAPTURE_PATH = $CapturePath
+
+  function Invoke-Launcher([string]$AuthUrl) {
+    $env:MONK_AUTH_URL = $AuthUrl
+    & powershell.exe -NoProfile -ExecutionPolicy Bypass -File $Launcher
+    if ($LASTEXITCODE -ne 0) { throw "Launcher exited with code $LASTEXITCODE." }
+    Start-Sleep -Milliseconds 300
+  }
+
+  Invoke-Launcher "https://auth-one.invalid"
+  Invoke-Launcher "https://auth-one.invalid"
+  Invoke-Launcher "https://auth-two.invalid"
+  Invoke-Launcher "https://auth-two.invalid"
+
+  $Starts = @(Get-Content $CapturePath)
+  if ($Starts.Count -ne 2) {
+    throw "Expected two starts (initial plus configuration change), got $($Starts.Count): $($Starts -join ', ')"
+  }
+  if ($Starts[0] -ne "auth=https://auth-one.invalid" -or $Starts[1] -ne "auth=https://auth-two.invalid") {
+    throw "Unexpected launch configurations: $($Starts -join ', ')"
+  }
+
+  $ConfigFile = Join-Path $MonkHome "agent\launcher\run\monk-agent.config"
+  if (-not (Test-Path $ConfigFile) -or -not (Get-Content -Raw $ConfigFile).Trim()) {
+    throw "Launcher configuration fingerprint was not persisted."
+  }
+
+  Write-Host "Windows launcher configuration-change regression passed."
+} finally {
+  foreach ($Name in $Previous.Keys) {
+    [Environment]::SetEnvironmentVariable($Name, $Previous[$Name], "Process")
+  }
+  if ($ServerJob) {
+    Stop-Job $ServerJob -ErrorAction SilentlyContinue
+    Remove-Job $ServerJob -Force -ErrorAction SilentlyContinue
+  }
+  $ResolvedTemp = [IO.Path]::GetFullPath([IO.Path]::GetTempPath())
+  $ResolvedTest = [IO.Path]::GetFullPath($TestRoot)
+  if ($ResolvedTest.StartsWith($ResolvedTemp, [StringComparison]::OrdinalIgnoreCase) -and (Test-Path $ResolvedTest)) {
+    Remove-Item -LiteralPath $ResolvedTest -Recurse -Force
+  }
+}

--- a/tests/start-monk-agent-config-change.sh
+++ b/tests/start-monk-agent-config-change.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env sh
+set -eu
+
+repo="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+root="$(mktemp -d)"
+server_pid=""
+
+cleanup() {
+  if [ -n "$server_pid" ]; then
+    kill "$server_pid" >/dev/null 2>&1 || true
+  fi
+  rm -rf "$root"
+}
+trap cleanup EXIT HUP INT TERM
+
+home="$root/home"
+install="$root/install"
+fake_bin="$root/bin"
+capture="$root/starts.log"
+port_file="$root/port"
+mkdir -p "$home" "$install" "$fake_bin"
+
+cat >"$fake_bin/uname" <<'EOF'
+#!/usr/bin/env sh
+case "${1:-}" in
+  -m) printf '%s\n' x86_64 ;;
+  *) printf '%s\n' Linux ;;
+esac
+EOF
+chmod +x "$fake_bin/uname"
+
+cat >"$install/monk-agent" <<'EOF'
+#!/usr/bin/env sh
+printf 'auth=%s\n' "${MONK_AUTH_URL:-}" >>"$MONK_CAPTURE_PATH"
+exit 0
+EOF
+chmod +x "$install/monk-agent"
+
+python3 - "$port_file" <<'PY' &
+import http.server
+import pathlib
+import sys
+
+class Handler(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        body = ('{"resource":"http://127.0.0.1:%d/mcp","signedIn":true}'
+                % self.server.server_port).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *_args):
+        pass
+
+server = http.server.HTTPServer(("127.0.0.1", 0), Handler)
+pathlib.Path(sys.argv[1]).write_text(str(server.server_port))
+server.serve_forever()
+PY
+server_pid="$!"
+
+tries=0
+while [ ! -s "$port_file" ]; do
+  tries=$((tries + 1))
+  [ "$tries" -lt 50 ] || { echo "Health fixture did not start." >&2; exit 1; }
+  sleep 0.1
+done
+port="$(cat "$port_file")"
+
+run_launcher() {
+  auth_url="$1"
+  PATH="$fake_bin:$PATH" \
+  HOME="$home" \
+  MONK_AGENT_HOME="$home/.monk" \
+  MONK_AGENT_INSTALL_DIR="$install" \
+  MONK_AGENT_AUTO_UPDATE=0 \
+  MONK_AGENT_PORT="$port" \
+  MONK_AGENT_SKIP_SIGNIN_NUDGE=1 \
+  MONK_DISABLE_ANALYTICS=1 \
+  MONK_CAPTURE_PATH="$capture" \
+  MONK_AUTH_URL="$auth_url" \
+    "$repo/scripts/start-monk-agent.sh"
+  sleep 0.2
+}
+
+run_launcher https://auth-one.invalid
+run_launcher https://auth-one.invalid
+run_launcher https://auth-two.invalid
+run_launcher https://auth-two.invalid
+
+expected="$(printf 'auth=%s\nauth=%s' https://auth-one.invalid https://auth-two.invalid)"
+actual="$(cat "$capture")"
+[ "$actual" = "$expected" ] || {
+  echo "Unexpected launch configurations:" >&2
+  printf '%s\n' "$actual" >&2
+  exit 1
+}
+
+config_file="$home/.monk/agent/launcher/run/monk-agent.config"
+[ -s "$config_file" ] || { echo "Launcher configuration fingerprint was not persisted." >&2; exit 1; }
+
+echo "POSIX launcher configuration-change regression passed."


### PR DESCRIPTION
## What changed

- Persist a fingerprint of the launcher configuration after the agent starts successfully.
- Require both a healthy agent and a matching fingerprint before taking the warm-start fast path.
- Restart the managed agent when its binary path, bind address, auth endpoints, autospin URL, local mode, or plugin version changes.
- Apply the fix consistently to the root, rendered Monk plugin, and Antigravity launcher copies.
- Add Windows and POSIX regression tests and run them in the install E2E workflow.

## Why

The launchers previously treated a successful health response as sufficient proof that the running process matched the requested configuration. A healthy process started with stale auth or server settings therefore prevented the new configuration from taking effect.

Fixes #21.

## Impact

Users can change launcher configuration without manually finding and killing an otherwise healthy `monk-agent` process. Unchanged healthy launches retain the existing fast path.

## Root cause

The warm-start decision checked process health only. No durable representation of the effective configuration was recorded or compared on subsequent launches.

## Validation

- Windows configuration-change regression passed locally.
- All three PowerShell launcher copies parse successfully.
- All three POSIX launcher copies pass `sh -n`.
- Distributed launcher copies have identical hashes.
- `git diff --check` passes.
- Windows and POSIX regression tests are wired into the repository's existing install E2E workflow.

The POSIX runtime regression is left to the Linux/macOS CI jobs because WSL is not available on the local Windows test host.
