### PR TITLE
fix: parse POSIX block-monk fallback commands

### DIFF
--- a/.antigravity-plugin/hooks/block-monk.sh
+++ b/.antigravity-plugin/hooks/block-monk.sh
@@ -8,9 +8,9 @@
 #   stdout: {"decision":"deny","reason":"..."} to block, or exit 0 to allow
 #
 # The decision is made by `monk-agent hook block-monk` so the only dependency is
-# the monk-agent binary the plugin already installs. If that binary is missing we
-# fall back to pure POSIX shell + grep, biased toward BLOCKING. The hook always
-# exits 0 (the deny JSON is the block signal).
+# the monk-agent binary the plugin already installs. If that binary is missing,
+# we inspect the command payload locally and keep a grep last resort for hosts
+# without python3. The hook always exits 0 (the deny JSON is the block signal).
 
 set -eu
 
@@ -30,9 +30,129 @@ if [ -x "$agent" ]; then
   fi
 fi
 
-# Fallback: binary unavailable. Grep the raw hook payload for a `monk` command
-# in command position. False positives only ever BLOCK, never allow.
-if printf '%s' "$input" | grep -Eq '(^|["[:space:];&|`(])(sudo[[:space:]]+)?monk([[:space:]"]|$)'; then
+monk_fallback_matches() {
+  if command -v python3 >/dev/null 2>&1; then
+    MONK_HOOK_PAYLOAD="$input" python3 - <<'PY'
+import json
+import os
+import sys
+
+payload = os.environ.get("MONK_HOOK_PAYLOAD", "")
+
+try:
+    data = json.loads(payload)
+except Exception:
+    command = payload
+else:
+    command = payload
+    if isinstance(data, dict):
+        tool_call = data.get("toolCall")
+        if isinstance(tool_call, dict):
+            args = tool_call.get("args")
+            if isinstance(args, dict) and isinstance(args.get("CommandLine"), str):
+                command = args["CommandLine"]
+        tool_input = data.get("tool_input")
+        if isinstance(tool_input, dict) and isinstance(tool_input.get("command"), str):
+            command = tool_input["command"]
+
+
+def command_parts(value):
+    start = 0
+    quote = ""
+    escaped = False
+    for index, char in enumerate(value):
+        if escaped:
+            escaped = False
+            continue
+        if char == "\\" and quote != "'":
+            escaped = True
+            continue
+        if quote:
+            if char == quote:
+                quote = ""
+            continue
+        if char in ("'", '"'):
+            quote = char
+            continue
+        if char in ";&|`\n\r":
+            yield value[start:index]
+            start = index + 1
+    yield value[start:]
+
+
+def next_token(value, index):
+    while index < len(value) and (value[index].isspace() or value[index] == "("):
+        index += 1
+    token = []
+    quote = ""
+    escaped = False
+    while index < len(value):
+        char = value[index]
+        if escaped:
+            token.append(char)
+            escaped = False
+            index += 1
+            continue
+        if quote:
+            if char == quote:
+                quote = ""
+                index += 1
+                continue
+            if char == "\\" and quote == '"':
+                escaped = True
+                index += 1
+                continue
+            token.append(char)
+            index += 1
+            continue
+        if char == "\\":
+            escaped = True
+            index += 1
+            continue
+        if char in ("'", '"'):
+            quote = char
+            index += 1
+            continue
+        if char.isspace() or char in ";&|`":
+            break
+        token.append(char)
+        index += 1
+    return "".join(token), index
+
+
+def monk_token(token):
+    return token == "monk" or token.endswith("/monk") or token.endswith("/monk.exe")
+
+
+def part_invokes_monk(part):
+    index = 0
+    in_env = False
+    for _ in range(10):
+        token, index = next_token(part, index)
+        if not token:
+            return False
+        if token in ("sudo", "command"):
+            continue
+        if token == "env":
+            in_env = True
+            continue
+        if in_env and (token.startswith("-") or ("=" in token and "/" not in token)):
+            continue
+        return monk_token(token)
+    return False
+
+
+sys.exit(0 if any(part_invokes_monk(part) for part in command_parts(command)) else 1)
+PY
+    return $?
+  fi
+
+  # Last-resort fallback: binary and python unavailable. Grep the raw hook
+  # payload for a command-position `monk` form. False positives only ever block.
+  printf '%s' "$input" | grep -Eq '(^|["'"'"'\\;;&|`(])[[:space:]]*(sudo[[:space:]]+)?["'"'"'\\]*monk(["'"'"'\\]*)([[:space:]"]|$)'
+}
+
+if monk_fallback_matches; then
   cat <<'JSON'
 {
   "decision": "deny",

--- a/hooks/block-monk.sh
+++ b/hooks/block-monk.sh
@@ -5,9 +5,9 @@
 #
 # The decision is made by `monk-agent hook block-monk` so the only dependency is
 # the monk-agent binary the plugin already installs. If that binary is somehow
-# missing we fall back to pure POSIX shell + grep, biased toward BLOCKING: a
-# `monk` invocation is still caught with zero tooling, and non-monk commands are
-# never blocked. The hook always exits 0 (the deny JSON is the block signal).
+# missing, we inspect the command payload locally and keep a grep last resort for
+# hosts without python3. The hook always exits 0 (the deny JSON is the block
+# signal).
 
 set -eu
 
@@ -27,11 +27,129 @@ if [ -x "$agent" ]; then
   fi
 fi
 
-# Fallback: binary unavailable. Grep the raw hook payload for a `monk` command.
-# Matches `monk` only in command position (start, or after a shell separator),
-# optional `sudo`, followed by whitespace/quote/end — so `monkey` is not matched.
-# False positives only ever BLOCK, never allow, which is the safe direction.
-if printf '%s' "$input" | grep -Eq '(^|["[:space:];&|`(])(sudo[[:space:]]+)?monk([[:space:]"]|$)'; then
+monk_fallback_matches() {
+  if command -v python3 >/dev/null 2>&1; then
+    MONK_HOOK_PAYLOAD="$input" python3 - <<'PY'
+import json
+import os
+import sys
+
+payload = os.environ.get("MONK_HOOK_PAYLOAD", "")
+
+try:
+    data = json.loads(payload)
+except Exception:
+    command = payload
+else:
+    command = payload
+    if isinstance(data, dict):
+        tool_call = data.get("toolCall")
+        if isinstance(tool_call, dict):
+            args = tool_call.get("args")
+            if isinstance(args, dict) and isinstance(args.get("CommandLine"), str):
+                command = args["CommandLine"]
+        tool_input = data.get("tool_input")
+        if isinstance(tool_input, dict) and isinstance(tool_input.get("command"), str):
+            command = tool_input["command"]
+
+
+def command_parts(value):
+    start = 0
+    quote = ""
+    escaped = False
+    for index, char in enumerate(value):
+        if escaped:
+            escaped = False
+            continue
+        if char == "\\" and quote != "'":
+            escaped = True
+            continue
+        if quote:
+            if char == quote:
+                quote = ""
+            continue
+        if char in ("'", '"'):
+            quote = char
+            continue
+        if char in ";&|`\n\r":
+            yield value[start:index]
+            start = index + 1
+    yield value[start:]
+
+
+def next_token(value, index):
+    while index < len(value) and (value[index].isspace() or value[index] == "("):
+        index += 1
+    token = []
+    quote = ""
+    escaped = False
+    while index < len(value):
+        char = value[index]
+        if escaped:
+            token.append(char)
+            escaped = False
+            index += 1
+            continue
+        if quote:
+            if char == quote:
+                quote = ""
+                index += 1
+                continue
+            if char == "\\" and quote == '"':
+                escaped = True
+                index += 1
+                continue
+            token.append(char)
+            index += 1
+            continue
+        if char == "\\":
+            escaped = True
+            index += 1
+            continue
+        if char in ("'", '"'):
+            quote = char
+            index += 1
+            continue
+        if char.isspace() or char in ";&|`":
+            break
+        token.append(char)
+        index += 1
+    return "".join(token), index
+
+
+def monk_token(token):
+    return token == "monk" or token.endswith("/monk") or token.endswith("/monk.exe")
+
+
+def part_invokes_monk(part):
+    index = 0
+    in_env = False
+    for _ in range(10):
+        token, index = next_token(part, index)
+        if not token:
+            return False
+        if token in ("sudo", "command"):
+            continue
+        if token == "env":
+            in_env = True
+            continue
+        if in_env and (token.startswith("-") or ("=" in token and "/" not in token)):
+            continue
+        return monk_token(token)
+    return False
+
+
+sys.exit(0 if any(part_invokes_monk(part) for part in command_parts(command)) else 1)
+PY
+    return $?
+  fi
+
+  # Last-resort fallback: binary and python unavailable. Grep the raw hook
+  # payload for a command-position `monk` form. False positives only ever block.
+  printf '%s' "$input" | grep -Eq '(^|["'"'"'\\;;&|`(])[[:space:]]*(sudo[[:space:]]+)?["'"'"'\\]*monk(["'"'"'\\]*)([[:space:]"]|$)'
+}
+
+if monk_fallback_matches; then
   cat <<'JSON'
 {
   "hookSpecificOutput": {

--- a/plugins/monk/hooks/block-monk.sh
+++ b/plugins/monk/hooks/block-monk.sh
@@ -5,9 +5,9 @@
 #
 # The decision is made by `monk-agent hook block-monk` so the only dependency is
 # the monk-agent binary the plugin already installs. If that binary is somehow
-# missing we fall back to pure POSIX shell + grep, biased toward BLOCKING: a
-# `monk` invocation is still caught with zero tooling, and non-monk commands are
-# never blocked. The hook always exits 0 (the deny JSON is the block signal).
+# missing, we inspect the command payload locally and keep a grep last resort for
+# hosts without python3. The hook always exits 0 (the deny JSON is the block
+# signal).
 
 set -eu
 
@@ -27,11 +27,129 @@ if [ -x "$agent" ]; then
   fi
 fi
 
-# Fallback: binary unavailable. Grep the raw hook payload for a `monk` command.
-# Matches `monk` only in command position (start, or after a shell separator),
-# optional `sudo`, followed by whitespace/quote/end — so `monkey` is not matched.
-# False positives only ever BLOCK, never allow, which is the safe direction.
-if printf '%s' "$input" | grep -Eq '(^|["[:space:];&|`(])(sudo[[:space:]]+)?monk([[:space:]"]|$)'; then
+monk_fallback_matches() {
+  if command -v python3 >/dev/null 2>&1; then
+    MONK_HOOK_PAYLOAD="$input" python3 - <<'PY'
+import json
+import os
+import sys
+
+payload = os.environ.get("MONK_HOOK_PAYLOAD", "")
+
+try:
+    data = json.loads(payload)
+except Exception:
+    command = payload
+else:
+    command = payload
+    if isinstance(data, dict):
+        tool_call = data.get("toolCall")
+        if isinstance(tool_call, dict):
+            args = tool_call.get("args")
+            if isinstance(args, dict) and isinstance(args.get("CommandLine"), str):
+                command = args["CommandLine"]
+        tool_input = data.get("tool_input")
+        if isinstance(tool_input, dict) and isinstance(tool_input.get("command"), str):
+            command = tool_input["command"]
+
+
+def command_parts(value):
+    start = 0
+    quote = ""
+    escaped = False
+    for index, char in enumerate(value):
+        if escaped:
+            escaped = False
+            continue
+        if char == "\\" and quote != "'":
+            escaped = True
+            continue
+        if quote:
+            if char == quote:
+                quote = ""
+            continue
+        if char in ("'", '"'):
+            quote = char
+            continue
+        if char in ";&|`\n\r":
+            yield value[start:index]
+            start = index + 1
+    yield value[start:]
+
+
+def next_token(value, index):
+    while index < len(value) and (value[index].isspace() or value[index] == "("):
+        index += 1
+    token = []
+    quote = ""
+    escaped = False
+    while index < len(value):
+        char = value[index]
+        if escaped:
+            token.append(char)
+            escaped = False
+            index += 1
+            continue
+        if quote:
+            if char == quote:
+                quote = ""
+                index += 1
+                continue
+            if char == "\\" and quote == '"':
+                escaped = True
+                index += 1
+                continue
+            token.append(char)
+            index += 1
+            continue
+        if char == "\\":
+            escaped = True
+            index += 1
+            continue
+        if char in ("'", '"'):
+            quote = char
+            index += 1
+            continue
+        if char.isspace() or char in ";&|`":
+            break
+        token.append(char)
+        index += 1
+    return "".join(token), index
+
+
+def monk_token(token):
+    return token == "monk" or token.endswith("/monk") or token.endswith("/monk.exe")
+
+
+def part_invokes_monk(part):
+    index = 0
+    in_env = False
+    for _ in range(10):
+        token, index = next_token(part, index)
+        if not token:
+            return False
+        if token in ("sudo", "command"):
+            continue
+        if token == "env":
+            in_env = True
+            continue
+        if in_env and (token.startswith("-") or ("=" in token and "/" not in token)):
+            continue
+        return monk_token(token)
+    return False
+
+
+sys.exit(0 if any(part_invokes_monk(part) for part in command_parts(command)) else 1)
+PY
+    return $?
+  fi
+
+  # Last-resort fallback: binary and python unavailable. Grep the raw hook
+  # payload for a command-position `monk` form. False positives only ever block.
+  printf '%s' "$input" | grep -Eq '(^|["'"'"'\\;;&|`(])[[:space:]]*(sudo[[:space:]]+)?["'"'"'\\]*monk(["'"'"'\\]*)([[:space:]"]|$)'
+}
+
+if monk_fallback_matches; then
   cat <<'JSON'
 {
   "hookSpecificOutput": {

--- a/tests/block-monk-posix.py
+++ b/tests/block-monk-posix.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+import json
+import os
+import subprocess
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MISSING_AGENT = str(REPO_ROOT / ".missing-monk-agent-for-posix-test")
+
+CASES = [
+    ("direct", "monk status", True),
+    ("double_quoted", '"monk" status', True),
+    ("single_quoted", "'monk' status", True),
+    ("backslash_escaped", r"\monk status", True),
+    ("sudo_quoted", 'sudo "monk" deploy', True),
+    ("command_wrapper", "command monk deploy", True),
+    ("env_wrapper", "env FOO=bar monk deploy", True),
+    ("separator", "echo ok; monk deploy", True),
+    ("similar_command", "monkey deploy", False),
+    ("harmless_argument", "grep monk README.md", False),
+    ("quoted_argument", 'grep "monk" README.md', False),
+]
+
+HOOKS = [
+    ("hooks/block-monk.sh", "claude"),
+    ("plugins/monk/hooks/block-monk.sh", "claude"),
+    (".antigravity-plugin/hooks/block-monk.sh", "antigravity"),
+]
+
+
+def payload_for(format_name, command):
+    if format_name == "claude":
+        return json.dumps({"tool_input": {"command": command}})
+    return json.dumps({"toolCall": {"name": "run_command", "args": {"CommandLine": command}}})
+
+
+def denied_by_output(format_name, output):
+    if format_name == "claude":
+        return '"permissionDecision"' in output and '"deny"' in output
+    return '"decision"' in output and '"deny"' in output
+
+
+def main():
+    env = os.environ.copy()
+    env["MONK_AGENT_PATH"] = MISSING_AGENT
+
+    for hook, format_name in HOOKS:
+        for name, command, expected in CASES:
+            proc = subprocess.run(
+                [str(REPO_ROOT / hook)],
+                input=payload_for(format_name, command),
+                text=True,
+                capture_output=True,
+                env=env,
+                check=False,
+            )
+            denied = denied_by_output(format_name, proc.stdout)
+            if denied != expected:
+                raise AssertionError(
+                    f"{hook} case {name!r} expected denied={expected}, got denied={denied}; "
+                    f"stdout={proc.stdout!r} stderr={proc.stderr!r}"
+                )
+
+    print("POSIX block-monk fallback tests passed.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Fixes #55.

## Summary

- parse the actual hook command payload in POSIX fallback mode when `monk-agent` is unavailable
- deny quoted, backslash-escaped, `sudo`, `command`, and simple `env` wrapper forms that still invoke the `monk` CLI
- keep harmless argument uses like `grep monk README.md` and `grep "monk" README.md` allowed
- apply the fallback fix to the root, packaged Monk, and Antigravity hook copies

## Verification

- `python3 tests/block-monk-posix.py`
- `sh -n .antigravity-plugin/hooks/block-monk.sh`
- `sh -n hooks/block-monk.sh`
- `sh -n plugins/monk/hooks/block-monk.sh`
- `git diff --check`
