### PR TITLE
fix: register Codex Monk CLI guard

### DIFF
--- a/.github/workflows/install-e2e.yml
+++ b/.github/workflows/install-e2e.yml
@@ -66,6 +66,10 @@ jobs:
         shell: pwsh
         run: .\tests\block-monk-windows.ps1
 
+      - name: Test Codex hook registration
+        shell: pwsh
+        run: .\tests\codex-hooks-windows.ps1
+
       - name: Install monk-agent
         shell: pwsh
         env:

--- a/hooks/codex-hooks.json
+++ b/hooks/codex-hooks.json
@@ -11,6 +11,20 @@
           }
         ]
       }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${PLUGIN_ROOT}/hooks/block-monk.sh",
+            "commandWindows": "powershell.exe -NoProfile -ExecutionPolicy Bypass -File \"${PLUGIN_ROOT}/hooks/block-monk.ps1\"",
+            "timeout": 5,
+            "statusMessage": "Checking Monk CLI guard"
+          }
+        ]
+      }
     ]
   }
 }

--- a/plugins/monk/hooks/block-monk.ps1
+++ b/plugins/monk/hooks/block-monk.ps1
@@ -1,0 +1,32 @@
+# PreToolUse hook for the Bash tool: block any shell-out to the `monk` CLI.
+# Monk owns its own cluster state - running `monk ...` from a shell desyncs it.
+# Use monk-agent MCP tools instead.
+#
+# Delegates to `monk-agent hook block-monk` so the logic stays in one place.
+# Falls back to native PowerShell if the binary is unavailable.
+
+$hookInput = [Console]::In.ReadToEnd()
+
+$agentDir = if ($env:MONK_AGENT_INSTALL_DIR) { $env:MONK_AGENT_INSTALL_DIR } else { Join-Path $HOME ".monk\bin" }
+$agent = if ($env:MONK_AGENT_PATH) { $env:MONK_AGENT_PATH } else { Join-Path $agentDir "monk-agent.exe" }
+
+if (Test-Path $agent) {
+  $hookInput | & $agent hook block-monk --format claude
+  exit $LASTEXITCODE
+}
+
+# Fallback: binary unavailable. Match `monk` only in command position.
+try { $command = ($hookInput | ConvertFrom-Json).tool_input.command } catch { exit 0 }
+if (-not $command) { exit 0 }
+
+if ($command -match '(^|[\r\n;&|`({])\s*(sudo\s+)?monk(\s|$)') {
+  @{
+    hookSpecificOutput = @{
+      hookEventName            = "PreToolUse"
+      permissionDecision       = "deny"
+      permissionDecisionReason = "Blocked: do not shell out to the ``monk`` CLI - it desyncs the cluster state Monk manages. Use the monk-agent MCP tools instead."
+    }
+  } | ConvertTo-Json -Compress
+}
+
+exit 0

--- a/plugins/monk/hooks/block-monk.sh
+++ b/plugins/monk/hooks/block-monk.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env sh
+# PreToolUse hook for the Bash tool: block any shell-out to the `monk` CLI.
+# Monk owns its own cluster state — running `monk ...` from a shell desyncs it.
+# Use monk-agent MCP tools instead.
+#
+# The decision is made by `monk-agent hook block-monk` so the only dependency is
+# the monk-agent binary the plugin already installs. If that binary is somehow
+# missing we fall back to pure POSIX shell + grep, biased toward BLOCKING: a
+# `monk` invocation is still caught with zero tooling, and non-monk commands are
+# never blocked. The hook always exits 0 (the deny JSON is the block signal).
+
+set -eu
+
+input="$(cat)"
+
+agent="${MONK_AGENT_PATH:-${MONK_AGENT_INSTALL_DIR:-"$HOME/.monk/bin"}/monk-agent}"
+if [ -x "$agent" ]; then
+  if printf '%s' "$input" | "$agent" hook block-monk --format claude; then
+    exit 0
+  fi
+fi
+
+# Fallback: binary unavailable. Grep the raw hook payload for a `monk` command.
+# Matches `monk` only in command position (start, or after a shell separator),
+# optional `sudo`, followed by whitespace/quote/end — so `monkey` is not matched.
+# False positives only ever BLOCK, never allow, which is the safe direction.
+if printf '%s' "$input" | grep -Eq '(^|["[:space:];&|`(])(sudo[[:space:]]+)?monk([[:space:]"]|$)'; then
+  cat <<'JSON'
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "deny",
+    "permissionDecisionReason": "Blocked: do not shell out to the `monk` CLI — it desyncs the cluster state Monk manages. Use the monk-agent MCP tools instead."
+  }
+}
+JSON
+  exit 0
+fi
+
+exit 0

--- a/plugins/monk/hooks/codex-hooks.json
+++ b/plugins/monk/hooks/codex-hooks.json
@@ -11,6 +11,20 @@
           }
         ]
       }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${PLUGIN_ROOT}/hooks/block-monk.sh",
+            "commandWindows": "powershell.exe -NoProfile -ExecutionPolicy Bypass -File \"${PLUGIN_ROOT}/hooks/block-monk.ps1\"",
+            "timeout": 5,
+            "statusMessage": "Checking Monk CLI guard"
+          }
+        ]
+      }
     ]
   }
 }

--- a/tests/codex-hooks-windows.ps1
+++ b/tests/codex-hooks-windows.ps1
@@ -1,0 +1,69 @@
+param(
+  [string]$RepoRoot = (Split-Path -Parent $PSScriptRoot)
+)
+
+$ErrorActionPreference = "Stop"
+
+$PluginRoots = @(
+  $RepoRoot,
+  (Join-Path $RepoRoot "plugins\monk")
+)
+
+foreach ($PluginRoot in $PluginRoots) {
+  $ManifestPath = Join-Path $PluginRoot ".codex-plugin\plugin.json"
+  $Manifest = Get-Content -Raw $ManifestPath | ConvertFrom-Json
+  $HooksPath = Join-Path $PluginRoot $Manifest.hooks
+
+  if (-not (Test-Path -LiteralPath $HooksPath -PathType Leaf)) {
+    throw "Codex hook file does not exist: $HooksPath"
+  }
+
+  $Config = Get-Content -Raw $HooksPath | ConvertFrom-Json
+  if (-not $Config.hooks.SessionStart) {
+    throw "Codex SessionStart hook is missing from $HooksPath"
+  }
+
+  $PreToolUse = @($Config.hooks.PreToolUse)
+  $BashGuards = @($PreToolUse | Where-Object { $_.matcher -eq "Bash" })
+  if ($BashGuards.Count -ne 1) {
+    throw "Expected exactly one Codex PreToolUse Bash guard in $HooksPath"
+  }
+
+  $Guard = @($BashGuards[0].hooks)
+  if ($Guard.Count -ne 1) {
+    throw "Expected exactly one command for the Codex PreToolUse Bash guard in $HooksPath"
+  }
+
+  foreach ($Property in @("command", "commandWindows")) {
+    $Command = $Guard[0].$Property
+    if ($Command -notmatch 'block-monk\.(sh|ps1)') {
+      throw "Codex $Property does not reference block-monk in $HooksPath"
+    }
+
+    $RelativePath = [regex]::Match($Command, '\$\{PLUGIN_ROOT\}/([^" ]*block-monk\.(?:sh|ps1))').Groups[1].Value
+    if (-not $RelativePath) {
+      throw "Could not resolve Codex $Property in $HooksPath"
+    }
+
+    $ResolvedPath = Join-Path $PluginRoot ($RelativePath -replace '/', '\')
+    if (-not (Test-Path -LiteralPath $ResolvedPath -PathType Leaf)) {
+      throw "Codex $Property references a missing file: $ResolvedPath"
+    }
+  }
+}
+
+$RootConfig = (Get-Content -Raw (Join-Path $RepoRoot "hooks\codex-hooks.json")) -replace "`r`n", "`n"
+$PackagedConfig = (Get-Content -Raw (Join-Path $RepoRoot "plugins\monk\hooks\codex-hooks.json")) -replace "`r`n", "`n"
+if ($RootConfig -cne $PackagedConfig) {
+  throw "Root and packaged Codex hook configurations differ"
+}
+
+foreach ($HookName in @("block-monk.ps1", "block-monk.sh")) {
+  $RootHook = (Get-Content -Raw (Join-Path $RepoRoot "hooks\$HookName")) -replace "`r`n", "`n"
+  $PackagedHook = (Get-Content -Raw (Join-Path $RepoRoot "plugins\monk\hooks\$HookName")) -replace "`r`n", "`n"
+  if ($RootHook -cne $PackagedHook) {
+    throw "Root and packaged $HookName files differ"
+  }
+}
+
+Write-Host "Codex hook registration tests passed."


### PR DESCRIPTION
## Summary

- Register the existing `block-monk` guard as a Codex `PreToolUse` hook for Bash.
- Include the guard scripts in the packaged `plugins/monk` layout, where the new hook references them.
- Add a regression that resolves each Codex manifest, validates the guard registration and target files, and ensures the root and packaged copies stay synchronized.
- Run the regression in the existing Windows CI job.

## Why

The Codex manifest loads `hooks/codex-hooks.json`, but that file only registered `SessionStart`. Direct `monk` shell commands therefore bypassed the local guard used by other supported hosts.

The packaged `plugins/monk` layout also lacked the guard scripts, so configuration alone would have left that distribution with broken hook targets.

Fixes #137.

## Validation

- `./tests/codex-hooks-windows.ps1`
- `./tests/block-monk-windows.ps1`
- JSON parsing for both manifests and both Codex hook files
- `sh -n hooks/block-monk.sh plugins/monk/hooks/block-monk.sh`
- `git diff --check`

The existing fallback behavior test confirms direct `monk` commands are denied while similar or argument-only uses are allowed. The new structural test confirms both shipped plugin layouts resolve to the same working guard files.
