### PR TITLE
fix(uninstall): don't abort POSIX uninstaller when sudo fails on apt/dnf removal

### DIFF
--- a/scripts/uninstall-monk-agent.sh
+++ b/scripts/uninstall-monk-agent.sh
@@ -145,9 +145,9 @@ remove_runtime_linux() {
     sudo systemctl daemon-reload >/dev/null 2>&1 || true
   fi
   if command -v apt-get >/dev/null 2>&1 && dpkg-query -W monk >/dev/null 2>&1; then
-    sudo apt-get remove -y monk
+    sudo apt-get remove -y monk || true
   elif command -v dnf >/dev/null 2>&1 && rpm -q monk >/dev/null 2>&1; then
-    sudo dnf remove -y monk
+    sudo dnf remove -y monk || true
   fi
 }
 


### PR DESCRIPTION
### Context

In `remove_runtime_linux()` every step is wrapped in `|| true` (systemctl stop/disable/daemon-reload, `monk machine stop`, `brew uninstall`), but the two package removals are not:

- `sudo apt-get remove -y monk`
- `sudo dnf remove -y monk`

The script runs with `set -eu` (line 2). When `sudo` is unavailable (minimal/root container) or non-interactive without passwordless sudo, the failing `sudo` aborts the whole script **after** the agent files were already removed, so the user gets a non-zero exit and no "uninstall complete." message while the Monk runtime is left half-removed.

### Change

Wrap both package removals in `|| true`, matching the surrounding guards.

### Verification

`sh -n` passes; diff is 2 lines.