### PR TITLE
fix: register Antigravity MCP on native Windows

### DIFF
--- a/.antigravity-plugin/scripts/start-monk-agent.ps1
+++ b/.antigravity-plugin/scripts/start-monk-agent.ps1
@@ -56,6 +56,48 @@ function Test-AgentRunning {
   }
 }
 
+function Register-AntigravityMcp {
+  $ConfigDir = Join-Path $HOME ".gemini\config"
+  if (-not (Test-Path $ConfigDir)) { return }
+
+  $ConfigPath = Join-Path $ConfigDir "mcp_config.json"
+  $ServerUrl = "http://${AgentHost}:$Port/mcp"
+  if ((Test-Path $ConfigPath) -and (Get-Item $ConfigPath).Length) {
+    try {
+      $Config = Get-Content -Raw $ConfigPath | ConvertFrom-Json
+    } catch {
+      Write-Warning "Could not register Monk MCP server because $ConfigPath is not valid JSON."
+      return
+    }
+    if ($null -eq $Config -or $Config.GetType().FullName -ne "System.Management.Automation.PSCustomObject") {
+      Write-Warning "Could not register Monk MCP server because $ConfigPath is not a JSON object."
+      return
+    }
+  } else {
+    $Config = [pscustomobject]@{}
+  }
+  if ($null -eq $Config.mcpServers -or $Config.mcpServers.GetType().FullName -ne "System.Management.Automation.PSCustomObject") {
+    Add-Member -InputObject $Config -NotePropertyName mcpServers -NotePropertyValue ([pscustomobject]@{}) -Force
+  }
+  if ($Config.mcpServers.PSObject.Properties.Name -contains "monk") {
+    if ($Config.mcpServers.monk.serverUrl -eq $ServerUrl) { return }
+    if ($null -ne $Config.mcpServers.monk -and $Config.mcpServers.monk.GetType().FullName -eq "System.Management.Automation.PSCustomObject") {
+      Add-Member -InputObject $Config.mcpServers.monk -NotePropertyName serverUrl -NotePropertyValue $ServerUrl -Force
+    } else {
+      $Config.mcpServers.monk = [pscustomobject]@{ serverUrl = $ServerUrl }
+    }
+  } else {
+    Add-Member -InputObject $Config.mcpServers -NotePropertyName monk -NotePropertyValue ([pscustomobject]@{ serverUrl = $ServerUrl })
+  }
+  $TempPath = "$ConfigPath.tmp-$PID"
+  try {
+    $Config | ConvertTo-Json -Depth 20 | Set-Content -Encoding UTF8 $TempPath
+    Move-Item -Force $TempPath $ConfigPath
+  } finally {
+    Remove-Item -Force $TempPath -ErrorAction SilentlyContinue
+  }
+}
+
 # If the agent is up but the user is not signed in to Monk, print SessionStart
 # context telling the host agent to prompt the user to sign in via /mcp. Without
 # this the host only sees "tools unavailable" and mis-reports it as a connection
@@ -245,6 +287,7 @@ $AgentHashAfter = Get-FileSha256 $AgentPath
 $AgentUpdated = $AgentHashAfter -and ($AgentHashBefore -ne $AgentHashAfter)
 
 if (-not $AgentUpdated -and (Test-AgentRunning)) {
+  Register-AntigravityMcp
   Show-SigninNudge
   exit 0
 }
@@ -273,6 +316,7 @@ $Process.Id | Set-Content -NoNewline $PidFile
 
 for ($Attempt = 0; $Attempt -lt 180; $Attempt++) {
   if (Test-AgentRunning) {
+    Register-AntigravityMcp
     Show-SigninNudge
     exit 0
   }

--- a/.antigravity-plugin/scripts/start-monk-agent.ps1
+++ b/.antigravity-plugin/scripts/start-monk-agent.ps1
@@ -91,7 +91,7 @@ function Register-AntigravityMcp {
   }
   $TempPath = "$ConfigPath.tmp-$PID"
   try {
-    $Config | ConvertTo-Json -Depth 20 | Set-Content -Encoding UTF8 $TempPath
+    $Config | ConvertTo-Json -Depth 100 | Set-Content -Encoding UTF8 $TempPath
     Move-Item -Force $TempPath $ConfigPath
   } finally {
     Remove-Item -Force $TempPath -ErrorAction SilentlyContinue

--- a/.github/workflows/install-e2e.yml
+++ b/.github/workflows/install-e2e.yml
@@ -66,6 +66,10 @@ jobs:
         shell: pwsh
         run: .\tests\block-monk-windows.ps1
 
+      - name: Test Windows Antigravity MCP registration
+        shell: pwsh
+        run: .\tests\register-antigravity-mcp-windows.ps1
+
       - name: Install monk-agent
         shell: pwsh
         env:

--- a/.github/workflows/install-e2e.yml
+++ b/.github/workflows/install-e2e.yml
@@ -67,7 +67,7 @@ jobs:
         run: .\tests\block-monk-windows.ps1
 
       - name: Test Windows Antigravity MCP registration
-        shell: pwsh
+        shell: powershell
         run: .\tests\register-antigravity-mcp-windows.ps1
 
       - name: Install monk-agent

--- a/plugins/monk/scripts/start-monk-agent.ps1
+++ b/plugins/monk/scripts/start-monk-agent.ps1
@@ -56,6 +56,48 @@ function Test-AgentRunning {
   }
 }
 
+function Register-AntigravityMcp {
+  $ConfigDir = Join-Path $HOME ".gemini\config"
+  if (-not (Test-Path $ConfigDir)) { return }
+
+  $ConfigPath = Join-Path $ConfigDir "mcp_config.json"
+  $ServerUrl = "http://${AgentHost}:$Port/mcp"
+  if ((Test-Path $ConfigPath) -and (Get-Item $ConfigPath).Length) {
+    try {
+      $Config = Get-Content -Raw $ConfigPath | ConvertFrom-Json
+    } catch {
+      Write-Warning "Could not register Monk MCP server because $ConfigPath is not valid JSON."
+      return
+    }
+    if ($null -eq $Config -or $Config.GetType().FullName -ne "System.Management.Automation.PSCustomObject") {
+      Write-Warning "Could not register Monk MCP server because $ConfigPath is not a JSON object."
+      return
+    }
+  } else {
+    $Config = [pscustomobject]@{}
+  }
+  if ($null -eq $Config.mcpServers -or $Config.mcpServers.GetType().FullName -ne "System.Management.Automation.PSCustomObject") {
+    Add-Member -InputObject $Config -NotePropertyName mcpServers -NotePropertyValue ([pscustomobject]@{}) -Force
+  }
+  if ($Config.mcpServers.PSObject.Properties.Name -contains "monk") {
+    if ($Config.mcpServers.monk.serverUrl -eq $ServerUrl) { return }
+    if ($null -ne $Config.mcpServers.monk -and $Config.mcpServers.monk.GetType().FullName -eq "System.Management.Automation.PSCustomObject") {
+      Add-Member -InputObject $Config.mcpServers.monk -NotePropertyName serverUrl -NotePropertyValue $ServerUrl -Force
+    } else {
+      $Config.mcpServers.monk = [pscustomobject]@{ serverUrl = $ServerUrl }
+    }
+  } else {
+    Add-Member -InputObject $Config.mcpServers -NotePropertyName monk -NotePropertyValue ([pscustomobject]@{ serverUrl = $ServerUrl })
+  }
+  $TempPath = "$ConfigPath.tmp-$PID"
+  try {
+    $Config | ConvertTo-Json -Depth 20 | Set-Content -Encoding UTF8 $TempPath
+    Move-Item -Force $TempPath $ConfigPath
+  } finally {
+    Remove-Item -Force $TempPath -ErrorAction SilentlyContinue
+  }
+}
+
 # If the agent is up but the user is not signed in to Monk, print SessionStart
 # context telling the host agent to prompt the user to sign in via /mcp. Without
 # this the host only sees "tools unavailable" and mis-reports it as a connection
@@ -245,6 +287,7 @@ $AgentHashAfter = Get-FileSha256 $AgentPath
 $AgentUpdated = $AgentHashAfter -and ($AgentHashBefore -ne $AgentHashAfter)
 
 if (-not $AgentUpdated -and (Test-AgentRunning)) {
+  Register-AntigravityMcp
   Show-SigninNudge
   exit 0
 }
@@ -273,6 +316,7 @@ $Process.Id | Set-Content -NoNewline $PidFile
 
 for ($Attempt = 0; $Attempt -lt 180; $Attempt++) {
   if (Test-AgentRunning) {
+    Register-AntigravityMcp
     Show-SigninNudge
     exit 0
   }

--- a/plugins/monk/scripts/start-monk-agent.ps1
+++ b/plugins/monk/scripts/start-monk-agent.ps1
@@ -91,7 +91,7 @@ function Register-AntigravityMcp {
   }
   $TempPath = "$ConfigPath.tmp-$PID"
   try {
-    $Config | ConvertTo-Json -Depth 20 | Set-Content -Encoding UTF8 $TempPath
+    $Config | ConvertTo-Json -Depth 100 | Set-Content -Encoding UTF8 $TempPath
     Move-Item -Force $TempPath $ConfigPath
   } finally {
     Remove-Item -Force $TempPath -ErrorAction SilentlyContinue

--- a/scripts/start-monk-agent.ps1
+++ b/scripts/start-monk-agent.ps1
@@ -56,6 +56,48 @@ function Test-AgentRunning {
   }
 }
 
+function Register-AntigravityMcp {
+  $ConfigDir = Join-Path $HOME ".gemini\config"
+  if (-not (Test-Path $ConfigDir)) { return }
+
+  $ConfigPath = Join-Path $ConfigDir "mcp_config.json"
+  $ServerUrl = "http://${AgentHost}:$Port/mcp"
+  if ((Test-Path $ConfigPath) -and (Get-Item $ConfigPath).Length) {
+    try {
+      $Config = Get-Content -Raw $ConfigPath | ConvertFrom-Json
+    } catch {
+      Write-Warning "Could not register Monk MCP server because $ConfigPath is not valid JSON."
+      return
+    }
+    if ($null -eq $Config -or $Config.GetType().FullName -ne "System.Management.Automation.PSCustomObject") {
+      Write-Warning "Could not register Monk MCP server because $ConfigPath is not a JSON object."
+      return
+    }
+  } else {
+    $Config = [pscustomobject]@{}
+  }
+  if ($null -eq $Config.mcpServers -or $Config.mcpServers.GetType().FullName -ne "System.Management.Automation.PSCustomObject") {
+    Add-Member -InputObject $Config -NotePropertyName mcpServers -NotePropertyValue ([pscustomobject]@{}) -Force
+  }
+  if ($Config.mcpServers.PSObject.Properties.Name -contains "monk") {
+    if ($Config.mcpServers.monk.serverUrl -eq $ServerUrl) { return }
+    if ($null -ne $Config.mcpServers.monk -and $Config.mcpServers.monk.GetType().FullName -eq "System.Management.Automation.PSCustomObject") {
+      Add-Member -InputObject $Config.mcpServers.monk -NotePropertyName serverUrl -NotePropertyValue $ServerUrl -Force
+    } else {
+      $Config.mcpServers.monk = [pscustomobject]@{ serverUrl = $ServerUrl }
+    }
+  } else {
+    Add-Member -InputObject $Config.mcpServers -NotePropertyName monk -NotePropertyValue ([pscustomobject]@{ serverUrl = $ServerUrl })
+  }
+  $TempPath = "$ConfigPath.tmp-$PID"
+  try {
+    $Config | ConvertTo-Json -Depth 20 | Set-Content -Encoding UTF8 $TempPath
+    Move-Item -Force $TempPath $ConfigPath
+  } finally {
+    Remove-Item -Force $TempPath -ErrorAction SilentlyContinue
+  }
+}
+
 # If the agent is up but the user is not signed in to Monk, print SessionStart
 # context telling the host agent to prompt the user to sign in via /mcp. Without
 # this the host only sees "tools unavailable" and mis-reports it as a connection
@@ -245,6 +287,7 @@ $AgentHashAfter = Get-FileSha256 $AgentPath
 $AgentUpdated = $AgentHashAfter -and ($AgentHashBefore -ne $AgentHashAfter)
 
 if (-not $AgentUpdated -and (Test-AgentRunning)) {
+  Register-AntigravityMcp
   Show-SigninNudge
   exit 0
 }
@@ -273,6 +316,7 @@ $Process.Id | Set-Content -NoNewline $PidFile
 
 for ($Attempt = 0; $Attempt -lt 180; $Attempt++) {
   if (Test-AgentRunning) {
+    Register-AntigravityMcp
     Show-SigninNudge
     exit 0
   }

--- a/scripts/start-monk-agent.ps1
+++ b/scripts/start-monk-agent.ps1
@@ -91,7 +91,7 @@ function Register-AntigravityMcp {
   }
   $TempPath = "$ConfigPath.tmp-$PID"
   try {
-    $Config | ConvertTo-Json -Depth 20 | Set-Content -Encoding UTF8 $TempPath
+    $Config | ConvertTo-Json -Depth 100 | Set-Content -Encoding UTF8 $TempPath
     Move-Item -Force $TempPath $ConfigPath
   } finally {
     Remove-Item -Force $TempPath -ErrorAction SilentlyContinue

--- a/tests/register-antigravity-mcp-windows.ps1
+++ b/tests/register-antigravity-mcp-windows.ps1
@@ -9,6 +9,10 @@ $Launchers = @(
   (Join-Path $RepoRoot ".antigravity-plugin\scripts\start-monk-agent.ps1")
 )
 $OriginalHome = $HOME
+$LauncherHashes = @($Launchers | ForEach-Object { (Get-FileHash -Algorithm SHA256 $_).Hash })
+if (@($LauncherHashes | Select-Object -Unique).Count -ne 1) {
+  throw "Rendered PowerShell launchers are not byte-identical"
+}
 
 try {
   foreach ($Launcher in $Launchers) {
@@ -79,15 +83,34 @@ try {
       $OldWarningPreference = $WarningPreference
       try {
         $WarningPreference = "SilentlyContinue"
-        foreach ($Seed in @('{invalid', '[]')) {
+        foreach ($Seed in @('{invalid', '[]', '[{"x":1}]', '1', 'true', '"text"')) {
           $Seed | Set-Content -NoNewline -Encoding UTF8 $ConfigPath
+          $BeforeHash = (Get-FileHash -Algorithm SHA256 $ConfigPath).Hash
           Register-AntigravityMcp
-          if ((Get-Content -Raw $ConfigPath) -ne $Seed) {
-            throw "Invalid or non-object config was overwritten: $Launcher"
+          $AfterHash = (Get-FileHash -Algorithm SHA256 $ConfigPath).Hash
+          if ($AfterHash -ne $BeforeHash) {
+            throw "Invalid or non-object config bytes were overwritten: $Launcher"
           }
         }
       } finally {
         $WarningPreference = $OldWarningPreference
+      }
+
+      $Nested = [pscustomobject]@{ leaf = "preserve-me" }
+      for ($Depth = 0; $Depth -lt 22; $Depth++) {
+        $Nested = [pscustomobject]@{ next = $Nested }
+      }
+      [pscustomobject]@{ unrelated = $Nested } |
+        ConvertTo-Json -Depth 100 |
+        Set-Content -Encoding UTF8 $ConfigPath
+      Register-AntigravityMcp
+      $Config = Get-Content -Raw $ConfigPath | ConvertFrom-Json
+      $Cursor = $Config.unrelated
+      for ($Depth = 0; $Depth -lt 22; $Depth++) {
+        $Cursor = $Cursor.next
+      }
+      if ($Cursor.leaf -ne "preserve-me") {
+        throw "Nested unrelated config was not preserved: $Launcher"
       }
     } finally {
       Set-Variable -Name HOME -Value $OriginalHome -Force

--- a/tests/register-antigravity-mcp-windows.ps1
+++ b/tests/register-antigravity-mcp-windows.ps1
@@ -1,0 +1,101 @@
+param(
+  [string]$RepoRoot = (Split-Path -Parent $PSScriptRoot)
+)
+
+$ErrorActionPreference = "Stop"
+$Launchers = @(
+  (Join-Path $RepoRoot "scripts\start-monk-agent.ps1"),
+  (Join-Path $RepoRoot "plugins\monk\scripts\start-monk-agent.ps1"),
+  (Join-Path $RepoRoot ".antigravity-plugin\scripts\start-monk-agent.ps1")
+)
+$OriginalHome = $HOME
+
+try {
+  foreach ($Launcher in $Launchers) {
+    $Tokens = $null
+    $Errors = $null
+    $Ast = [System.Management.Automation.Language.Parser]::ParseFile($Launcher, [ref]$Tokens, [ref]$Errors)
+    if ($Errors.Count) { throw "PowerShell parse failed: $Launcher" }
+
+    $Function = $Ast.Find({
+      param($Node)
+      $Node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
+        $Node.Name -eq "Register-AntigravityMcp"
+    }, $true)
+    if (-not $Function) { throw "Missing Register-AntigravityMcp: $Launcher" }
+
+    $Source = Get-Content -Raw $Launcher
+    if ([regex]::Matches($Source, 'Register-AntigravityMcp').Count -ne 3) {
+      throw "Registration must run on both successful launcher paths: $Launcher"
+    }
+
+    $TempHome = Join-Path $env:TEMP ("monk-register-mcp-" + [guid]::NewGuid())
+    $ConfigDir = Join-Path $TempHome ".gemini\config"
+    $ConfigPath = Join-Path $ConfigDir "mcp_config.json"
+    New-Item -ItemType Directory -Force $ConfigDir | Out-Null
+    '{"preferences":{"theme":"dark"},"mcpServers":{"existing":{"serverUrl":"http://127.0.0.1:9000/mcp"}}}' |
+      Set-Content -NoNewline -Encoding UTF8 $ConfigPath
+
+    try {
+      Set-Variable -Name HOME -Value $TempHome -Force
+      $AgentHost = "127.0.0.1"
+      $Port = "17419"
+      Invoke-Expression $Function.Extent.Text
+      Register-AntigravityMcp
+      Register-AntigravityMcp
+
+      $Config = Get-Content -Raw $ConfigPath | ConvertFrom-Json
+      if ($Config.preferences.theme -ne "dark") { throw "Unrelated config changed: $Launcher" }
+      if ($Config.mcpServers.existing.serverUrl -ne "http://127.0.0.1:9000/mcp") {
+        throw "Existing MCP server changed: $Launcher"
+      }
+      if ($Config.mcpServers.monk.serverUrl -ne "http://127.0.0.1:17419/mcp") {
+        throw "Monk MCP URL missing or incorrect: $Launcher"
+      }
+      if (@($Config.mcpServers.PSObject.Properties.Name | Where-Object { $_ -eq "monk" }).Count -ne 1) {
+        throw "Monk MCP registration is not idempotent: $Launcher"
+      }
+
+      foreach ($Seed in @('{}', '{"mcpServers":null}', '{"mcpServers":"invalid"}')) {
+        $Seed | Set-Content -NoNewline -Encoding UTF8 $ConfigPath
+        Register-AntigravityMcp
+        $Config = Get-Content -Raw $ConfigPath | ConvertFrom-Json
+        if ($Config.mcpServers.monk.serverUrl -ne "http://127.0.0.1:17419/mcp") {
+          throw "Monk MCP URL missing when mcpServers is absent, null, or non-object: $Launcher"
+        }
+      }
+
+      '{"mcpServers":{"monk":{"serverUrl":"http://127.0.0.1:7419/mcp","transport":"http"}}}' |
+        Set-Content -NoNewline -Encoding UTF8 $ConfigPath
+      Register-AntigravityMcp
+      $Config = Get-Content -Raw $ConfigPath | ConvertFrom-Json
+      if ($Config.mcpServers.monk.serverUrl -ne "http://127.0.0.1:17419/mcp") {
+        throw "Stale Monk MCP URL was not updated: $Launcher"
+      }
+      if ($Config.mcpServers.monk.transport -ne "http") {
+        throw "Existing Monk MCP properties were not preserved: $Launcher"
+      }
+
+      $OldWarningPreference = $WarningPreference
+      try {
+        $WarningPreference = "SilentlyContinue"
+        foreach ($Seed in @('{invalid', '[]')) {
+          $Seed | Set-Content -NoNewline -Encoding UTF8 $ConfigPath
+          Register-AntigravityMcp
+          if ((Get-Content -Raw $ConfigPath) -ne $Seed) {
+            throw "Invalid or non-object config was overwritten: $Launcher"
+          }
+        }
+      } finally {
+        $WarningPreference = $OldWarningPreference
+      }
+    } finally {
+      Set-Variable -Name HOME -Value $OriginalHome -Force
+      Remove-Item -Recurse -Force $TempHome -ErrorAction SilentlyContinue
+    }
+  }
+} finally {
+  Set-Variable -Name HOME -Value $OriginalHome -Force
+}
+
+Write-Host "Windows Antigravity MCP registration tests passed."


### PR DESCRIPTION
## Summary

- register Monk in Antigravity's global MCP config from native Windows setup
- preserve unrelated config and existing MCP server properties
- create absent/null/non-object `mcpServers` and refresh stale Monk endpoint URLs
- leave malformed or non-object root JSON untouched with a warning
- run registration on both successful launcher paths
- test all three rendered PowerShell launchers on Windows CI

## Test plan

- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests/register-antigravity-mcp-windows.ps1`
- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests/block-monk-windows.ps1`
- PowerShell AST parsing across every `.ps1`
- byte parity across all three rendered PowerShell launchers
- POSIX `sh -n` across tracked shell scripts
- `git diff --check`

Fixes #148
