### PR TITLE
fix: block assignment-prefixed monk commands

### DIFF
--- a/.antigravity-plugin/hooks/block-monk.sh
+++ b/.antigravity-plugin/hooks/block-monk.sh
@@ -52,7 +52,11 @@ raw_command="$(printf '%s' "$input" |
 # to a real newline first (same for \r).
 raw_command="$(printf '%s' "$raw_command" | awk '{gsub(/\\n/, "\n"); gsub(/\\r/, "\r"); print}')"
 normalized="$(printf '%s' "$raw_command" | tr -d '\\' | tr -d '"' | tr -d "'")"
-if printf '%s' "$normalized" | grep -Eq '(^|[;&|`(){}])[[:space:]]*(sudo|command|env|exec|nohup|time|nice)?[[:space:]]*([^[:space:];&|`(){}]*[/\\])?monkd?(\.(exe|cmd|bat|ps1))?([[:space:]]|$)'; then
+# Shell variable assignments may precede a command directly or follow wrappers
+# such as `env`. Treat assignments and wrappers as repeatable prefix tokens so
+# `A=1 monk`, `env A=1 monk`, and `command env A=1 monk` cannot bypass the
+# degraded guard.
+if printf '%s' "$normalized" | grep -Eq '(^|[;&|`(){}])[[:space:]]*(([A-Za-z_][A-Za-z0-9_]*=[^[:space:];&|`(){}]*|(sudo|command|env|exec|nohup|time|nice))[[:space:]]+)*([^[:space:];&|`(){}]*[/\\])?monkd?(\.(exe|cmd|bat|ps1))?([[:space:]]|$)'; then
   cat <<'JSON'
 {
   "decision": "deny",

--- a/hooks/block-monk.sh
+++ b/hooks/block-monk.sh
@@ -52,7 +52,11 @@ raw_command="$(printf '%s' "$input" |
 # below unless restored to a real newline first (same for \r).
 raw_command="$(printf '%s' "$raw_command" | awk '{gsub(/\\n/, "\n"); gsub(/\\r/, "\r"); print}')"
 normalized="$(printf '%s' "$raw_command" | tr -d '\\' | tr -d '"' | tr -d "'")"
-if printf '%s' "$normalized" | grep -Eq '(^|[;&|`(){}])[[:space:]]*(sudo|command|env|exec|nohup|time|nice)?[[:space:]]*([^[:space:];&|`(){}]*[/\\])?monkd?(\.(exe|cmd|bat|ps1))?([[:space:]]|$)'; then
+# Shell variable assignments may precede a command directly or follow wrappers
+# such as `env`. Treat assignments and wrappers as repeatable prefix tokens so
+# `A=1 monk`, `env A=1 monk`, and `command env A=1 monk` cannot bypass the
+# degraded guard.
+if printf '%s' "$normalized" | grep -Eq '(^|[;&|`(){}])[[:space:]]*(([A-Za-z_][A-Za-z0-9_]*=[^[:space:];&|`(){}]*|(sudo|command|env|exec|nohup|time|nice))[[:space:]]+)*([^[:space:];&|`(){}]*[/\\])?monkd?(\.(exe|cmd|bat|ps1))?([[:space:]]|$)'; then
   cat <<'JSON'
 {
   "hookSpecificOutput": {

--- a/plugins/monk/hooks/block-monk.sh
+++ b/plugins/monk/hooks/block-monk.sh
@@ -52,7 +52,11 @@ raw_command="$(printf '%s' "$input" |
 # below unless restored to a real newline first (same for \r).
 raw_command="$(printf '%s' "$raw_command" | awk '{gsub(/\\n/, "\n"); gsub(/\\r/, "\r"); print}')"
 normalized="$(printf '%s' "$raw_command" | tr -d '\\' | tr -d '"' | tr -d "'")"
-if printf '%s' "$normalized" | grep -Eq '(^|[;&|`(){}])[[:space:]]*(sudo|command|env|exec|nohup|time|nice)?[[:space:]]*([^[:space:];&|`(){}]*[/\\])?monkd?(\.(exe|cmd|bat|ps1))?([[:space:]]|$)'; then
+# Shell variable assignments may precede a command directly or follow wrappers
+# such as `env`. Treat assignments and wrappers as repeatable prefix tokens so
+# `A=1 monk`, `env A=1 monk`, and `command env A=1 monk` cannot bypass the
+# degraded guard.
+if printf '%s' "$normalized" | grep -Eq '(^|[;&|`(){}])[[:space:]]*(([A-Za-z_][A-Za-z0-9_]*=[^[:space:];&|`(){}]*|(sudo|command|env|exec|nohup|time|nice))[[:space:]]+)*([^[:space:];&|`(){}]*[/\\])?monkd?(\.(exe|cmd|bat|ps1))?([[:space:]]|$)'; then
   cat <<'JSON'
 {
   "hookSpecificOutput": {

--- a/tests/block-monk-posix.sh
+++ b/tests/block-monk-posix.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env sh
+
+set -eu
+
+repo_root="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+missing_agent="${TMPDIR:-/tmp}/missing-monk-agent-$$"
+
+run_case() {
+  hook=$1
+  format=$2
+  name=$3
+  command=$4
+  expected=$5
+
+  if [ "$format" = "claude" ]; then
+    payload=$(printf '{"tool_input":{"command":"%s"}}' "$command")
+    deny_marker='"permissionDecision": "deny"'
+  else
+    payload=$(printf '{"toolCall":{"name":"run_command","args":{"CommandLine":"%s"}}}' "$command")
+    deny_marker='"decision": "deny"'
+  fi
+
+  output=$(printf '%s' "$payload" |
+    MONK_AGENT_PATH="$missing_agent" sh "$hook")
+  if printf '%s' "$output" | grep -Fq "$deny_marker"; then
+    actual=deny
+  else
+    actual=allow
+  fi
+
+  if [ "$actual" != "$expected" ]; then
+    printf '%s\n' "$format hook case '$name' expected $expected, got $actual" >&2
+    printf '%s\n' "$output" >&2
+    exit 1
+  fi
+}
+
+run_suite() {
+  hook=$1
+  format=$2
+
+  run_case "$hook" "$format" direct 'monk deploy' deny
+  run_case "$hook" "$format" assignment 'MONK_X=1 monk deploy' deny
+  run_case "$hook" "$format" empty-assignment 'MONK_X= monk deploy' deny
+  run_case "$hook" "$format" repeated-assignments 'A=1 B=2 monk deploy' deny
+  run_case "$hook" "$format" wrapper-assignment 'env MONK_X=1 monk deploy' deny
+  run_case "$hook" "$format" repeated-wrappers 'command env MONK_X=1 monk deploy' deny
+  run_case "$hook" "$format" assignment-path 'MONK_X=1 /usr/local/bin/monk deploy' deny
+  run_case "$hook" "$format" lookalike 'MONK_X=1 monkey deploy' allow
+  run_case "$hook" "$format" assignment-as-argument 'printf MONK_X=1 monk deploy' allow
+  run_case "$hook" "$format" invalid-assignment-name '1MONK=1 monk deploy' allow
+}
+
+run_suite "$repo_root/hooks/block-monk.sh" claude
+run_suite "$repo_root/plugins/monk/hooks/block-monk.sh" claude
+run_suite "$repo_root/.antigravity-plugin/hooks/block-monk.sh" antigravity
+
+printf '%s\n' 'POSIX block-monk fallback tests passed.'


### PR DESCRIPTION
Closes #211

## What changed

- Treat POSIX shell assignment tokens and supported wrappers as repeatable command prefixes.
- Apply the fix consistently to the Claude/Codex, packaged plugin, and Antigravity hook copies.
- Add a POSIX regression suite covering direct, empty, repeated, wrapper-prefixed, and path-qualified assignments, plus false-positive controls.

## Validation

- `sh tests/block-monk-posix.sh` on Linux (WSL2): passed
- `sh -n` on all changed shell scripts: passed
- Existing `tests/block-monk-windows.ps1`: passed

The change is limited to the degraded POSIX fallback used when `monk-agent` is unavailable; the primary agent-backed path is unchanged.