### PR TITLE
fix(antigravity): pass plugin version, launch client, and local flag to monk-agent

### DIFF
--- a/.antigravity-plugin/hooks/ensure-monk-agent.ps1
+++ b/.antigravity-plugin/hooks/ensure-monk-agent.ps1
@@ -111,6 +111,9 @@ $env:MONK_AUTH_URL = if ($env:MONK_AUTH_URL) { $env:MONK_AUTH_URL } else { "http
 $env:MONK_AGENT_AUTH_CLIENT_ID = if ($env:MONK_AGENT_AUTH_CLIENT_ID) { $env:MONK_AGENT_AUTH_CLIENT_ID } else { "UW84YWcJME3buMSLfqLX8IbBsYdNWi47" }
 $env:MONK_AUTH_AUDIENCE = if ($env:MONK_AUTH_AUDIENCE) { $env:MONK_AUTH_AUDIENCE } else { "oaknode.com" }
 $env:MONK_AUTOSPIN_URL = if ($env:MONK_AUTOSPIN_URL) { $env:MONK_AUTOSPIN_URL } else { "wss://api.app.monk.io/autospin/" }
+$env:MONK_AGENT_LOCAL = if ($env:MONK_AGENT_LOCAL) { $env:MONK_AGENT_LOCAL } else { "" }
+$env:MONK_PLUGIN_VERSION = if ($env:MONK_PLUGIN_VERSION) { $env:MONK_PLUGIN_VERSION } else { "" }
+$env:MONK_AGENT_LAUNCH_CLIENT = if ($env:MONK_AGENT_LAUNCH_CLIENT) { $env:MONK_AGENT_LAUNCH_CLIENT } else { "antigravity" }
 
 $Process = $null
 try {

--- a/.antigravity-plugin/hooks/ensure-monk-agent.sh
+++ b/.antigravity-plugin/hooks/ensure-monk-agent.sh
@@ -89,6 +89,9 @@ export MONK_AUTH_URL="${MONK_AUTH_URL:-https://auth.monk.io}"
 export MONK_AGENT_AUTH_CLIENT_ID="${MONK_AGENT_AUTH_CLIENT_ID:-UW84YWcJME3buMSLfqLX8IbBsYdNWi47}"
 export MONK_AUTH_AUDIENCE="${MONK_AUTH_AUDIENCE:-oaknode.com}"
 export MONK_AUTOSPIN_URL="${MONK_AUTOSPIN_URL:-wss://api.app.monk.io/autospin/}"
+export MONK_AGENT_LOCAL="${MONK_AGENT_LOCAL:-}"
+export MONK_PLUGIN_VERSION="${MONK_PLUGIN_VERSION:-}"
+export MONK_AGENT_LAUNCH_CLIENT="${MONK_AGENT_LAUNCH_CLIENT:-antigravity}"
 
 if command -v setsid >/dev/null 2>&1; then
   setsid "$agent_path" serve --host "$host" --port "$port" >>"$log_file" 2>&1 </dev/null &


### PR DESCRIPTION
### Context

The main launchers (`scripts/start-monk-agent.sh` / `.ps1`) hand the spawned `monk-agent` companion `MONK_PLUGIN_VERSION`, `MONK_AGENT_LAUNCH_CLIENT`, and `MONK_AGENT_LOCAL` so session metadata/telemetry report the real plugin version and launching client (see `start-monk-agent.sh` `start_with_background_process()` and the launchd plist).

The Antigravity `PreInvocation` cold-start hooks (`.antigravity-plugin/hooks/ensure-monk-agent.sh` / `.ps1`) start the companion with only the four auth/autospin variables, so every cold start on Antigravity:
- reports an empty `pluginVersion` and no `launch_client` in telemetry,
- silently drops a user-set `MONK_AGENT_LOCAL` (the agent's local-mode switch).

### Change

Mirror the launcher exports in both Antigravity hooks. Behavior-preserving for existing users; the launch client defaults to `antigravity` (this hook is Antigravity-specific), matching the existing hardcoded telemetry comment.

### Verification

- `sh -n` passes on the POSIX hook.
- Additive env exports only; no change to the spawn command or fast path.