### PR TITLE
fix: restart POSIX agent on local config drift

### DIFF
--- a/.antigravity-plugin/scripts/start-monk-agent.sh
+++ b/.antigravity-plugin/scripts/start-monk-agent.sh
@@ -341,7 +341,9 @@ background_process_configured() {
     printf '%s\n' "$state" | grep -Fxq "auth_url=$auth_url" &&
     printf '%s\n' "$state" | grep -Fxq "auth_client_id=$auth_client_id" &&
     printf '%s\n' "$state" | grep -Fxq "auth_audience=$auth_audience" &&
-    printf '%s\n' "$state" | grep -Fxq "autospin_url=$autospin_url"
+    printf '%s\n' "$state" | grep -Fxq "autospin_url=$autospin_url" &&
+    printf '%s\n' "$state" | grep -Fxq "agent_local=${MONK_AGENT_LOCAL:-}" &&
+    printf '%s\n' "$state" | grep -Fxq "plugin_version=${MONK_PLUGIN_VERSION:-}"
 }
 
 if [ "${MONK_AGENT_SKIP_ENSURE:-0}" != "1" ]; then
@@ -460,6 +462,8 @@ start_with_background_process() {
     printf 'auth_client_id=%s\n' "$auth_client_id"
     printf 'auth_audience=%s\n' "$auth_audience"
     printf 'autospin_url=%s\n' "$autospin_url"
+    printf 'agent_local=%s\n' "${MONK_AGENT_LOCAL:-}"
+    printf 'plugin_version=%s\n' "${MONK_PLUGIN_VERSION:-}"
   } >"$state_file"
 }
 

--- a/plugins/monk/scripts/start-monk-agent.sh
+++ b/plugins/monk/scripts/start-monk-agent.sh
@@ -341,7 +341,9 @@ background_process_configured() {
     printf '%s\n' "$state" | grep -Fxq "auth_url=$auth_url" &&
     printf '%s\n' "$state" | grep -Fxq "auth_client_id=$auth_client_id" &&
     printf '%s\n' "$state" | grep -Fxq "auth_audience=$auth_audience" &&
-    printf '%s\n' "$state" | grep -Fxq "autospin_url=$autospin_url"
+    printf '%s\n' "$state" | grep -Fxq "autospin_url=$autospin_url" &&
+    printf '%s\n' "$state" | grep -Fxq "agent_local=${MONK_AGENT_LOCAL:-}" &&
+    printf '%s\n' "$state" | grep -Fxq "plugin_version=${MONK_PLUGIN_VERSION:-}"
 }
 
 if [ "${MONK_AGENT_SKIP_ENSURE:-0}" != "1" ]; then
@@ -460,6 +462,8 @@ start_with_background_process() {
     printf 'auth_client_id=%s\n' "$auth_client_id"
     printf 'auth_audience=%s\n' "$auth_audience"
     printf 'autospin_url=%s\n' "$autospin_url"
+    printf 'agent_local=%s\n' "${MONK_AGENT_LOCAL:-}"
+    printf 'plugin_version=%s\n' "${MONK_PLUGIN_VERSION:-}"
   } >"$state_file"
 }
 

--- a/scripts/start-monk-agent.sh
+++ b/scripts/start-monk-agent.sh
@@ -341,7 +341,9 @@ background_process_configured() {
     printf '%s\n' "$state" | grep -Fxq "auth_url=$auth_url" &&
     printf '%s\n' "$state" | grep -Fxq "auth_client_id=$auth_client_id" &&
     printf '%s\n' "$state" | grep -Fxq "auth_audience=$auth_audience" &&
-    printf '%s\n' "$state" | grep -Fxq "autospin_url=$autospin_url"
+    printf '%s\n' "$state" | grep -Fxq "autospin_url=$autospin_url" &&
+    printf '%s\n' "$state" | grep -Fxq "agent_local=${MONK_AGENT_LOCAL:-}" &&
+    printf '%s\n' "$state" | grep -Fxq "plugin_version=${MONK_PLUGIN_VERSION:-}"
 }
 
 if [ "${MONK_AGENT_SKIP_ENSURE:-0}" != "1" ]; then
@@ -460,6 +462,8 @@ start_with_background_process() {
     printf 'auth_client_id=%s\n' "$auth_client_id"
     printf 'auth_audience=%s\n' "$auth_audience"
     printf 'autospin_url=%s\n' "$autospin_url"
+    printf 'agent_local=%s\n' "${MONK_AGENT_LOCAL:-}"
+    printf 'plugin_version=%s\n' "${MONK_PLUGIN_VERSION:-}"
   } >"$state_file"
 }
 

--- a/tests/start-monk-agent-fastpath.sh
+++ b/tests/start-monk-agent-fastpath.sh
@@ -9,15 +9,19 @@ repo_root="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
 fixture_bin="$repo_root/tests/fixtures/start-monk-agent"
 work_dir="$(mktemp -d)"
 trap 'rm -rf "$work_dir"' EXIT HUP INT TERM
+. "$repo_root/scripts/plugin-version.sh"
+current_plugin_version="$MONK_PLUGIN_VERSION"
 
 run_launcher() {
   agent_home="$1"
   auth_url="$2"
+  local_mode="${3:-}"
   HOME="$work_dir/home" \
   PATH="$fixture_bin:/usr/bin:/bin" \
   MONK_AGENT_PATH=/usr/bin/true \
   MONK_AGENT_HOME="$agent_home" \
   MONK_AUTH_URL="$auth_url" \
+  MONK_AGENT_LOCAL="$local_mode" \
   MONK_AGENT_SKIP_SIGNIN_NUDGE=1 \
     "$repo_root/scripts/start-monk-agent.sh"
 }
@@ -25,12 +29,16 @@ run_launcher() {
 write_state() {
   state_file="$1"
   auth_url="$2"
+  local_mode="${3:-}"
+  plugin_version="${4:-$current_plugin_version}"
   {
     printf 'agent_path=/usr/bin/true\n'
     printf 'auth_url=%s\n' "$auth_url"
     printf 'auth_client_id=UW84YWcJME3buMSLfqLX8IbBsYdNWi47\n'
     printf 'auth_audience=oaknode.com\n'
     printf 'autospin_url=wss://api.app.monk.io/autospin/\n'
+    printf 'agent_local=%s\n' "$local_mode"
+    printf 'plugin_version=%s\n' "$plugin_version"
   } >"$state_file"
 }
 
@@ -62,6 +70,42 @@ if [ ! -e "$drift_run_dir/monk-agent.pid" ]; then
 fi
 if ! grep -Fxq "auth_url=https://auth-two.invalid" "$drift_run_dir/monk-agent.state"; then
   echo "updated auth_url was not recorded in the state file" >&2
+  exit 1
+fi
+
+# Case 3: unchanged auth config but changed MONK_AGENT_LOCAL -> restarted once
+# and the new mode is persisted.
+local_dir="$work_dir/local-mode/monk"
+local_run_dir="$local_dir/agent/launcher/run"
+mkdir -p "$local_run_dir"
+write_state "$local_run_dir/monk-agent.state" "https://auth.monk.io" ""
+
+run_launcher "$local_dir" "https://auth.monk.io" "1"
+
+if [ ! -e "$local_run_dir/monk-agent.pid" ]; then
+  echo "companion was not restarted after MONK_AGENT_LOCAL drifted" >&2
+  exit 1
+fi
+if ! grep -Fxq "agent_local=1" "$local_run_dir/monk-agent.state"; then
+  echo "updated MONK_AGENT_LOCAL was not recorded in the state file" >&2
+  exit 1
+fi
+
+# Case 4: a plugin upgrade with an unchanged companion binary -> restarted so
+# the agent inherits the current rendered plugin version.
+version_dir="$work_dir/plugin-version/monk"
+version_run_dir="$version_dir/agent/launcher/run"
+mkdir -p "$version_run_dir"
+write_state "$version_run_dir/monk-agent.state" "https://auth.monk.io" "" "stale-test-version"
+
+run_launcher "$version_dir" "https://auth.monk.io"
+
+if [ ! -e "$version_run_dir/monk-agent.pid" ]; then
+  echo "companion was not restarted after MONK_PLUGIN_VERSION drifted" >&2
+  exit 1
+fi
+if ! grep -Fxq "plugin_version=$current_plugin_version" "$version_run_dir/monk-agent.state"; then
+  echo "updated MONK_PLUGIN_VERSION was not recorded in the state file" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

- persist `MONK_AGENT_LOCAL` and `MONK_PLUGIN_VERSION` in the non-Darwin POSIX launcher state
- require both values to match before reusing a healthy background companion
- extend the fast-path regression for local-mode and plugin-version drift

## Root cause

The Linux/other-POSIX fast path only fingerprints the executable and auth/autospin configuration. Although `MONK_AGENT_LOCAL` and `MONK_PLUGIN_VERSION` are exported to a newly started companion, changes to either value are ignored while the existing process is healthy.

This differs from the macOS launchd path, whose reuse check already includes both values.

The first launch after this change treats an older state file without the new fields as stale, restarts once, and writes the complete fingerprint. Later unchanged launches continue to reuse the healthy process.

Fixes #183.

## Validation

- `sh tests/start-monk-agent-fastpath.sh`
- `sh tests/start-monk-agent-readiness-timeout.sh`
- `find . -type f -name '*.sh' -exec sh -n {} +`
- generated POSIX launcher copy parity by SHA-256
- `git diff --check`

OpenAI Codex assisted with the product run, reproduction, patch, tests, issue, and PR preparation, as permitted by the contest.
