### PR TITLE
fix: preserve LF in POSIX plugin hooks

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/.github/workflows/install-e2e.yml
+++ b/.github/workflows/install-e2e.yml
@@ -66,6 +66,10 @@ jobs:
         shell: pwsh
         run: .\tests\block-monk-windows.ps1
 
+      - name: Test POSIX shell line endings
+        shell: pwsh
+        run: .\tests\posix-line-endings-windows.ps1
+
       - name: Install monk-agent
         shell: pwsh
         env:

--- a/tests/posix-line-endings-windows.ps1
+++ b/tests/posix-line-endings-windows.ps1
@@ -1,0 +1,27 @@
+param(
+  [string]$RepoRoot = (Split-Path -Parent $PSScriptRoot)
+)
+
+$ErrorActionPreference = "Stop"
+$ShellFiles = @(git -C $RepoRoot ls-files -- "*.sh")
+
+if ($LASTEXITCODE -ne 0 -or $ShellFiles.Count -eq 0) {
+  throw "Could not enumerate tracked POSIX shell files"
+}
+
+foreach ($RelativePath in $ShellFiles) {
+  $Attribute = git -C $RepoRoot check-attr eol -- $RelativePath
+  if ($LASTEXITCODE -ne 0 -or $Attribute -notmatch ': eol: lf$') {
+    throw "Missing eol=lf attribute for $RelativePath"
+  }
+
+  $Path = Join-Path $RepoRoot ($RelativePath -replace '/', '\')
+  $Bytes = [IO.File]::ReadAllBytes($Path)
+  for ($Index = 0; $Index -lt $Bytes.Length - 1; $Index++) {
+    if ($Bytes[$Index] -eq 13 -and $Bytes[$Index + 1] -eq 10) {
+      throw "POSIX shell file contains CRLF: $RelativePath"
+    }
+  }
+}
+
+Write-Host "POSIX shell line-ending tests passed for $($ShellFiles.Count) files."


### PR DESCRIPTION
## Summary

- Enforce LF line endings for every tracked POSIX shell file through `.gitattributes`.
- Add a Windows regression that checks both the Git attribute and the checked-out bytes of all tracked `.sh` files.
- Run the regression in the existing Windows CI job.

## Why

On Windows with automatic line-ending conversion, the shipped Antigravity shell hooks can be checked out with CRLF. A POSIX shell then fails before `block-monk.sh` can emit its guard decision. The PowerShell sibling may already have delegated because Bash is available, so the combined guard path can allow a direct Monk CLI command.

The repository blobs are already LF. The missing piece is a checkout rule that preserves LF on Windows.

Fixes #135.

## Validation

- `./tests/posix-line-endings-windows.ps1`
- `./tests/block-monk-windows.ps1`
- `git diff --check`
- `git ls-files --eol '*.sh'` confirms `w/lf` and `attr/text eol=lf` for all 20 tracked shell files

The regression enumerates tracked shell files instead of maintaining a fixed list, so newly added plugin or generated shell files are covered automatically.
