### PR TITLE
fix: restart background agent on MONK_AGENT_LOCAL / plugin-version drift (closes #229)

### DIFF
--- a/.antigravity-plugin/scripts/start-monk-agent.ps1
+++ b/.antigravity-plugin/scripts/start-monk-agent.ps1
@@ -327,6 +327,10 @@ if ($ManagedAgentEnsured) {
 # fields that matter for reuse are persisted to $StateFile on every start and
 # diffed here. Covers both a stale custom MONK_AGENT_PATH and drifted
 # auth/autospin config on an otherwise-healthy companion (ENG-390, ENG-397).
+# local/plugin_version are gated too (parity with the macOS launchd plist
+# check): flipping MONK_AGENT_LOCAL or upgrading only the plugin must restart
+# a "healthy" agent so it picks up the new mode and stops reporting a stale
+# plugin version — previously both were silently ignored on Windows and Linux.
 function Test-BackgroundStateConfigured {
   if (-not (Test-Path $StateFile)) {
     return $false
@@ -340,7 +344,9 @@ function Test-BackgroundStateConfigured {
     "auth_url=$AuthUrl",
     "auth_client_id=$AuthClientId",
     "auth_audience=$AuthAudience",
-    "autospin_url=$AutospinUrl"
+    "autospin_url=$AutospinUrl",
+    "local=$($env:MONK_AGENT_LOCAL)",
+    "plugin_version=$($env:MONK_PLUGIN_VERSION)"
   )
   $Lines = $State -split "`r?`n"
   foreach ($Line in $Expected) {
@@ -382,7 +388,9 @@ $Process.Id | Set-Content -NoNewline $PidFile
   "auth_url=$AuthUrl",
   "auth_client_id=$AuthClientId",
   "auth_audience=$AuthAudience",
-  "autospin_url=$AutospinUrl"
+  "autospin_url=$AutospinUrl",
+  "local=$($env:MONK_AGENT_LOCAL)",
+  "plugin_version=$($env:MONK_PLUGIN_VERSION)"
 ) -join "`n" | Set-Content -NoNewline $StateFile
 
 $ReadyTimer = [System.Diagnostics.Stopwatch]::StartNew()

--- a/.antigravity-plugin/scripts/start-monk-agent.sh
+++ b/.antigravity-plugin/scripts/start-monk-agent.sh
@@ -334,6 +334,12 @@ launchd_configured() {
 # diffed here. Covers both a stale custom MONK_AGENT_PATH (ENG-390) and
 # drifted auth/autospin config on an otherwise-healthy Linux/other-POSIX
 # companion (ENG-397 -- launchd_configured above already covers macOS).
+# local/plugin_version ARE gated here (unlike PATH and launch client): they
+# change only on an explicit user setting or a plugin install/upgrade, and
+# both are exactly the moments the agent should restart -- mirroring the
+# launchd plist checks on macOS. Before this, flipping MONK_AGENT_LOCAL or
+# upgrading only the plugin left a "healthy" background agent silently
+# running with the old mode and old version indefinitely.
 background_process_configured() {
   [ -f "$state_file" ] || return 1
   state="$(cat "$state_file" 2>/dev/null || true)"
@@ -341,7 +347,9 @@ background_process_configured() {
     printf '%s\n' "$state" | grep -Fxq "auth_url=$auth_url" &&
     printf '%s\n' "$state" | grep -Fxq "auth_client_id=$auth_client_id" &&
     printf '%s\n' "$state" | grep -Fxq "auth_audience=$auth_audience" &&
-    printf '%s\n' "$state" | grep -Fxq "autospin_url=$autospin_url"
+    printf '%s\n' "$state" | grep -Fxq "autospin_url=$autospin_url" &&
+    printf '%s\n' "$state" | grep -Fxq "local=${MONK_AGENT_LOCAL:-}" &&
+    printf '%s\n' "$state" | grep -Fxq "plugin_version=${MONK_PLUGIN_VERSION:-}"
 }
 
 if [ "${MONK_AGENT_SKIP_ENSURE:-0}" != "1" ]; then
@@ -460,6 +468,8 @@ start_with_background_process() {
     printf 'auth_client_id=%s\n' "$auth_client_id"
     printf 'auth_audience=%s\n' "$auth_audience"
     printf 'autospin_url=%s\n' "$autospin_url"
+    printf 'local=%s\n' "${MONK_AGENT_LOCAL:-}"
+    printf 'plugin_version=%s\n' "${MONK_PLUGIN_VERSION:-}"
   } >"$state_file"
 }
 

--- a/plugins/monk/scripts/start-monk-agent.ps1
+++ b/plugins/monk/scripts/start-monk-agent.ps1
@@ -327,6 +327,10 @@ if ($ManagedAgentEnsured) {
 # fields that matter for reuse are persisted to $StateFile on every start and
 # diffed here. Covers both a stale custom MONK_AGENT_PATH and drifted
 # auth/autospin config on an otherwise-healthy companion (ENG-390, ENG-397).
+# local/plugin_version are gated too (parity with the macOS launchd plist
+# check): flipping MONK_AGENT_LOCAL or upgrading only the plugin must restart
+# a "healthy" agent so it picks up the new mode and stops reporting a stale
+# plugin version — previously both were silently ignored on Windows and Linux.
 function Test-BackgroundStateConfigured {
   if (-not (Test-Path $StateFile)) {
     return $false
@@ -340,7 +344,9 @@ function Test-BackgroundStateConfigured {
     "auth_url=$AuthUrl",
     "auth_client_id=$AuthClientId",
     "auth_audience=$AuthAudience",
-    "autospin_url=$AutospinUrl"
+    "autospin_url=$AutospinUrl",
+    "local=$($env:MONK_AGENT_LOCAL)",
+    "plugin_version=$($env:MONK_PLUGIN_VERSION)"
   )
   $Lines = $State -split "`r?`n"
   foreach ($Line in $Expected) {
@@ -382,7 +388,9 @@ $Process.Id | Set-Content -NoNewline $PidFile
   "auth_url=$AuthUrl",
   "auth_client_id=$AuthClientId",
   "auth_audience=$AuthAudience",
-  "autospin_url=$AutospinUrl"
+  "autospin_url=$AutospinUrl",
+  "local=$($env:MONK_AGENT_LOCAL)",
+  "plugin_version=$($env:MONK_PLUGIN_VERSION)"
 ) -join "`n" | Set-Content -NoNewline $StateFile
 
 $ReadyTimer = [System.Diagnostics.Stopwatch]::StartNew()

--- a/plugins/monk/scripts/start-monk-agent.sh
+++ b/plugins/monk/scripts/start-monk-agent.sh
@@ -334,6 +334,12 @@ launchd_configured() {
 # diffed here. Covers both a stale custom MONK_AGENT_PATH (ENG-390) and
 # drifted auth/autospin config on an otherwise-healthy Linux/other-POSIX
 # companion (ENG-397 -- launchd_configured above already covers macOS).
+# local/plugin_version ARE gated here (unlike PATH and launch client): they
+# change only on an explicit user setting or a plugin install/upgrade, and
+# both are exactly the moments the agent should restart -- mirroring the
+# launchd plist checks on macOS. Before this, flipping MONK_AGENT_LOCAL or
+# upgrading only the plugin left a "healthy" background agent silently
+# running with the old mode and old version indefinitely.
 background_process_configured() {
   [ -f "$state_file" ] || return 1
   state="$(cat "$state_file" 2>/dev/null || true)"
@@ -341,7 +347,9 @@ background_process_configured() {
     printf '%s\n' "$state" | grep -Fxq "auth_url=$auth_url" &&
     printf '%s\n' "$state" | grep -Fxq "auth_client_id=$auth_client_id" &&
     printf '%s\n' "$state" | grep -Fxq "auth_audience=$auth_audience" &&
-    printf '%s\n' "$state" | grep -Fxq "autospin_url=$autospin_url"
+    printf '%s\n' "$state" | grep -Fxq "autospin_url=$autospin_url" &&
+    printf '%s\n' "$state" | grep -Fxq "local=${MONK_AGENT_LOCAL:-}" &&
+    printf '%s\n' "$state" | grep -Fxq "plugin_version=${MONK_PLUGIN_VERSION:-}"
 }
 
 if [ "${MONK_AGENT_SKIP_ENSURE:-0}" != "1" ]; then
@@ -460,6 +468,8 @@ start_with_background_process() {
     printf 'auth_client_id=%s\n' "$auth_client_id"
     printf 'auth_audience=%s\n' "$auth_audience"
     printf 'autospin_url=%s\n' "$autospin_url"
+    printf 'local=%s\n' "${MONK_AGENT_LOCAL:-}"
+    printf 'plugin_version=%s\n' "${MONK_PLUGIN_VERSION:-}"
   } >"$state_file"
 }
 

--- a/scripts/start-monk-agent.ps1
+++ b/scripts/start-monk-agent.ps1
@@ -327,6 +327,10 @@ if ($ManagedAgentEnsured) {
 # fields that matter for reuse are persisted to $StateFile on every start and
 # diffed here. Covers both a stale custom MONK_AGENT_PATH and drifted
 # auth/autospin config on an otherwise-healthy companion (ENG-390, ENG-397).
+# local/plugin_version are gated too (parity with the macOS launchd plist
+# check): flipping MONK_AGENT_LOCAL or upgrading only the plugin must restart
+# a "healthy" agent so it picks up the new mode and stops reporting a stale
+# plugin version — previously both were silently ignored on Windows and Linux.
 function Test-BackgroundStateConfigured {
   if (-not (Test-Path $StateFile)) {
     return $false
@@ -340,7 +344,9 @@ function Test-BackgroundStateConfigured {
     "auth_url=$AuthUrl",
     "auth_client_id=$AuthClientId",
     "auth_audience=$AuthAudience",
-    "autospin_url=$AutospinUrl"
+    "autospin_url=$AutospinUrl",
+    "local=$($env:MONK_AGENT_LOCAL)",
+    "plugin_version=$($env:MONK_PLUGIN_VERSION)"
   )
   $Lines = $State -split "`r?`n"
   foreach ($Line in $Expected) {
@@ -382,7 +388,9 @@ $Process.Id | Set-Content -NoNewline $PidFile
   "auth_url=$AuthUrl",
   "auth_client_id=$AuthClientId",
   "auth_audience=$AuthAudience",
-  "autospin_url=$AutospinUrl"
+  "autospin_url=$AutospinUrl",
+  "local=$($env:MONK_AGENT_LOCAL)",
+  "plugin_version=$($env:MONK_PLUGIN_VERSION)"
 ) -join "`n" | Set-Content -NoNewline $StateFile
 
 $ReadyTimer = [System.Diagnostics.Stopwatch]::StartNew()

--- a/scripts/start-monk-agent.sh
+++ b/scripts/start-monk-agent.sh
@@ -334,6 +334,12 @@ launchd_configured() {
 # diffed here. Covers both a stale custom MONK_AGENT_PATH (ENG-390) and
 # drifted auth/autospin config on an otherwise-healthy Linux/other-POSIX
 # companion (ENG-397 -- launchd_configured above already covers macOS).
+# local/plugin_version ARE gated here (unlike PATH and launch client): they
+# change only on an explicit user setting or a plugin install/upgrade, and
+# both are exactly the moments the agent should restart -- mirroring the
+# launchd plist checks on macOS. Before this, flipping MONK_AGENT_LOCAL or
+# upgrading only the plugin left a "healthy" background agent silently
+# running with the old mode and old version indefinitely.
 background_process_configured() {
   [ -f "$state_file" ] || return 1
   state="$(cat "$state_file" 2>/dev/null || true)"
@@ -341,7 +347,9 @@ background_process_configured() {
     printf '%s\n' "$state" | grep -Fxq "auth_url=$auth_url" &&
     printf '%s\n' "$state" | grep -Fxq "auth_client_id=$auth_client_id" &&
     printf '%s\n' "$state" | grep -Fxq "auth_audience=$auth_audience" &&
-    printf '%s\n' "$state" | grep -Fxq "autospin_url=$autospin_url"
+    printf '%s\n' "$state" | grep -Fxq "autospin_url=$autospin_url" &&
+    printf '%s\n' "$state" | grep -Fxq "local=${MONK_AGENT_LOCAL:-}" &&
+    printf '%s\n' "$state" | grep -Fxq "plugin_version=${MONK_PLUGIN_VERSION:-}"
 }
 
 if [ "${MONK_AGENT_SKIP_ENSURE:-0}" != "1" ]; then
@@ -460,6 +468,8 @@ start_with_background_process() {
     printf 'auth_client_id=%s\n' "$auth_client_id"
     printf 'auth_audience=%s\n' "$auth_audience"
     printf 'autospin_url=%s\n' "$autospin_url"
+    printf 'local=%s\n' "${MONK_AGENT_LOCAL:-}"
+    printf 'plugin_version=%s\n' "${MONK_PLUGIN_VERSION:-}"
   } >"$state_file"
 }
 

--- a/tests/start-monk-agent-fastpath.sh
+++ b/tests/start-monk-agent-fastpath.sh
@@ -31,6 +31,8 @@ write_state() {
     printf 'auth_client_id=UW84YWcJME3buMSLfqLX8IbBsYdNWi47\n'
     printf 'auth_audience=oaknode.com\n'
     printf 'autospin_url=wss://api.app.monk.io/autospin/\n'
+    printf 'local=\n'
+    printf 'plugin_version=0.1.52\n'
   } >"$state_file"
 }
 
@@ -62,6 +64,46 @@ if [ ! -e "$drift_run_dir/monk-agent.pid" ]; then
 fi
 if ! grep -Fxq "auth_url=https://auth-two.invalid" "$drift_run_dir/monk-agent.state"; then
   echo "updated auth_url was not recorded in the state file" >&2
+  exit 1
+fi
+
+# Case 3: MONK_AGENT_LOCAL drift -> restarted (issue #229: user-set local-mode
+# switch must not be silently ignored by the Linux background fast path,
+# mirroring the launchd plist gate on macOS).
+write_state_with_local() {
+  state_file="$1"
+  local_value="$2"
+  {
+    printf 'agent_path=/usr/bin/true\n'
+    printf 'auth_url=https://auth.monk.io\n'
+    printf 'auth_client_id=UW84YWcJME3buMSLfqLX8IbBsYdNWi47\n'
+    printf 'auth_audience=oaknode.com\n'
+    printf 'autospin_url=wss://api.app.monk.io/autospin/\n'
+    printf 'local=%s\n' "$local_value"
+    printf 'plugin_version=0.1.52\n'
+  } >"$state_file"
+}
+
+local_dir="$work_dir/local/monk"
+local_run_dir="$local_dir/agent/launcher/run"
+mkdir -p "$local_run_dir"
+write_state_with_local "$local_run_dir/monk-agent.state" ""
+
+HOME="$work_dir/home" \
+PATH="$fixture_bin:/usr/bin:/bin" \
+MONK_AGENT_PATH=/usr/bin/true \
+MONK_AGENT_HOME="$local_dir" \
+MONK_AUTH_URL="https://auth.monk.io" \
+MONK_AGENT_LOCAL=1 \
+MONK_AGENT_SKIP_SIGNIN_NUDGE=1 \
+  "$repo_root/scripts/start-monk-agent.sh"
+
+if [ ! -e "$local_run_dir/monk-agent.pid" ]; then
+  echo "companion was not restarted after MONK_AGENT_LOCAL flipped on" >&2
+  exit 1
+fi
+if ! grep -Fxq "local=1" "$local_run_dir/monk-agent.state"; then
+  echo "updated MONK_AGENT_LOCAL was not recorded in the state file" >&2
   exit 1
 fi
 


### PR DESCRIPTION
Closes #229

## What this fixes

The launcher's "healthy agent" fast path restarts a running agent when its recorded configuration drifts. The macOS `launchd_configured()` gate diffs the plist against `agent_path`, auth fields, autospin URL, **`MONK_AGENT_LOCAL`**, and **`MONK_PLUGIN_VERSION`** — but:

- Linux `background_process_configured()` diffed only `agent_path`, `auth_url`, `auth_client_id`, `auth_audience`, `autospin_url`
- Windows `Test-BackgroundStateConfigured()` had the same five-field list, and `MONK_AGENT_LOCAL` appeared nowhere in the `.ps1` launcher

So on Linux and Windows:
1. Flipping `MONK_AGENT_LOCAL` had no effect until unrelated drift happened to force a restart — a user setting silently ignored;
2. A plugin-only upgrade (same agent binary, new plugin version) left the running agent reporting the old `MONK_PLUGIN_VERSION` in telemetry/session metadata indefinitely.

## Change

- Both launchers now persist `local=` and `plugin_version=` into the state file on every start (POSIX + PS1, all three mirrored copies: `scripts/`, `plugins/monk/scripts/`, `.antigravity-plugin/scripts/`)
- Both reuse gates diff those two fields, mirroring the launchd plist check
- Named `local=`/`plugin_version=` (not `agent_local=`) to avoid any ambiguity in the strict `grep -Fxq` line match

Behaviour for existing installs: an old 5-field state file mismatches once on the first run after upgrade, causing a single one-time restart — the same once-per-fill semantics the state-file design already uses for newly tracked fields.

## Test evidence

`tests/start-monk-agent-fastpath.sh` (repo fixture, no network):

- **Case 1** unchanged config → no restart ✓ (fixture state now uses the new 7-field format, `local=` + `plugin_version=0.1.52`)
- **Case 2** `MONK_AUTH_URL` drift → restarted once, new URL persisted ✓ (unchanged behaviour)
- **Case 3 (new)** `MONK_AGENT_LOCAL` flipped `""`→`1` → restarted once, `local=1` persisted ✓

```
$ sh tests/start-monk-agent-fastpath.sh
start-monk-agent fast-path tests passed.
```

Additional scenario verification (scratch harness, same fixtures):
- S1: unchanged 7-field state → reuse, no restart ✓
- S2: local-drift restart + persistence ✓
- S3: legacy 5-field pre-fix state → exactly one upgrade restart, state rewritten with new fields ✓

`tests/start-monk-agent-readiness-timeout.sh` also passes (it enforces the `scripts/` ↔ `plugins/monk/scripts/` ↔ `.antigravity-plugin/scripts/` mirror, which is why all three copies are updated).
