### PR TITLE
fix: support Windows PowerShell 5.1 bootstrap downloads

### DIFF
--- a/.antigravity-plugin/scripts/ensure-monk-agent.ps1
+++ b/.antigravity-plugin/scripts/ensure-monk-agent.ps1
@@ -111,7 +111,7 @@ $ChecksumTmp = Join-Path $InstallDir ".monk-agent.tmp.sha256"
 $ExtractDir = Join-Path $InstallDir ".monk-agent.extract"
 New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
 
-Invoke-WebRequest -Uri $ChecksumUrl -OutFile $ChecksumTmp
+Invoke-WebRequest -Uri $ChecksumUrl -UseBasicParsing -OutFile $ChecksumTmp
 
 $Expected = ((Get-Content -Raw $ChecksumTmp).Trim() -split "\s+")[0].ToLowerInvariant()
 
@@ -125,7 +125,7 @@ if ((Test-Path $Target) -and (Get-Item $Target).Length -gt 0 -and (Test-Path $Ch
 }
 
 Write-Host "Installing monk-agent from $Url"
-Invoke-WebRequest -Uri $Url -OutFile $ArchiveTmp
+Invoke-WebRequest -Uri $Url -UseBasicParsing -OutFile $ArchiveTmp
 
 $Actual = Get-FileSha256 $ArchiveTmp
 if ($Actual -ne $Expected) {

--- a/plugins/monk/scripts/ensure-monk-agent.ps1
+++ b/plugins/monk/scripts/ensure-monk-agent.ps1
@@ -111,7 +111,7 @@ $ChecksumTmp = Join-Path $InstallDir ".monk-agent.tmp.sha256"
 $ExtractDir = Join-Path $InstallDir ".monk-agent.extract"
 New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
 
-Invoke-WebRequest -Uri $ChecksumUrl -OutFile $ChecksumTmp
+Invoke-WebRequest -Uri $ChecksumUrl -UseBasicParsing -OutFile $ChecksumTmp
 
 $Expected = ((Get-Content -Raw $ChecksumTmp).Trim() -split "\s+")[0].ToLowerInvariant()
 
@@ -125,7 +125,7 @@ if ((Test-Path $Target) -and (Get-Item $Target).Length -gt 0 -and (Test-Path $Ch
 }
 
 Write-Host "Installing monk-agent from $Url"
-Invoke-WebRequest -Uri $Url -OutFile $ArchiveTmp
+Invoke-WebRequest -Uri $Url -UseBasicParsing -OutFile $ArchiveTmp
 
 $Actual = Get-FileSha256 $ArchiveTmp
 if ($Actual -ne $Expected) {

--- a/scripts/ensure-monk-agent.ps1
+++ b/scripts/ensure-monk-agent.ps1
@@ -111,7 +111,7 @@ $ChecksumTmp = Join-Path $InstallDir ".monk-agent.tmp.sha256"
 $ExtractDir = Join-Path $InstallDir ".monk-agent.extract"
 New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
 
-Invoke-WebRequest -Uri $ChecksumUrl -OutFile $ChecksumTmp
+Invoke-WebRequest -Uri $ChecksumUrl -UseBasicParsing -OutFile $ChecksumTmp
 
 $Expected = ((Get-Content -Raw $ChecksumTmp).Trim() -split "\s+")[0].ToLowerInvariant()
 
@@ -125,7 +125,7 @@ if ((Test-Path $Target) -and (Get-Item $Target).Length -gt 0 -and (Test-Path $Ch
 }
 
 Write-Host "Installing monk-agent from $Url"
-Invoke-WebRequest -Uri $Url -OutFile $ArchiveTmp
+Invoke-WebRequest -Uri $Url -UseBasicParsing -OutFile $ArchiveTmp
 
 $Actual = Get-FileSha256 $ArchiveTmp
 if ($Actual -ne $Expected) {

--- a/tests/ensure-monk-agent-basic-parsing.ps1
+++ b/tests/ensure-monk-agent-basic-parsing.ps1
@@ -1,0 +1,30 @@
+param(
+  [string]$RepoRoot = (Split-Path -Parent $PSScriptRoot)
+)
+
+$ErrorActionPreference = "Stop"
+
+$Installers = @(
+  (Join-Path $RepoRoot "scripts\ensure-monk-agent.ps1"),
+  (Join-Path $RepoRoot "plugins\monk\scripts\ensure-monk-agent.ps1"),
+  (Join-Path $RepoRoot ".antigravity-plugin\scripts\ensure-monk-agent.ps1")
+)
+
+foreach ($Installer in $Installers) {
+  if (-not (Test-Path -LiteralPath $Installer)) {
+    throw "Missing installer: $Installer"
+  }
+
+  $Downloads = Select-String -LiteralPath $Installer -Pattern "Invoke-WebRequest.*-OutFile"
+  if ($Downloads.Count -ne 2) {
+    throw "$Installer should contain exactly two download calls; found $($Downloads.Count)."
+  }
+
+  foreach ($Download in $Downloads) {
+    if ($Download.Line -notmatch "-UseBasicParsing") {
+      throw "$Installer has a download without -UseBasicParsing at line $($Download.LineNumber)."
+    }
+  }
+}
+
+Write-Output "ensure_basic_parsing_status=pass installers=$($Installers.Count) downloads=$($Installers.Count * 2)"


### PR DESCRIPTION
Fixes #195

Windows PowerShell 5.1 can route Invoke-WebRequest through the legacy Internet Explorer parser unless -UseBasicParsing is supplied. This patch adds -UseBasicParsing to both download calls in all three shipped ensure-monk-agent.ps1 copies.

Validation:
- powershell.exe -NoLogo -NoProfile -ExecutionPolicy Bypass -File .\tests\ensure-monk-agent-basic-parsing.ps1
- Result: ensure_basic_parsing_status=pass installers=3 downloads=6