### PR TITLE
fix: wait for old POSIX agent before restart

### DIFF
--- a/scripts/start-monk-agent.sh
+++ b/scripts/start-monk-agent.sh
@@ -340,8 +340,22 @@ EOF
 start_with_background_process() {
   if [ -f "$pid_file" ]; then
     old_pid="$(cat "$pid_file" 2>/dev/null || true)"
+    case "$old_pid" in
+      ''|0|*[!0-9]*) old_pid="" ;;
+    esac
     if [ -n "$old_pid" ]; then
-      kill "$old_pid" >/dev/null 2>&1 || true
+      if kill -0 "$old_pid" >/dev/null 2>&1; then
+        kill -TERM "$old_pid" >/dev/null 2>&1 || true
+        wait_tries=0
+        while kill -0 "$old_pid" >/dev/null 2>&1; do
+          if [ "$wait_tries" -ge 30 ]; then
+            echo "monk-agent pid $old_pid did not exit within 30s after SIGTERM." >&2
+            return 1
+          fi
+          wait_tries=$((wait_tries + 1))
+          sleep 1
+        done
+      fi
     fi
   fi
   export MONK_AUTH_URL="$auth_url"

--- a/tests/start-monk-agent-posix-restart-test.sh
+++ b/tests/start-monk-agent-posix-restart-test.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env sh
+set -eu
+
+repo_root="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+tmp="$(mktemp -d)"
+cleanup() {
+  if [ -f "$tmp/old.pid" ]; then
+    old_pid="$(cat "$tmp/old.pid" 2>/dev/null || true)"
+    case "$old_pid" in ''|0|*[!0-9]*) ;; *) kill "$old_pid" >/dev/null 2>&1 || true ;; esac
+  fi
+  if [ -f "$tmp/new.pid" ]; then
+    new_pid="$(cat "$tmp/new.pid" 2>/dev/null || true)"
+    case "$new_pid" in ''|0|*[!0-9]*) ;; *) kill "$new_pid" >/dev/null 2>&1 || true ;; esac
+  fi
+  rm -rf "$tmp"
+}
+trap cleanup EXIT HUP INT TERM
+
+cat >"$tmp/uname" <<'EOF'
+#!/usr/bin/env sh
+printf '%s\n' Linux
+EOF
+chmod +x "$tmp/uname"
+
+cat >"$tmp/curl" <<'EOF'
+#!/usr/bin/env sh
+if [ -f "$TEST_NEW_STARTED_FILE" ]; then
+  printf '{"resource":"http://127.0.0.1:7419/mcp"}\n'
+  exit 0
+fi
+exit 7
+EOF
+chmod +x "$tmp/curl"
+
+cat >"$tmp/monk-agent" <<'EOF'
+#!/usr/bin/env sh
+if [ ! -f "$TEST_OLD_EXIT_FILE" ]; then
+  printf 'replacement started before old pid exited\n' >"$TEST_VIOLATION_FILE"
+fi
+printf '%s\n' "$$" >"$TEST_NEW_PID_FILE"
+touch "$TEST_NEW_STARTED_FILE"
+while :; do sleep 1; done
+EOF
+chmod +x "$tmp/monk-agent"
+
+export TEST_OLD_EXIT_FILE="$tmp/old-exited"
+export TEST_NEW_STARTED_FILE="$tmp/new-started"
+export TEST_NEW_PID_FILE="$tmp/new.pid"
+export TEST_VIOLATION_FILE="$tmp/violation"
+
+(
+  trap 'sleep 2; touch "$TEST_OLD_EXIT_FILE"; exit 0' TERM
+  while :; do sleep 1; done
+) &
+old_pid="$!"
+printf '%s\n' "$old_pid" >"$tmp/old.pid"
+
+pid_dir="$tmp/home/agent/launcher/run"
+mkdir -p "$pid_dir"
+printf '%s\n' "$old_pid" >"$pid_dir/monk-agent.pid"
+
+PATH="$tmp:$PATH" \
+HOME="$tmp/user-home" \
+MONK_AGENT_HOME="$tmp/home" \
+MONK_AGENT_PATH="$tmp/monk-agent" \
+MONK_AGENT_SKIP_ENSURE=1 \
+MONK_AGENT_PORT=7419 \
+MONK_AGENT_HOST=127.0.0.1 \
+"$repo_root/scripts/start-monk-agent.sh" >/dev/null
+
+if [ -f "$TEST_VIOLATION_FILE" ]; then
+  cat "$TEST_VIOLATION_FILE" >&2
+  exit 1
+fi
+if [ ! -f "$TEST_OLD_EXIT_FILE" ]; then
+  echo "old pid did not receive SIGTERM and exit" >&2
+  exit 1
+fi
+if [ ! -f "$TEST_NEW_STARTED_FILE" ]; then
+  echo "replacement agent was not started" >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- Wait for the recorded POSIX background companion PID to exit after SIGTERM before starting the replacement agent.
- Reject empty, zero, and non-numeric pid-file contents before signalling.
- Add a POSIX regression test that fails if the replacement starts before the old companion has completed its delayed shutdown.

Fixes monk-io/monk-plugin#154.

## Tests
- `sh -n scripts/start-monk-agent.sh`
- `sh -n tests/start-monk-agent-posix-restart-test.sh`
- `sh tests/start-monk-agent-posix-restart-test.sh`

Note: `shellcheck` was not available in this environment.
