### PR TITLE
fix: fail when launcher mutex wait times out

### DIFF
--- a/.antigravity-plugin/scripts/start-monk-agent.ps1
+++ b/.antigravity-plugin/scripts/start-monk-agent.ps1
@@ -210,9 +210,14 @@ if (Test-Path $TelemetryHelper) {
 # `exit` points need no explicit unlock.
 $LauncherMutex = New-Object System.Threading.Mutex($false, "Local\monk-agent-launcher-$Port")
 try {
-  [void]$LauncherMutex.WaitOne([TimeSpan]::FromSeconds(190))
+  $LauncherMutexAcquired = $LauncherMutex.WaitOne([TimeSpan]::FromSeconds(190))
 } catch [System.Threading.AbandonedMutexException] {
   # A previous holder died mid-start; we now own the mutex and continue.
+  $LauncherMutexAcquired = $true
+}
+if (-not $LauncherMutexAcquired) {
+  Write-Error "Timed out waiting for another monk-agent launcher on port $Port to finish."
+  exit 1
 }
 
 $ManagedAgentPath = Join-Path $InstallDir "monk-agent.exe"

--- a/.github/workflows/install-e2e.yml
+++ b/.github/workflows/install-e2e.yml
@@ -66,6 +66,10 @@ jobs:
         shell: pwsh
         run: .\tests\block-monk-windows.ps1
 
+      - name: Test Windows launcher mutex timeout
+        shell: pwsh
+        run: .\tests\start-monk-agent-mutex-timeout.ps1
+
       - name: Install monk-agent
         shell: pwsh
         env:

--- a/plugins/monk/scripts/start-monk-agent.ps1
+++ b/plugins/monk/scripts/start-monk-agent.ps1
@@ -210,9 +210,14 @@ if (Test-Path $TelemetryHelper) {
 # `exit` points need no explicit unlock.
 $LauncherMutex = New-Object System.Threading.Mutex($false, "Local\monk-agent-launcher-$Port")
 try {
-  [void]$LauncherMutex.WaitOne([TimeSpan]::FromSeconds(190))
+  $LauncherMutexAcquired = $LauncherMutex.WaitOne([TimeSpan]::FromSeconds(190))
 } catch [System.Threading.AbandonedMutexException] {
   # A previous holder died mid-start; we now own the mutex and continue.
+  $LauncherMutexAcquired = $true
+}
+if (-not $LauncherMutexAcquired) {
+  Write-Error "Timed out waiting for another monk-agent launcher on port $Port to finish."
+  exit 1
 }
 
 $ManagedAgentPath = Join-Path $InstallDir "monk-agent.exe"

--- a/scripts/start-monk-agent.ps1
+++ b/scripts/start-monk-agent.ps1
@@ -210,9 +210,14 @@ if (Test-Path $TelemetryHelper) {
 # `exit` points need no explicit unlock.
 $LauncherMutex = New-Object System.Threading.Mutex($false, "Local\monk-agent-launcher-$Port")
 try {
-  [void]$LauncherMutex.WaitOne([TimeSpan]::FromSeconds(190))
+  $LauncherMutexAcquired = $LauncherMutex.WaitOne([TimeSpan]::FromSeconds(190))
 } catch [System.Threading.AbandonedMutexException] {
   # A previous holder died mid-start; we now own the mutex and continue.
+  $LauncherMutexAcquired = $true
+}
+if (-not $LauncherMutexAcquired) {
+  Write-Error "Timed out waiting for another monk-agent launcher on port $Port to finish."
+  exit 1
 }
 
 $ManagedAgentPath = Join-Path $InstallDir "monk-agent.exe"

--- a/tests/start-monk-agent-mutex-timeout.ps1
+++ b/tests/start-monk-agent-mutex-timeout.ps1
@@ -1,0 +1,79 @@
+param(
+  [string]$RepoRoot = (Split-Path -Parent $PSScriptRoot)
+)
+
+$ErrorActionPreference = "Stop"
+$WindowsPowerShell = Join-Path $env:SystemRoot "System32\WindowsPowerShell\v1.0\powershell.exe"
+$Launchers = @(
+  "scripts\start-monk-agent.ps1",
+  "plugins\monk\scripts\start-monk-agent.ps1",
+  ".antigravity-plugin\scripts\start-monk-agent.ps1"
+)
+
+foreach ($RelativeLauncher in $Launchers) {
+  $Root = Join-Path $env:TEMP ("monk-launcher-mutex-timeout-" + [guid]::NewGuid())
+  $Port = Get-Random -Minimum 20000 -Maximum 60000
+  $Mutex = New-Object System.Threading.Mutex($false, "Local\monk-agent-launcher-$Port")
+  $Acquired = $false
+  $PreviousPort = $env:MONK_AGENT_PORT
+  $PreviousPath = $env:MONK_AGENT_PATH
+  $PreviousHome = $env:MONK_AGENT_HOME
+
+  try {
+    New-Item -ItemType Directory -Force -Path $Root | Out-Null
+    $SourcePath = Join-Path $RepoRoot $RelativeLauncher
+    $TestLauncher = Join-Path $Root "start-monk-agent.ps1"
+    $FakeAgent = Join-Path $Root "fake-agent.cmd"
+    $Marker = Join-Path $Root "fake-agent-started"
+
+    $Source = Get-Content -LiteralPath $SourcePath -Raw
+    $Source = $Source.Replace(
+      '$LauncherMutex.WaitOne([TimeSpan]::FromSeconds(190))',
+      '$LauncherMutex.WaitOne([TimeSpan]::FromMilliseconds(100))'
+    )
+    if ($Source -notmatch 'FromMilliseconds\(100\)') {
+      throw "Could not shorten the mutex wait in $RelativeLauncher."
+    }
+    Set-Content -LiteralPath $TestLauncher -Value $Source -NoNewline
+    Set-Content -LiteralPath $FakeAgent -Value "@echo off`r`necho started>$Marker`r`nexit /b 0`r`n" -NoNewline
+
+    $Acquired = $Mutex.WaitOne([TimeSpan]::FromSeconds(1))
+    if (-not $Acquired) {
+      throw "Could not acquire the test mutex for port $Port."
+    }
+
+    $env:MONK_AGENT_PORT = [string]$Port
+    $env:MONK_AGENT_PATH = $FakeAgent
+    $env:MONK_AGENT_HOME = Join-Path $Root "home"
+    $PreviousPreference = $ErrorActionPreference
+    $ErrorActionPreference = "Continue"
+    try {
+      $Output = & $WindowsPowerShell -NoProfile -ExecutionPolicy Bypass -File $TestLauncher 2>&1
+      $ExitCode = $LASTEXITCODE
+    } finally {
+      $ErrorActionPreference = $PreviousPreference
+    }
+    $OutputText = $Output | Out-String
+
+    if ($ExitCode -eq 0) {
+      throw "$RelativeLauncher unexpectedly succeeded without owning the launcher mutex."
+    }
+    if ($OutputText -notmatch 'Timed out waiting for another monk-agent launcher') {
+      throw "$RelativeLauncher did not report its mutex timeout. Output: $OutputText"
+    }
+    if (Test-Path -LiteralPath $Marker) {
+      throw "$RelativeLauncher started work after its mutex wait timed out."
+    }
+  } finally {
+    if ($Acquired) {
+      $Mutex.ReleaseMutex()
+    }
+    $Mutex.Dispose()
+    $env:MONK_AGENT_PORT = $PreviousPort
+    $env:MONK_AGENT_PATH = $PreviousPath
+    $env:MONK_AGENT_HOME = $PreviousHome
+    Remove-Item -LiteralPath $Root -Recurse -Force -ErrorAction SilentlyContinue
+  }
+}
+
+Write-Host "Windows launcher mutex timeout tests passed."


### PR DESCRIPTION
## Summary

- require the Windows launcher to own its named mutex before entering installer or process lifecycle work
- fail with a clear nonzero result when the bounded mutex wait expires
- preserve abandoned-mutex recovery, where the waiting thread becomes the owner
- keep all three distributed PowerShell launchers byte-identical
- add a deterministic regression for the timeout path to the Windows install workflow

## Root cause

`Mutex.WaitOne(timeout)` returns `false` on a normal timeout. The launcher cast that result to `void`, so a second invocation continued without owning the mutex after 190 seconds. This defeated the single-instance guard precisely when the first launcher was still slow or stuck.

## Validation

- new regression fails against current main because the old launcher reaches work after the mutex timeout
- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\tests\start-monk-agent-mutex-timeout.ps1`
- PowerShell parser checks for all changed scripts
- all three launcher copies have identical SHA-256 hashes
- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\tests\block-monk-windows.ps1`
- `git diff --check`

Fixes #146