### PR TITLE
fix: retry Linux background launcher after early exit

### DIFF
--- a/.antigravity-plugin/scripts/start-monk-agent.sh
+++ b/.antigravity-plugin/scripts/start-monk-agent.sh
@@ -23,6 +23,14 @@ elif [ "$ready_timeout" -gt 150 ]; then
   ready_timeout=150
 fi
 
+background_restart_limit="${MONK_AGENT_BACKGROUND_RESTARTS:-3}"
+case "$background_restart_limit" in
+  ''|*[!0-9]*) background_restart_limit=3 ;;
+esac
+if [ "$background_restart_limit" -gt 10 ]; then
+  background_restart_limit=10
+fi
+
 # Rendered at plugin build time; carries MONK_PLUGIN_VERSION so the agent can
 # report the real plugin version in telemetry. Guarded: an older rendered
 # plugin without the file must still launch (the agent falls back to a labeled
@@ -468,6 +476,7 @@ case "$os" in
   *) start_with_background_process ;;
 esac
 
+background_restarts=0
 ready_deadline=$(( $(date +%s) + ready_timeout ))
 while [ "$(date +%s)" -lt "$ready_deadline" ]; do
   if is_running; then
@@ -480,6 +489,13 @@ while [ "$(date +%s)" -lt "$ready_deadline" ]; do
   if [ -f "$pid_file" ]; then
     _pid="$(cat "$pid_file" 2>/dev/null || true)"
     if [ -n "$_pid" ] && ! kill -0 "$_pid" 2>/dev/null; then
+      if [ "$os" != "Darwin" ] && [ "$background_restarts" -lt "$background_restart_limit" ]; then
+        background_restarts=$((background_restarts + 1))
+        echo "monk-agent exited before readiness; retrying background start ($background_restarts/$background_restart_limit)." >&2
+        start_with_background_process
+        sleep 1
+        continue
+      fi
       break
     fi
   fi

--- a/.github/workflows/install-e2e.yml
+++ b/.github/workflows/install-e2e.yml
@@ -58,6 +58,10 @@ jobs:
         shell: bash
         run: ./tests/start-monk-agent-fastpath.sh
 
+      - name: Check launcher background retry
+        shell: bash
+        run: ./tests/start-monk-agent-background-retry.sh
+
       - name: Check launcher readiness deadline
         shell: bash
         run: ./tests/start-monk-agent-readiness-timeout.sh

--- a/plugins/monk/scripts/start-monk-agent.sh
+++ b/plugins/monk/scripts/start-monk-agent.sh
@@ -23,6 +23,14 @@ elif [ "$ready_timeout" -gt 150 ]; then
   ready_timeout=150
 fi
 
+background_restart_limit="${MONK_AGENT_BACKGROUND_RESTARTS:-3}"
+case "$background_restart_limit" in
+  ''|*[!0-9]*) background_restart_limit=3 ;;
+esac
+if [ "$background_restart_limit" -gt 10 ]; then
+  background_restart_limit=10
+fi
+
 # Rendered at plugin build time; carries MONK_PLUGIN_VERSION so the agent can
 # report the real plugin version in telemetry. Guarded: an older rendered
 # plugin without the file must still launch (the agent falls back to a labeled
@@ -468,6 +476,7 @@ case "$os" in
   *) start_with_background_process ;;
 esac
 
+background_restarts=0
 ready_deadline=$(( $(date +%s) + ready_timeout ))
 while [ "$(date +%s)" -lt "$ready_deadline" ]; do
   if is_running; then
@@ -480,6 +489,13 @@ while [ "$(date +%s)" -lt "$ready_deadline" ]; do
   if [ -f "$pid_file" ]; then
     _pid="$(cat "$pid_file" 2>/dev/null || true)"
     if [ -n "$_pid" ] && ! kill -0 "$_pid" 2>/dev/null; then
+      if [ "$os" != "Darwin" ] && [ "$background_restarts" -lt "$background_restart_limit" ]; then
+        background_restarts=$((background_restarts + 1))
+        echo "monk-agent exited before readiness; retrying background start ($background_restarts/$background_restart_limit)." >&2
+        start_with_background_process
+        sleep 1
+        continue
+      fi
       break
     fi
   fi

--- a/scripts/start-monk-agent.sh
+++ b/scripts/start-monk-agent.sh
@@ -23,6 +23,14 @@ elif [ "$ready_timeout" -gt 150 ]; then
   ready_timeout=150
 fi
 
+background_restart_limit="${MONK_AGENT_BACKGROUND_RESTARTS:-3}"
+case "$background_restart_limit" in
+  ''|*[!0-9]*) background_restart_limit=3 ;;
+esac
+if [ "$background_restart_limit" -gt 10 ]; then
+  background_restart_limit=10
+fi
+
 # Rendered at plugin build time; carries MONK_PLUGIN_VERSION so the agent can
 # report the real plugin version in telemetry. Guarded: an older rendered
 # plugin without the file must still launch (the agent falls back to a labeled
@@ -468,6 +476,7 @@ case "$os" in
   *) start_with_background_process ;;
 esac
 
+background_restarts=0
 ready_deadline=$(( $(date +%s) + ready_timeout ))
 while [ "$(date +%s)" -lt "$ready_deadline" ]; do
   if is_running; then
@@ -480,6 +489,13 @@ while [ "$(date +%s)" -lt "$ready_deadline" ]; do
   if [ -f "$pid_file" ]; then
     _pid="$(cat "$pid_file" 2>/dev/null || true)"
     if [ -n "$_pid" ] && ! kill -0 "$_pid" 2>/dev/null; then
+      if [ "$os" != "Darwin" ] && [ "$background_restarts" -lt "$background_restart_limit" ]; then
+        background_restarts=$((background_restarts + 1))
+        echo "monk-agent exited before readiness; retrying background start ($background_restarts/$background_restart_limit)." >&2
+        start_with_background_process
+        sleep 1
+        continue
+      fi
       break
     fi
   fi

--- a/tests/start-monk-agent-background-retry.sh
+++ b/tests/start-monk-agent-background-retry.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env sh
+# Regression coverage for Linux/other-POSIX background launch recovery: if the
+# first child exits before readiness, retry within the existing readiness budget.
+set -eu
+
+repo="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+root="$(mktemp -d)"
+cleanup() {
+  if [ -f "$root/monk/agent/launcher/run/monk-agent.pid" ]; then
+    IFS= read -r child_pid <"$root/monk/agent/launcher/run/monk-agent.pid" || true
+    [ -z "${child_pid:-}" ] || kill "$child_pid" 2>/dev/null || true
+  fi
+  rm -rf "$root"
+}
+trap cleanup EXIT HUP INT TERM
+
+set +e
+output="$(
+  HOME="$root/home" \
+  MONK_AGENT_HOME="$root/monk" \
+  MONK_AGENT_PATH=/usr/bin/true \
+  MONK_AGENT_READY_TIMEOUT=6 \
+  MONK_AGENT_BACKGROUND_RESTARTS=2 \
+  MONK_AGENT_SKIP_SIGNIN_NUDGE=1 \
+  TEST_ROOT="$root" \
+  /bin/sh -c '
+    count_file="$TEST_ROOT/launch-count"
+    printf "0\n" >"$count_file"
+    uname() { printf "%s\n" Linux; }
+    curl() {
+      count="$(cat "$count_file")"
+      if [ "$count" -ge 2 ]; then
+        printf "%s\n" "{\"resource\":\"http://127.0.0.1:7419/mcp\"}"
+        return 0
+      fi
+      return 7
+    }
+    setsid() {
+      count="$(cat "$count_file")"
+      count=$((count + 1))
+      printf "%s\n" "$count" >"$count_file"
+      if [ "$count" -eq 1 ]; then
+        return 1
+      fi
+      /bin/sleep 1000
+    }
+    sleep() { /bin/sleep "$1"; }
+    . "$0"
+  ' "$repo/scripts/start-monk-agent.sh" 2>&1
+)"
+status=$?
+set -e
+
+[ "$status" -eq 0 ]
+launch_count="$(cat "$root/launch-count")"
+[ "$launch_count" -eq 2 ]
+printf '%s\n' "$output" | grep -q 'retrying background start (1/2)'
+
+cmp "$repo/scripts/start-monk-agent.sh" "$repo/plugins/monk/scripts/start-monk-agent.sh"
+cmp "$repo/scripts/start-monk-agent.sh" "$repo/.antigravity-plugin/scripts/start-monk-agent.sh"
+
+printf 'background_retry_status=pass launches=%s\n' "$launch_count"


### PR DESCRIPTION
## Summary

- retry non-launchd POSIX launcher starts when the child exits before readiness
- keep retries bounded and inside the existing readiness deadline
- add a Linux regression that proves the second start is used after an early child exit

## Root cause

The macOS path delegates non-zero agent exits to launchd `KeepAlive`, but the Linux/background path started the child once. If that child exited before the health endpoint became ready, the launcher observed the dead PID, stopped waiting, and returned a not-ready error without giving the agent another chance to recover.

The retry stays limited by `MONK_AGENT_BACKGROUND_RESTARTS` with a small default and the existing readiness deadline, so persistent failures still terminate cleanly.

## Validation

- `./tests/start-monk-agent-background-retry.sh`
- `./tests/start-monk-agent-readiness-timeout.sh`
- `./tests/start-monk-agent-fastpath.sh`
- `sh -n scripts/start-monk-agent.sh plugins/monk/scripts/start-monk-agent.sh .antigravity-plugin/scripts/start-monk-agent.sh tests/start-monk-agent-background-retry.sh tests/start-monk-agent-readiness-timeout.sh tests/start-monk-agent-fastpath.sh`
- generated launcher copy parity with `cmp`
- Ruby YAML parse for `.github/workflows/install-e2e.yml`
- `git diff --check`

Fixes #180.