### PR TITLE
fix: preserve non-object Antigravity configs

### DIFF
--- a/.antigravity-plugin/scripts/start-monk-agent.sh
+++ b/.antigravity-plugin/scripts/start-monk-agent.sh
@@ -106,14 +106,15 @@ register_antigravity_mcp() {
     # produce a warning, not abort the launcher after the health check passed.
     valid=1
     if command -v jq >/dev/null 2>&1; then
-      jq empty "$mcp_cfg" >/dev/null 2>&1 || valid=0
+      jq -e 'type == "object"' "$mcp_cfg" >/dev/null 2>&1 || valid=0
     elif command -v python3 >/dev/null 2>&1; then
       python3 -c 'import json, sys
 with open(sys.argv[1], encoding="utf-8") as handle:
-    json.load(handle)' "$mcp_cfg" >/dev/null 2>&1 || valid=0
+    cfg = json.load(handle)
+raise SystemExit(0 if isinstance(cfg, dict) else 1)' "$mcp_cfg" >/dev/null 2>&1 || valid=0
     fi
     if [ "$valid" = "0" ]; then
-      echo "Warning: $mcp_cfg is not valid JSON; skipping automatic Antigravity MCP registration." >&2
+      echo "Warning: $mcp_cfg is not a valid JSON object; skipping automatic Antigravity MCP registration." >&2
       printf '  Add manually if desired: {"mcpServers":{"monk":{"serverUrl":"%s"}}}\n' "$server_url" >&2
       return 0
     fi

--- a/plugins/monk/scripts/start-monk-agent.sh
+++ b/plugins/monk/scripts/start-monk-agent.sh
@@ -106,14 +106,15 @@ register_antigravity_mcp() {
     # produce a warning, not abort the launcher after the health check passed.
     valid=1
     if command -v jq >/dev/null 2>&1; then
-      jq empty "$mcp_cfg" >/dev/null 2>&1 || valid=0
+      jq -e 'type == "object"' "$mcp_cfg" >/dev/null 2>&1 || valid=0
     elif command -v python3 >/dev/null 2>&1; then
       python3 -c 'import json, sys
 with open(sys.argv[1], encoding="utf-8") as handle:
-    json.load(handle)' "$mcp_cfg" >/dev/null 2>&1 || valid=0
+    cfg = json.load(handle)
+raise SystemExit(0 if isinstance(cfg, dict) else 1)' "$mcp_cfg" >/dev/null 2>&1 || valid=0
     fi
     if [ "$valid" = "0" ]; then
-      echo "Warning: $mcp_cfg is not valid JSON; skipping automatic Antigravity MCP registration." >&2
+      echo "Warning: $mcp_cfg is not a valid JSON object; skipping automatic Antigravity MCP registration." >&2
       printf '  Add manually if desired: {"mcpServers":{"monk":{"serverUrl":"%s"}}}\n' "$server_url" >&2
       return 0
     fi

--- a/scripts/start-monk-agent.sh
+++ b/scripts/start-monk-agent.sh
@@ -106,14 +106,15 @@ register_antigravity_mcp() {
     # produce a warning, not abort the launcher after the health check passed.
     valid=1
     if command -v jq >/dev/null 2>&1; then
-      jq empty "$mcp_cfg" >/dev/null 2>&1 || valid=0
+      jq -e 'type == "object"' "$mcp_cfg" >/dev/null 2>&1 || valid=0
     elif command -v python3 >/dev/null 2>&1; then
       python3 -c 'import json, sys
 with open(sys.argv[1], encoding="utf-8") as handle:
-    json.load(handle)' "$mcp_cfg" >/dev/null 2>&1 || valid=0
+    cfg = json.load(handle)
+raise SystemExit(0 if isinstance(cfg, dict) else 1)' "$mcp_cfg" >/dev/null 2>&1 || valid=0
     fi
     if [ "$valid" = "0" ]; then
-      echo "Warning: $mcp_cfg is not valid JSON; skipping automatic Antigravity MCP registration." >&2
+      echo "Warning: $mcp_cfg is not a valid JSON object; skipping automatic Antigravity MCP registration." >&2
       printf '  Add manually if desired: {"mcpServers":{"monk":{"serverUrl":"%s"}}}\n' "$server_url" >&2
       return 0
     fi

--- a/tests/start-monk-agent-antigravity-nonobject-config.sh
+++ b/tests/start-monk-agent-antigravity-nonobject-config.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env sh
+# A syntactically valid Antigravity config with a non-object root must be
+# rejected as an incompatible config shape, not abort an otherwise healthy
+# launcher while trying to access or assign mcpServers.
+set -eu
+
+repo_root="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+fixture_src="$repo_root/tests/fixtures/start-monk-agent"
+work_dir="$(mktemp -d)"
+trap 'rm -rf "$work_dir"' EXIT HUP INT TERM
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "python3 not available; skipping non-object config regression" >&2
+  exit 0
+fi
+
+fake_bin="$work_dir/bin"
+mkdir -p "$fake_bin"
+for command_name in cat date dirname grep head id kill mkdir mktemp mv python3 sed sh tr; do
+  command_path="$(command -v "$command_name" || true)"
+  case "$command_path" in
+    /*)
+      printf '#!/usr/bin/sh\nexec "%s" "$@"\n' "$command_path" >"$fake_bin/$command_name"
+      chmod +x "$fake_bin/$command_name"
+      ;;
+  esac
+done
+for fixture_name in curl uname; do
+  printf '#!/usr/bin/sh\nexec "%s" "$@"\n' "$fixture_src/$fixture_name" >"$fake_bin/$fixture_name"
+  chmod +x "$fake_bin/$fixture_name"
+done
+
+home_root="$work_dir"
+case "$(uname -s 2>/dev/null || printf unknown)" in
+  MINGW*|MSYS*|CYGWIN*) home_root="$(cygpath -m "$work_dir")" ;;
+esac
+home="$home_root/home"
+config="$home/.gemini/config/mcp_config.json"
+mkdir -p "$(dirname "$config")"
+printf '%s\n' '[{"preserved":"still here"}]' >"$config"
+
+HOME="$home" \
+PATH="$fake_bin" \
+MONK_AGENT_HOME="$home/.monk" \
+MONK_AGENT_PATH=/usr/bin/true \
+MONK_AGENT_SKIP_SIGNIN_NUDGE=1 \
+  /usr/bin/sh "$repo_root/scripts/start-monk-agent.sh"
+
+python3 -c '
+import json, sys
+with open(sys.argv[1], encoding="utf-8") as handle:
+    config = json.load(handle)
+assert config == [{"preserved": "still here"}]
+' "$config"
+
+echo "Antigravity launcher preserves and skips a non-object JSON config."


### PR DESCRIPTION
## Summary
- validate Antigravity's existing MCP config as a JSON object, not only as syntactically valid JSON
- preserve valid non-object configs and keep the healthy launcher running with a warning
- apply the fix to all three shipped launcher mirrors
- add a red-to-green regression for the Python fallback path

## Why
A valid JSON array passes the current syntax check, then the Python fallback calls `cfg.get(...)` and exits under `set -e`. The same incompatible shape also breaks the jq assignment path. A healthy monk-agent therefore appears to fail solely because an existing Antigravity config has the wrong root type.

## Validation
- `C:\Program Files\Git\bin\bash.exe tests/start-monk-agent-antigravity-nonobject-config.sh`
- `C:\Program Files\Git\bin\bash.exe -n scripts/start-monk-agent.sh`
- SHA-256 equality verified across all three launcher mirrors
- `git diff --check`

The regression fails on pristine v0.1.54 with `AttributeError: 'list' object has no attribute 'get'` and passes with this change while preserving the original config.

## Generated artifacts
`GENERATED.md` says the public tree is generated from the private `monk-agent/plugin` source. This PR updates the mirrored public artifacts consistently; the corresponding source change should be ported before the next regeneration.

Fixes #255