### PR TITLE
fix: uninstaller fails closed + block-monk regex wrappers (#214, #215)

### DIFF
--- a/.antigravity-plugin/hooks/block-monk.sh
+++ b/.antigravity-plugin/hooks/block-monk.sh
@@ -52,7 +52,7 @@ raw_command="$(printf '%s' "$input" |
 # to a real newline first (same for \r).
 raw_command="$(printf '%s' "$raw_command" | awk '{gsub(/\\n/, "\n"); gsub(/\\r/, "\r"); print}')"
 normalized="$(printf '%s' "$raw_command" | tr -d '\\' | tr -d '"' | tr -d "'")"
-if printf '%s' "$normalized" | grep -Eq '(^|[;&|`(){}])[[:space:]]*(sudo|command|env|exec|nohup|time|nice)?[[:space:]]*([^[:space:];&|`(){}]*[/\\])?monkd?(\.(exe|cmd|bat|ps1))?([[:space:]]|$)'; then
+if printf '%s' "$normalized" | grep -Eq '(^|[;&|`(){}])[[:space:]]*(sudo|command|env|exec|nohup|time|nice|eval|xargs|bash|sh|find|awk|perl|python)?[[:space:]]*([^[:space:];&|`(){}]*[/\\])?monkd?(\.(exe|cmd|bat|ps1))?([[:space:]]|$)'; then
   cat <<'JSON'
 {
   "decision": "deny",

--- a/.antigravity-plugin/scripts/uninstall-monk-agent.sh
+++ b/.antigravity-plugin/scripts/uninstall-monk-agent.sh
@@ -106,7 +106,7 @@ stop_agent() {
           if [ -z "$proc_name" ] && command -v ps >/dev/null 2>&1; then
             proc_name="$(ps -p "$pid" -o comm= 2>/dev/null || true)"
           fi
-          if [ -z "$proc_name" ] || [ "$proc_name" = "monk-agent" ]; then
+          if [ -n "$proc_name" ] && [ "$proc_name" = "monk-agent" ]; then
             kill "$pid" >/dev/null 2>&1 || true
           fi
         fi

--- a/hooks/block-monk.sh
+++ b/hooks/block-monk.sh
@@ -52,7 +52,7 @@ raw_command="$(printf '%s' "$input" |
 # below unless restored to a real newline first (same for \r).
 raw_command="$(printf '%s' "$raw_command" | awk '{gsub(/\\n/, "\n"); gsub(/\\r/, "\r"); print}')"
 normalized="$(printf '%s' "$raw_command" | tr -d '\\' | tr -d '"' | tr -d "'")"
-if printf '%s' "$normalized" | grep -Eq '(^|[;&|`(){}])[[:space:]]*(sudo|command|env|exec|nohup|time|nice)?[[:space:]]*([^[:space:];&|`(){}]*[/\\])?monkd?(\.(exe|cmd|bat|ps1))?([[:space:]]|$)'; then
+if printf '%s' "$normalized" | grep -Eq '(^|[;&|`(){}])[[:space:]]*(sudo|command|env|exec|nohup|time|nice|eval|xargs|bash|sh|find|awk|perl|python)?[[:space:]]*([^[:space:];&|`(){}]*[/\\])?monkd?(\.(exe|cmd|bat|ps1))?([[:space:]]|$)'; then
   cat <<'JSON'
 {
   "hookSpecificOutput": {

--- a/plugins/monk/hooks/block-monk.sh
+++ b/plugins/monk/hooks/block-monk.sh
@@ -52,7 +52,7 @@ raw_command="$(printf '%s' "$input" |
 # below unless restored to a real newline first (same for \r).
 raw_command="$(printf '%s' "$raw_command" | awk '{gsub(/\\n/, "\n"); gsub(/\\r/, "\r"); print}')"
 normalized="$(printf '%s' "$raw_command" | tr -d '\\' | tr -d '"' | tr -d "'")"
-if printf '%s' "$normalized" | grep -Eq '(^|[;&|`(){}])[[:space:]]*(sudo|command|env|exec|nohup|time|nice)?[[:space:]]*([^[:space:];&|`(){}]*[/\\])?monkd?(\.(exe|cmd|bat|ps1))?([[:space:]]|$)'; then
+if printf '%s' "$normalized" | grep -Eq '(^|[;&|`(){}])[[:space:]]*(sudo|command|env|exec|nohup|time|nice|eval|xargs|bash|sh|find|awk|perl|python)?[[:space:]]*([^[:space:];&|`(){}]*[/\\])?monkd?(\.(exe|cmd|bat|ps1))?([[:space:]]|$)'; then
   cat <<'JSON'
 {
   "hookSpecificOutput": {

--- a/plugins/monk/scripts/uninstall-monk-agent.sh
+++ b/plugins/monk/scripts/uninstall-monk-agent.sh
@@ -106,7 +106,7 @@ stop_agent() {
           if [ -z "$proc_name" ] && command -v ps >/dev/null 2>&1; then
             proc_name="$(ps -p "$pid" -o comm= 2>/dev/null || true)"
           fi
-          if [ -z "$proc_name" ] || [ "$proc_name" = "monk-agent" ]; then
+          if [ -n "$proc_name" ] && [ "$proc_name" = "monk-agent" ]; then
             kill "$pid" >/dev/null 2>&1 || true
           fi
         fi

--- a/scripts/uninstall-monk-agent.sh
+++ b/scripts/uninstall-monk-agent.sh
@@ -106,7 +106,7 @@ stop_agent() {
           if [ -z "$proc_name" ] && command -v ps >/dev/null 2>&1; then
             proc_name="$(ps -p "$pid" -o comm= 2>/dev/null || true)"
           fi
-          if [ -z "$proc_name" ] || [ "$proc_name" = "monk-agent" ]; then
+          if [ -n "$proc_name" ] && [ "$proc_name" = "monk-agent" ]; then
             kill "$pid" >/dev/null 2>&1 || true
           fi
         fi


### PR DESCRIPTION
## Fixes #214 and #215

### #214: Uninstaller fails closed when process name unknown

**Before:** `if [ -z $proc_name ] || [ $proc_name = monk-agent ]` — kills when name is empty (fails open)
**After:** `if [ -n $proc_name ] && [ $proc_name = monk-agent ]` — kills only when name is CONFIRMED (fails closed)

Applied to all 3 copies: scripts/, .antigravity-plugin/scripts/, plugins/monk/scripts/.

### #215: Block-monk regex catches eval/xargs/bash/sh

Added eval, xargs, bash, sh, find, awk, perl, python to the wrapper allowlist in all 3 copies of block-monk.sh.

Both fixes are minimal and surgical.