### PR TITLE
fix: remove Antigravity MCP registration on uninstall

### DIFF
--- a/.antigravity-plugin/scripts/uninstall-monk-agent.ps1
+++ b/.antigravity-plugin/scripts/uninstall-monk-agent.ps1
@@ -29,6 +29,9 @@ $AgentDataDir = Join-Path $MonkHome "agent"
 $PidFile = Join-Path $AgentDataDir "launcher\run\monk-agent.pid"
 $Target = Join-Path $InstallDir "monk-agent.exe"
 $Checksum = Join-Path $InstallDir "monk-agent.sha256"
+$AntigravityMcpConfig = if ($env:MONK_ANTIGRAVITY_CONFIG) { $env:MONK_ANTIGRAVITY_CONFIG } else {
+  Join-Path $HOME ".gemini\config\mcp_config.json"
+}
 
 if (-not $Yes) {
   $suffix = if ($Runtime) { " and Monk runtime" } else { "" }
@@ -135,10 +138,53 @@ fi
   wsl.exe -d $distro --user root -- sh -lc $script
 }
 
+function Remove-AntigravityMcpRegistration {
+  if (-not (Test-Path -LiteralPath $AntigravityMcpConfig -PathType Leaf)) {
+    return
+  }
+
+  try {
+    $Config = Get-Content -LiteralPath $AntigravityMcpConfig -Raw | ConvertFrom-Json
+  } catch {
+    Write-Warning "Leaving malformed Antigravity MCP config unchanged: $AntigravityMcpConfig"
+    return
+  }
+
+  if ($null -eq $Config) {
+    return
+  }
+  $ServersProperty = $Config.PSObject.Properties["mcpServers"]
+  if ($null -eq $ServersProperty -or $null -eq $ServersProperty.Value) {
+    return
+  }
+  $MonkProperty = $ServersProperty.Value.PSObject.Properties["monk"]
+  if ($null -eq $MonkProperty) {
+    return
+  }
+
+  $ServersProperty.Value.PSObject.Properties.Remove("monk")
+  if (@($ServersProperty.Value.PSObject.Properties).Count -eq 0) {
+    $Config.PSObject.Properties.Remove("mcpServers")
+  }
+
+  $Directory = Split-Path -Parent $AntigravityMcpConfig
+  $TempPath = Join-Path $Directory (".monk-mcp-config-{0}.tmp" -f [guid]::NewGuid())
+  try {
+    $Json = $Config | ConvertTo-Json -Depth 100
+    [IO.File]::WriteAllText($TempPath, $Json + [Environment]::NewLine, [Text.UTF8Encoding]::new($false))
+    Move-Item -LiteralPath $TempPath -Destination $AntigravityMcpConfig -Force
+    Write-Host "Removed Monk MCP registration from $AntigravityMcpConfig"
+  } catch {
+    Remove-Item -LiteralPath $TempPath -Force -ErrorAction SilentlyContinue
+    Write-Warning "Could not update Antigravity MCP config: $AntigravityMcpConfig"
+  }
+}
+
 Stop-ManagedAgent
 Remove-AgentFiles
 if ($Runtime) {
   Remove-MonkRuntime
 }
+Remove-AntigravityMcpRegistration
 
 Write-Host "monk-agent uninstall complete."

--- a/.antigravity-plugin/scripts/uninstall-monk-agent.sh
+++ b/.antigravity-plugin/scripts/uninstall-monk-agent.sh
@@ -156,10 +156,78 @@ remove_runtime() {
   esac
 }
 
+remove_antigravity_mcp_registration() {
+  mcp_cfg="${MONK_ANTIGRAVITY_CONFIG:-"$home_dir/.gemini/config/mcp_config.json"}"
+  [ -f "$mcp_cfg" ] || return 0
+
+  tmp="$(mktemp "${TMPDIR:-/tmp}/monk-mcp-config.XXXXXX")"
+  if command -v jq >/dev/null 2>&1; then
+    if ! jq empty "$mcp_cfg" >/dev/null 2>&1; then
+      rm -f "$tmp"
+      echo "Warning: leaving malformed Antigravity MCP config unchanged: $mcp_cfg" >&2
+      return 0
+    fi
+    if ! jq -e '.mcpServers | type == "object" and has("monk")' "$mcp_cfg" >/dev/null 2>&1; then
+      rm -f "$tmp"
+      return 0
+    fi
+    if ! jq 'del(.mcpServers.monk) | if .mcpServers == {} then del(.mcpServers) else . end' "$mcp_cfg" >"$tmp"; then
+      rm -f "$tmp"
+      echo "Warning: could not update Antigravity MCP config: $mcp_cfg" >&2
+      return 0
+    fi
+  elif command -v python3 >/dev/null 2>&1; then
+    status=0
+    python3 - "$mcp_cfg" >"$tmp" <<'PY' || status=$?
+import json
+import sys
+
+path = sys.argv[1]
+try:
+    with open(path, encoding="utf-8-sig") as source:
+        config = json.load(source)
+except (OSError, ValueError):
+    sys.exit(2)
+
+servers = config.get("mcpServers") if isinstance(config, dict) else None
+if not isinstance(servers, dict) or "monk" not in servers:
+    sys.exit(3)
+
+del servers["monk"]
+if not servers:
+    del config["mcpServers"]
+json.dump(config, sys.stdout, indent=2)
+sys.stdout.write("\n")
+PY
+    case "$status" in
+      0) ;;
+      3) rm -f "$tmp"; return 0 ;;
+      *)
+        rm -f "$tmp"
+        echo "Warning: leaving malformed Antigravity MCP config unchanged: $mcp_cfg" >&2
+        return 0
+        ;;
+    esac
+  else
+    rm -f "$tmp"
+    echo "Warning: could not inspect $mcp_cfg; remove mcpServers.monk manually (jq or python3 required)." >&2
+    return 0
+  fi
+
+  if mv "$tmp" "$mcp_cfg"; then
+    echo "Removed Monk MCP registration from $mcp_cfg" >&2
+  else
+    rm -f "$tmp"
+    echo "Warning: could not update Antigravity MCP config: $mcp_cfg" >&2
+  fi
+}
+
 stop_agent
 remove_agent_files
 if [ "$remove_runtime" = "1" ]; then
   remove_runtime
 fi
+
+remove_antigravity_mcp_registration
 
 echo "monk-agent uninstall complete."

--- a/.github/workflows/install-e2e.yml
+++ b/.github/workflows/install-e2e.yml
@@ -27,6 +27,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Test POSIX Antigravity MCP cleanup
+        shell: bash
+        run: ./tests/uninstall-antigravity-mcp.sh
+
       - name: Install monk-agent
         shell: bash
         env:
@@ -65,6 +69,10 @@ jobs:
       - name: Test Windows block-monk fallbacks
         shell: pwsh
         run: .\tests\block-monk-windows.ps1
+
+      - name: Test Windows Antigravity MCP cleanup
+        shell: pwsh
+        run: .\tests\uninstall-antigravity-mcp-windows.ps1
 
       - name: Install monk-agent
         shell: pwsh

--- a/plugins/monk/scripts/uninstall-monk-agent.ps1
+++ b/plugins/monk/scripts/uninstall-monk-agent.ps1
@@ -29,6 +29,9 @@ $AgentDataDir = Join-Path $MonkHome "agent"
 $PidFile = Join-Path $AgentDataDir "launcher\run\monk-agent.pid"
 $Target = Join-Path $InstallDir "monk-agent.exe"
 $Checksum = Join-Path $InstallDir "monk-agent.sha256"
+$AntigravityMcpConfig = if ($env:MONK_ANTIGRAVITY_CONFIG) { $env:MONK_ANTIGRAVITY_CONFIG } else {
+  Join-Path $HOME ".gemini\config\mcp_config.json"
+}
 
 if (-not $Yes) {
   $suffix = if ($Runtime) { " and Monk runtime" } else { "" }
@@ -135,10 +138,53 @@ fi
   wsl.exe -d $distro --user root -- sh -lc $script
 }
 
+function Remove-AntigravityMcpRegistration {
+  if (-not (Test-Path -LiteralPath $AntigravityMcpConfig -PathType Leaf)) {
+    return
+  }
+
+  try {
+    $Config = Get-Content -LiteralPath $AntigravityMcpConfig -Raw | ConvertFrom-Json
+  } catch {
+    Write-Warning "Leaving malformed Antigravity MCP config unchanged: $AntigravityMcpConfig"
+    return
+  }
+
+  if ($null -eq $Config) {
+    return
+  }
+  $ServersProperty = $Config.PSObject.Properties["mcpServers"]
+  if ($null -eq $ServersProperty -or $null -eq $ServersProperty.Value) {
+    return
+  }
+  $MonkProperty = $ServersProperty.Value.PSObject.Properties["monk"]
+  if ($null -eq $MonkProperty) {
+    return
+  }
+
+  $ServersProperty.Value.PSObject.Properties.Remove("monk")
+  if (@($ServersProperty.Value.PSObject.Properties).Count -eq 0) {
+    $Config.PSObject.Properties.Remove("mcpServers")
+  }
+
+  $Directory = Split-Path -Parent $AntigravityMcpConfig
+  $TempPath = Join-Path $Directory (".monk-mcp-config-{0}.tmp" -f [guid]::NewGuid())
+  try {
+    $Json = $Config | ConvertTo-Json -Depth 100
+    [IO.File]::WriteAllText($TempPath, $Json + [Environment]::NewLine, [Text.UTF8Encoding]::new($false))
+    Move-Item -LiteralPath $TempPath -Destination $AntigravityMcpConfig -Force
+    Write-Host "Removed Monk MCP registration from $AntigravityMcpConfig"
+  } catch {
+    Remove-Item -LiteralPath $TempPath -Force -ErrorAction SilentlyContinue
+    Write-Warning "Could not update Antigravity MCP config: $AntigravityMcpConfig"
+  }
+}
+
 Stop-ManagedAgent
 Remove-AgentFiles
 if ($Runtime) {
   Remove-MonkRuntime
 }
+Remove-AntigravityMcpRegistration
 
 Write-Host "monk-agent uninstall complete."

--- a/plugins/monk/scripts/uninstall-monk-agent.sh
+++ b/plugins/monk/scripts/uninstall-monk-agent.sh
@@ -156,10 +156,78 @@ remove_runtime() {
   esac
 }
 
+remove_antigravity_mcp_registration() {
+  mcp_cfg="${MONK_ANTIGRAVITY_CONFIG:-"$home_dir/.gemini/config/mcp_config.json"}"
+  [ -f "$mcp_cfg" ] || return 0
+
+  tmp="$(mktemp "${TMPDIR:-/tmp}/monk-mcp-config.XXXXXX")"
+  if command -v jq >/dev/null 2>&1; then
+    if ! jq empty "$mcp_cfg" >/dev/null 2>&1; then
+      rm -f "$tmp"
+      echo "Warning: leaving malformed Antigravity MCP config unchanged: $mcp_cfg" >&2
+      return 0
+    fi
+    if ! jq -e '.mcpServers | type == "object" and has("monk")' "$mcp_cfg" >/dev/null 2>&1; then
+      rm -f "$tmp"
+      return 0
+    fi
+    if ! jq 'del(.mcpServers.monk) | if .mcpServers == {} then del(.mcpServers) else . end' "$mcp_cfg" >"$tmp"; then
+      rm -f "$tmp"
+      echo "Warning: could not update Antigravity MCP config: $mcp_cfg" >&2
+      return 0
+    fi
+  elif command -v python3 >/dev/null 2>&1; then
+    status=0
+    python3 - "$mcp_cfg" >"$tmp" <<'PY' || status=$?
+import json
+import sys
+
+path = sys.argv[1]
+try:
+    with open(path, encoding="utf-8-sig") as source:
+        config = json.load(source)
+except (OSError, ValueError):
+    sys.exit(2)
+
+servers = config.get("mcpServers") if isinstance(config, dict) else None
+if not isinstance(servers, dict) or "monk" not in servers:
+    sys.exit(3)
+
+del servers["monk"]
+if not servers:
+    del config["mcpServers"]
+json.dump(config, sys.stdout, indent=2)
+sys.stdout.write("\n")
+PY
+    case "$status" in
+      0) ;;
+      3) rm -f "$tmp"; return 0 ;;
+      *)
+        rm -f "$tmp"
+        echo "Warning: leaving malformed Antigravity MCP config unchanged: $mcp_cfg" >&2
+        return 0
+        ;;
+    esac
+  else
+    rm -f "$tmp"
+    echo "Warning: could not inspect $mcp_cfg; remove mcpServers.monk manually (jq or python3 required)." >&2
+    return 0
+  fi
+
+  if mv "$tmp" "$mcp_cfg"; then
+    echo "Removed Monk MCP registration from $mcp_cfg" >&2
+  else
+    rm -f "$tmp"
+    echo "Warning: could not update Antigravity MCP config: $mcp_cfg" >&2
+  fi
+}
+
 stop_agent
 remove_agent_files
 if [ "$remove_runtime" = "1" ]; then
   remove_runtime
 fi
+
+remove_antigravity_mcp_registration
 
 echo "monk-agent uninstall complete."

--- a/scripts/uninstall-monk-agent.ps1
+++ b/scripts/uninstall-monk-agent.ps1
@@ -29,6 +29,9 @@ $AgentDataDir = Join-Path $MonkHome "agent"
 $PidFile = Join-Path $AgentDataDir "launcher\run\monk-agent.pid"
 $Target = Join-Path $InstallDir "monk-agent.exe"
 $Checksum = Join-Path $InstallDir "monk-agent.sha256"
+$AntigravityMcpConfig = if ($env:MONK_ANTIGRAVITY_CONFIG) { $env:MONK_ANTIGRAVITY_CONFIG } else {
+  Join-Path $HOME ".gemini\config\mcp_config.json"
+}
 
 if (-not $Yes) {
   $suffix = if ($Runtime) { " and Monk runtime" } else { "" }
@@ -135,10 +138,53 @@ fi
   wsl.exe -d $distro --user root -- sh -lc $script
 }
 
+function Remove-AntigravityMcpRegistration {
+  if (-not (Test-Path -LiteralPath $AntigravityMcpConfig -PathType Leaf)) {
+    return
+  }
+
+  try {
+    $Config = Get-Content -LiteralPath $AntigravityMcpConfig -Raw | ConvertFrom-Json
+  } catch {
+    Write-Warning "Leaving malformed Antigravity MCP config unchanged: $AntigravityMcpConfig"
+    return
+  }
+
+  if ($null -eq $Config) {
+    return
+  }
+  $ServersProperty = $Config.PSObject.Properties["mcpServers"]
+  if ($null -eq $ServersProperty -or $null -eq $ServersProperty.Value) {
+    return
+  }
+  $MonkProperty = $ServersProperty.Value.PSObject.Properties["monk"]
+  if ($null -eq $MonkProperty) {
+    return
+  }
+
+  $ServersProperty.Value.PSObject.Properties.Remove("monk")
+  if (@($ServersProperty.Value.PSObject.Properties).Count -eq 0) {
+    $Config.PSObject.Properties.Remove("mcpServers")
+  }
+
+  $Directory = Split-Path -Parent $AntigravityMcpConfig
+  $TempPath = Join-Path $Directory (".monk-mcp-config-{0}.tmp" -f [guid]::NewGuid())
+  try {
+    $Json = $Config | ConvertTo-Json -Depth 100
+    [IO.File]::WriteAllText($TempPath, $Json + [Environment]::NewLine, [Text.UTF8Encoding]::new($false))
+    Move-Item -LiteralPath $TempPath -Destination $AntigravityMcpConfig -Force
+    Write-Host "Removed Monk MCP registration from $AntigravityMcpConfig"
+  } catch {
+    Remove-Item -LiteralPath $TempPath -Force -ErrorAction SilentlyContinue
+    Write-Warning "Could not update Antigravity MCP config: $AntigravityMcpConfig"
+  }
+}
+
 Stop-ManagedAgent
 Remove-AgentFiles
 if ($Runtime) {
   Remove-MonkRuntime
 }
+Remove-AntigravityMcpRegistration
 
 Write-Host "monk-agent uninstall complete."

--- a/scripts/uninstall-monk-agent.sh
+++ b/scripts/uninstall-monk-agent.sh
@@ -156,10 +156,78 @@ remove_runtime() {
   esac
 }
 
+remove_antigravity_mcp_registration() {
+  mcp_cfg="${MONK_ANTIGRAVITY_CONFIG:-"$home_dir/.gemini/config/mcp_config.json"}"
+  [ -f "$mcp_cfg" ] || return 0
+
+  tmp="$(mktemp "${TMPDIR:-/tmp}/monk-mcp-config.XXXXXX")"
+  if command -v jq >/dev/null 2>&1; then
+    if ! jq empty "$mcp_cfg" >/dev/null 2>&1; then
+      rm -f "$tmp"
+      echo "Warning: leaving malformed Antigravity MCP config unchanged: $mcp_cfg" >&2
+      return 0
+    fi
+    if ! jq -e '.mcpServers | type == "object" and has("monk")' "$mcp_cfg" >/dev/null 2>&1; then
+      rm -f "$tmp"
+      return 0
+    fi
+    if ! jq 'del(.mcpServers.monk) | if .mcpServers == {} then del(.mcpServers) else . end' "$mcp_cfg" >"$tmp"; then
+      rm -f "$tmp"
+      echo "Warning: could not update Antigravity MCP config: $mcp_cfg" >&2
+      return 0
+    fi
+  elif command -v python3 >/dev/null 2>&1; then
+    status=0
+    python3 - "$mcp_cfg" >"$tmp" <<'PY' || status=$?
+import json
+import sys
+
+path = sys.argv[1]
+try:
+    with open(path, encoding="utf-8-sig") as source:
+        config = json.load(source)
+except (OSError, ValueError):
+    sys.exit(2)
+
+servers = config.get("mcpServers") if isinstance(config, dict) else None
+if not isinstance(servers, dict) or "monk" not in servers:
+    sys.exit(3)
+
+del servers["monk"]
+if not servers:
+    del config["mcpServers"]
+json.dump(config, sys.stdout, indent=2)
+sys.stdout.write("\n")
+PY
+    case "$status" in
+      0) ;;
+      3) rm -f "$tmp"; return 0 ;;
+      *)
+        rm -f "$tmp"
+        echo "Warning: leaving malformed Antigravity MCP config unchanged: $mcp_cfg" >&2
+        return 0
+        ;;
+    esac
+  else
+    rm -f "$tmp"
+    echo "Warning: could not inspect $mcp_cfg; remove mcpServers.monk manually (jq or python3 required)." >&2
+    return 0
+  fi
+
+  if mv "$tmp" "$mcp_cfg"; then
+    echo "Removed Monk MCP registration from $mcp_cfg" >&2
+  else
+    rm -f "$tmp"
+    echo "Warning: could not update Antigravity MCP config: $mcp_cfg" >&2
+  fi
+}
+
 stop_agent
 remove_agent_files
 if [ "$remove_runtime" = "1" ]; then
   remove_runtime
 fi
+
+remove_antigravity_mcp_registration
 
 echo "monk-agent uninstall complete."

--- a/tests/uninstall-antigravity-mcp-windows.ps1
+++ b/tests/uninstall-antigravity-mcp-windows.ps1
@@ -1,0 +1,91 @@
+param(
+  [string]$RepoRoot = (Split-Path -Parent $PSScriptRoot)
+)
+
+$ErrorActionPreference = "Stop"
+$WindowsPowerShell = Join-Path $env:SystemRoot "System32\WindowsPowerShell\v1.0\powershell.exe"
+$TempRoot = Join-Path $env:TEMP "monk-uninstall-mcp-$PID"
+$PreviousInstallDir = $env:MONK_AGENT_INSTALL_DIR
+$PreviousMonkHome = $env:MONK_AGENT_HOME
+$PreviousConfig = $env:MONK_ANTIGRAVITY_CONFIG
+
+$Scripts = @(
+  (Join-Path $RepoRoot "scripts\uninstall-monk-agent.ps1"),
+  (Join-Path $RepoRoot "plugins\monk\scripts\uninstall-monk-agent.ps1"),
+  (Join-Path $RepoRoot ".antigravity-plugin\scripts\uninstall-monk-agent.ps1")
+)
+
+function Invoke-IsolatedUninstall {
+  param(
+    [string]$Script,
+    [string]$Name,
+    [string]$ConfigText
+  )
+
+  $CaseRoot = Join-Path $TempRoot $Name
+  $ConfigPath = Join-Path $CaseRoot "config\mcp_config.json"
+  New-Item -ItemType Directory -Force -Path (Split-Path -Parent $ConfigPath) | Out-Null
+  [IO.File]::WriteAllText($ConfigPath, $ConfigText, [Text.UTF8Encoding]::new($false))
+
+  $env:MONK_AGENT_INSTALL_DIR = Join-Path $CaseRoot "install"
+  $env:MONK_AGENT_HOME = Join-Path $CaseRoot "monk-home"
+  $env:MONK_ANTIGRAVITY_CONFIG = $ConfigPath
+  New-Item -ItemType Directory -Force -Path $env:MONK_AGENT_INSTALL_DIR, $env:MONK_AGENT_HOME | Out-Null
+
+  & $WindowsPowerShell -NoProfile -ExecutionPolicy Bypass -File $Script -Yes -KeepData | Out-Null
+  if ($LASTEXITCODE -ne 0) {
+    throw "Uninstaller failed for $Name with exit code $LASTEXITCODE"
+  }
+  return $ConfigPath
+}
+
+try {
+  for ($Index = 0; $Index -lt $Scripts.Count; $Index++) {
+    $ConfigPath = Invoke-IsolatedUninstall -Script $Scripts[$Index] -Name "copy-$Index" -ConfigText @'
+{
+  "theme": "dark",
+  "mcpServers": {
+    "existing": { "serverUrl": "http://127.0.0.1:9000/mcp" },
+    "monk": { "serverUrl": "http://127.0.0.1:7419/mcp" }
+  }
+}
+'@
+    $Config = Get-Content -Raw -LiteralPath $ConfigPath | ConvertFrom-Json
+    if ($Config.theme -ne "dark") {
+      throw "Uninstaller changed an unrelated top-level value for copy $Index"
+    }
+    if ($null -eq $Config.mcpServers.existing) {
+      throw "Uninstaller removed an unrelated MCP server for copy $Index"
+    }
+    if ($null -ne $Config.mcpServers.PSObject.Properties["monk"]) {
+      throw "Uninstaller left the Monk MCP registration for copy $Index"
+    }
+  }
+
+  $EmptyConfigPath = Invoke-IsolatedUninstall -Script $Scripts[0] -Name "empty-servers" -ConfigText '{"other":true,"mcpServers":{"monk":{"serverUrl":"http://127.0.0.1:7419/mcp"}}}'
+  $EmptyConfig = Get-Content -Raw -LiteralPath $EmptyConfigPath | ConvertFrom-Json
+  if ($null -ne $EmptyConfig.PSObject.Properties["mcpServers"] -or -not $EmptyConfig.other) {
+    throw "Uninstaller did not remove the empty mcpServers object cleanly"
+  }
+
+  $Malformed = '{not-json'
+  $MalformedPath = Invoke-IsolatedUninstall -Script $Scripts[0] -Name "malformed" -ConfigText $Malformed
+  if ((Get-Content -Raw -LiteralPath $MalformedPath) -cne $Malformed) {
+    throw "Uninstaller changed malformed JSON"
+  }
+
+  $Reference = (Get-Content -Raw -LiteralPath $Scripts[0]) -replace "`r`n", "`n"
+  foreach ($Script in $Scripts[1..2]) {
+    $Copy = (Get-Content -Raw -LiteralPath $Script) -replace "`r`n", "`n"
+    if ($Copy -cne $Reference) {
+      throw "Rendered PowerShell uninstaller differs: $Script"
+    }
+  }
+} finally {
+  $env:MONK_AGENT_INSTALL_DIR = $PreviousInstallDir
+  $env:MONK_AGENT_HOME = $PreviousMonkHome
+  $env:MONK_ANTIGRAVITY_CONFIG = $PreviousConfig
+  Remove-Item -LiteralPath $TempRoot -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+Write-Host "Windows Antigravity MCP uninstall tests passed."

--- a/tests/uninstall-antigravity-mcp.sh
+++ b/tests/uninstall-antigravity-mcp.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env sh
+set -eu
+
+repo_root="${1:-$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)}"
+root="$(mktemp -d)"
+trap 'rm -rf "$root"' EXIT HUP INT TERM
+
+scripts="
+$repo_root/scripts/uninstall-monk-agent.sh
+$repo_root/plugins/monk/scripts/uninstall-monk-agent.sh
+$repo_root/.antigravity-plugin/scripts/uninstall-monk-agent.sh
+"
+
+index=0
+printf '%s\n' "$scripts" | while IFS= read -r script; do
+  [ -n "$script" ] || continue
+  case_root="$root/copy-$index"
+  config="$case_root/config/mcp_config.json"
+  mkdir -p "$(dirname "$config")" "$case_root/install" "$case_root/monk-home"
+  cat >"$config" <<'JSON'
+{
+  "theme": "dark",
+  "mcpServers": {
+    "existing": { "serverUrl": "http://127.0.0.1:9000/mcp" },
+    "monk": { "serverUrl": "http://127.0.0.1:7419/mcp" }
+  }
+}
+JSON
+
+  HOME="$case_root/home" \
+    MONK_AGENT_INSTALL_DIR="$case_root/install" \
+    MONK_AGENT_HOME="$case_root/monk-home" \
+    MONK_ANTIGRAVITY_CONFIG="$config" \
+    "$script" --yes --keep-data >/dev/null
+
+  python3 - "$config" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as source:
+    config = json.load(source)
+assert config["theme"] == "dark"
+assert config["mcpServers"]["existing"]["serverUrl"] == "http://127.0.0.1:9000/mcp"
+assert "monk" not in config["mcpServers"]
+PY
+  index=$((index + 1))
+done
+
+case_root="$root/empty-servers"
+config="$case_root/config/mcp_config.json"
+mkdir -p "$(dirname "$config")" "$case_root/install" "$case_root/monk-home"
+printf '%s\n' '{"other":true,"mcpServers":{"monk":{"serverUrl":"http://127.0.0.1:7419/mcp"}}}' >"$config"
+HOME="$case_root/home" \
+  MONK_AGENT_INSTALL_DIR="$case_root/install" \
+  MONK_AGENT_HOME="$case_root/monk-home" \
+  MONK_ANTIGRAVITY_CONFIG="$config" \
+  "$repo_root/scripts/uninstall-monk-agent.sh" --yes --keep-data >/dev/null
+python3 - "$config" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as source:
+    config = json.load(source)
+assert config == {"other": True}
+PY
+
+case_root="$root/malformed"
+config="$case_root/config/mcp_config.json"
+mkdir -p "$(dirname "$config")" "$case_root/install" "$case_root/monk-home"
+printf '%s' '{not-json' >"$config"
+cp "$config" "$config.before"
+HOME="$case_root/home" \
+  MONK_AGENT_INSTALL_DIR="$case_root/install" \
+  MONK_AGENT_HOME="$case_root/monk-home" \
+  MONK_ANTIGRAVITY_CONFIG="$config" \
+  "$repo_root/scripts/uninstall-monk-agent.sh" --yes --keep-data >/dev/null
+cmp "$config.before" "$config"
+
+cmp "$repo_root/scripts/uninstall-monk-agent.sh" "$repo_root/plugins/monk/scripts/uninstall-monk-agent.sh"
+cmp "$repo_root/scripts/uninstall-monk-agent.sh" "$repo_root/.antigravity-plugin/scripts/uninstall-monk-agent.sh"
+
+echo "POSIX Antigravity MCP uninstall tests passed."


### PR DESCRIPTION
## Summary

- Remove only `mcpServers.monk` from Antigravity's global MCP configuration during uninstall.
- Remove `mcpServers` when the Monk entry was its final member.
- Preserve unrelated MCP servers and top-level configuration.
- Leave malformed JSON unchanged and print a warning instead of destroying the file.
- Apply the fix to all three POSIX and all three PowerShell rendered uninstallers.
- Add isolated Windows and POSIX regressions to the existing install E2E workflow.

## Why

The launcher registers Monk in `~/.gemini/config/mcp_config.json`, but the official uninstallers removed only the agent binary and data. Antigravity therefore retained a dead Monk MCP server after an apparently successful uninstall.

Fixes #27.

## Validation

- `./tests/uninstall-antigravity-mcp-windows.ps1`
- `sh tests/uninstall-antigravity-mcp.sh` under WSL
- `sh -n` for all changed POSIX uninstallers and the new test
- PowerShell AST parsing for all three rendered PowerShell uninstallers
- `git diff --check`

Both test suites execute every rendered platform copy against isolated temporary homes and configurations. They verify unrelated data is preserved, the Monk registration is removed, an empty server container is removed, and malformed JSON remains byte-for-byte unchanged.
