### PR TITLE
fix: escape dynamic launchd plist values

### DIFF
--- a/.antigravity-plugin/scripts/start-monk-agent.sh
+++ b/.antigravity-plugin/scripts/start-monk-agent.sh
@@ -10,6 +10,15 @@ autospin_url="${MONK_AUTOSPIN_URL:-wss://api.app.monk.io/autospin/}"
 agent_path_env="${PATH:-/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin}"
 script_dir="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
 
+xml_escape() {
+  printf '%s' "$1" | sed \
+    -e 's/&/\&amp;/g' \
+    -e 's/</\&lt;/g' \
+    -e 's/>/\&gt;/g' \
+    -e 's/"/\&quot;/g' \
+    -e "s/'/\&apos;/g"
+}
+
 # Host hooks terminate this launcher after 180 seconds. Keep readiness work
 # below that deadline so startup failures can print their own diagnostics
 # instead of being killed mid-wait (ENG-410).
@@ -332,6 +341,25 @@ if [ ! -x "$agent_path" ]; then
   exit 2
 fi
 
+# The launchd plist is XML. Encode every dynamic string once, before both the
+# reuse check and plist generation, so valid paths and URLs cannot corrupt it
+# and the fast path compares the serialized representation.
+if [ "$os" = "Darwin" ]; then
+  esc_launchd_label="$(xml_escape "$launchd_label")"
+  esc_agent_path="$(xml_escape "$agent_path")"
+  esc_host="$(xml_escape "$host")"
+  esc_port="$(xml_escape "$port")"
+  esc_auth_url="$(xml_escape "$auth_url")"
+  esc_auth_client_id="$(xml_escape "$auth_client_id")"
+  esc_auth_audience="$(xml_escape "$auth_audience")"
+  esc_autospin_url="$(xml_escape "$autospin_url")"
+  esc_agent_local="$(xml_escape "${MONK_AGENT_LOCAL:-}")"
+  esc_plugin_version="$(xml_escape "${MONK_PLUGIN_VERSION:-}")"
+  esc_client="$(xml_escape "$client")"
+  esc_agent_path_env="$(xml_escape "$agent_path_env")"
+  esc_log_file="$(xml_escape "$log_file")"
+fi
+
 agent_updated=0
 if [ "$managed_agent_ensured" = "1" ]; then
   agent_hash_after="$(hash_file "$agent_path")"
@@ -353,13 +381,13 @@ launchd_configured() {
   # moment the agent should restart so telemetry reports the new version. It
   # cannot cause the per-session restart churn PATH did.
   [ -f "$launchd_plist" ] &&
-    grep -Fq "<string>$agent_path</string>" "$launchd_plist" &&
-    grep -q "<string>$auth_client_id</string>" "$launchd_plist" &&
-    grep -q "<string>$auth_url</string>" "$launchd_plist" &&
-    grep -q "<string>$auth_audience</string>" "$launchd_plist" &&
-    grep -q "<string>$autospin_url</string>" "$launchd_plist" &&
-    grep -q "<string>${MONK_AGENT_LOCAL:-}</string>" "$launchd_plist" &&
-    grep -q "<string>${MONK_PLUGIN_VERSION:-}</string>" "$launchd_plist"
+    grep -Fq "<string>$esc_agent_path</string>" "$launchd_plist" &&
+    grep -Fq "<string>$esc_auth_client_id</string>" "$launchd_plist" &&
+    grep -Fq "<string>$esc_auth_url</string>" "$launchd_plist" &&
+    grep -Fq "<string>$esc_auth_audience</string>" "$launchd_plist" &&
+    grep -Fq "<string>$esc_autospin_url</string>" "$launchd_plist" &&
+    grep -Fq "<string>$esc_agent_local</string>" "$launchd_plist" &&
+    grep -Fq "<string>$esc_plugin_version</string>" "$launchd_plist"
 }
 
 # The background-process (non-launchd) path has no plist to introspect, so the
@@ -399,15 +427,15 @@ start_with_launchd() {
 <plist version="1.0">
 <dict>
   <key>Label</key>
-  <string>$launchd_label</string>
+  <string>$esc_launchd_label</string>
   <key>ProgramArguments</key>
   <array>
-    <string>$agent_path</string>
+    <string>$esc_agent_path</string>
     <string>serve</string>
     <string>--host</string>
-    <string>$host</string>
+    <string>$esc_host</string>
     <string>--port</string>
-    <string>$port</string>
+    <string>$esc_port</string>
   </array>
   <key>RunAtLoad</key>
   <true/>
@@ -428,30 +456,30 @@ start_with_launchd() {
   <key>EnvironmentVariables</key>
   <dict>
     <key>MONK_AUTH_URL</key>
-    <string>$auth_url</string>
+    <string>$esc_auth_url</string>
     <key>MONK_AGENT_AUTH_CLIENT_ID</key>
-    <string>$auth_client_id</string>
+    <string>$esc_auth_client_id</string>
     <key>MONK_AUTH_AUDIENCE</key>
-    <string>$auth_audience</string>
+    <string>$esc_auth_audience</string>
     <key>MONK_AUTOSPIN_URL</key>
-    <string>$autospin_url</string>
+    <string>$esc_autospin_url</string>
     <key>MONK_AGENT_LOCAL</key>
-    <string>${MONK_AGENT_LOCAL:-}</string>
+    <string>$esc_agent_local</string>
     <key>MONK_PLUGIN_VERSION</key>
-    <string>${MONK_PLUGIN_VERSION:-}</string>
+    <string>$esc_plugin_version</string>
     <!-- Deliberately NOT gated in launchd_configured(): the launching client
          legitimately differs per session, and gating a restart on it would
          reintroduce the per-session churn the PATH exclusion comment warns
          about. On macOS this reflects the client of the last real (re)start. -->
     <key>MONK_AGENT_LAUNCH_CLIENT</key>
-    <string>$client</string>
+    <string>$esc_client</string>
     <key>PATH</key>
-    <string>$agent_path_env</string>
+    <string>$esc_agent_path_env</string>
   </dict>
   <key>StandardOutPath</key>
-  <string>$log_file</string>
+  <string>$esc_log_file</string>
   <key>StandardErrorPath</key>
-  <string>$log_file</string>
+  <string>$esc_log_file</string>
 </dict>
 </plist>
 EOF

--- a/plugins/monk/scripts/start-monk-agent.sh
+++ b/plugins/monk/scripts/start-monk-agent.sh
@@ -10,6 +10,15 @@ autospin_url="${MONK_AUTOSPIN_URL:-wss://api.app.monk.io/autospin/}"
 agent_path_env="${PATH:-/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin}"
 script_dir="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
 
+xml_escape() {
+  printf '%s' "$1" | sed \
+    -e 's/&/\&amp;/g' \
+    -e 's/</\&lt;/g' \
+    -e 's/>/\&gt;/g' \
+    -e 's/"/\&quot;/g' \
+    -e "s/'/\&apos;/g"
+}
+
 # Host hooks terminate this launcher after 180 seconds. Keep readiness work
 # below that deadline so startup failures can print their own diagnostics
 # instead of being killed mid-wait (ENG-410).
@@ -332,6 +341,25 @@ if [ ! -x "$agent_path" ]; then
   exit 2
 fi
 
+# The launchd plist is XML. Encode every dynamic string once, before both the
+# reuse check and plist generation, so valid paths and URLs cannot corrupt it
+# and the fast path compares the serialized representation.
+if [ "$os" = "Darwin" ]; then
+  esc_launchd_label="$(xml_escape "$launchd_label")"
+  esc_agent_path="$(xml_escape "$agent_path")"
+  esc_host="$(xml_escape "$host")"
+  esc_port="$(xml_escape "$port")"
+  esc_auth_url="$(xml_escape "$auth_url")"
+  esc_auth_client_id="$(xml_escape "$auth_client_id")"
+  esc_auth_audience="$(xml_escape "$auth_audience")"
+  esc_autospin_url="$(xml_escape "$autospin_url")"
+  esc_agent_local="$(xml_escape "${MONK_AGENT_LOCAL:-}")"
+  esc_plugin_version="$(xml_escape "${MONK_PLUGIN_VERSION:-}")"
+  esc_client="$(xml_escape "$client")"
+  esc_agent_path_env="$(xml_escape "$agent_path_env")"
+  esc_log_file="$(xml_escape "$log_file")"
+fi
+
 agent_updated=0
 if [ "$managed_agent_ensured" = "1" ]; then
   agent_hash_after="$(hash_file "$agent_path")"
@@ -353,13 +381,13 @@ launchd_configured() {
   # moment the agent should restart so telemetry reports the new version. It
   # cannot cause the per-session restart churn PATH did.
   [ -f "$launchd_plist" ] &&
-    grep -Fq "<string>$agent_path</string>" "$launchd_plist" &&
-    grep -q "<string>$auth_client_id</string>" "$launchd_plist" &&
-    grep -q "<string>$auth_url</string>" "$launchd_plist" &&
-    grep -q "<string>$auth_audience</string>" "$launchd_plist" &&
-    grep -q "<string>$autospin_url</string>" "$launchd_plist" &&
-    grep -q "<string>${MONK_AGENT_LOCAL:-}</string>" "$launchd_plist" &&
-    grep -q "<string>${MONK_PLUGIN_VERSION:-}</string>" "$launchd_plist"
+    grep -Fq "<string>$esc_agent_path</string>" "$launchd_plist" &&
+    grep -Fq "<string>$esc_auth_client_id</string>" "$launchd_plist" &&
+    grep -Fq "<string>$esc_auth_url</string>" "$launchd_plist" &&
+    grep -Fq "<string>$esc_auth_audience</string>" "$launchd_plist" &&
+    grep -Fq "<string>$esc_autospin_url</string>" "$launchd_plist" &&
+    grep -Fq "<string>$esc_agent_local</string>" "$launchd_plist" &&
+    grep -Fq "<string>$esc_plugin_version</string>" "$launchd_plist"
 }
 
 # The background-process (non-launchd) path has no plist to introspect, so the
@@ -399,15 +427,15 @@ start_with_launchd() {
 <plist version="1.0">
 <dict>
   <key>Label</key>
-  <string>$launchd_label</string>
+  <string>$esc_launchd_label</string>
   <key>ProgramArguments</key>
   <array>
-    <string>$agent_path</string>
+    <string>$esc_agent_path</string>
     <string>serve</string>
     <string>--host</string>
-    <string>$host</string>
+    <string>$esc_host</string>
     <string>--port</string>
-    <string>$port</string>
+    <string>$esc_port</string>
   </array>
   <key>RunAtLoad</key>
   <true/>
@@ -428,30 +456,30 @@ start_with_launchd() {
   <key>EnvironmentVariables</key>
   <dict>
     <key>MONK_AUTH_URL</key>
-    <string>$auth_url</string>
+    <string>$esc_auth_url</string>
     <key>MONK_AGENT_AUTH_CLIENT_ID</key>
-    <string>$auth_client_id</string>
+    <string>$esc_auth_client_id</string>
     <key>MONK_AUTH_AUDIENCE</key>
-    <string>$auth_audience</string>
+    <string>$esc_auth_audience</string>
     <key>MONK_AUTOSPIN_URL</key>
-    <string>$autospin_url</string>
+    <string>$esc_autospin_url</string>
     <key>MONK_AGENT_LOCAL</key>
-    <string>${MONK_AGENT_LOCAL:-}</string>
+    <string>$esc_agent_local</string>
     <key>MONK_PLUGIN_VERSION</key>
-    <string>${MONK_PLUGIN_VERSION:-}</string>
+    <string>$esc_plugin_version</string>
     <!-- Deliberately NOT gated in launchd_configured(): the launching client
          legitimately differs per session, and gating a restart on it would
          reintroduce the per-session churn the PATH exclusion comment warns
          about. On macOS this reflects the client of the last real (re)start. -->
     <key>MONK_AGENT_LAUNCH_CLIENT</key>
-    <string>$client</string>
+    <string>$esc_client</string>
     <key>PATH</key>
-    <string>$agent_path_env</string>
+    <string>$esc_agent_path_env</string>
   </dict>
   <key>StandardOutPath</key>
-  <string>$log_file</string>
+  <string>$esc_log_file</string>
   <key>StandardErrorPath</key>
-  <string>$log_file</string>
+  <string>$esc_log_file</string>
 </dict>
 </plist>
 EOF

--- a/scripts/start-monk-agent.sh
+++ b/scripts/start-monk-agent.sh
@@ -10,6 +10,15 @@ autospin_url="${MONK_AUTOSPIN_URL:-wss://api.app.monk.io/autospin/}"
 agent_path_env="${PATH:-/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin}"
 script_dir="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
 
+xml_escape() {
+  printf '%s' "$1" | sed \
+    -e 's/&/\&amp;/g' \
+    -e 's/</\&lt;/g' \
+    -e 's/>/\&gt;/g' \
+    -e 's/"/\&quot;/g' \
+    -e "s/'/\&apos;/g"
+}
+
 # Host hooks terminate this launcher after 180 seconds. Keep readiness work
 # below that deadline so startup failures can print their own diagnostics
 # instead of being killed mid-wait (ENG-410).
@@ -332,6 +341,25 @@ if [ ! -x "$agent_path" ]; then
   exit 2
 fi
 
+# The launchd plist is XML. Encode every dynamic string once, before both the
+# reuse check and plist generation, so valid paths and URLs cannot corrupt it
+# and the fast path compares the serialized representation.
+if [ "$os" = "Darwin" ]; then
+  esc_launchd_label="$(xml_escape "$launchd_label")"
+  esc_agent_path="$(xml_escape "$agent_path")"
+  esc_host="$(xml_escape "$host")"
+  esc_port="$(xml_escape "$port")"
+  esc_auth_url="$(xml_escape "$auth_url")"
+  esc_auth_client_id="$(xml_escape "$auth_client_id")"
+  esc_auth_audience="$(xml_escape "$auth_audience")"
+  esc_autospin_url="$(xml_escape "$autospin_url")"
+  esc_agent_local="$(xml_escape "${MONK_AGENT_LOCAL:-}")"
+  esc_plugin_version="$(xml_escape "${MONK_PLUGIN_VERSION:-}")"
+  esc_client="$(xml_escape "$client")"
+  esc_agent_path_env="$(xml_escape "$agent_path_env")"
+  esc_log_file="$(xml_escape "$log_file")"
+fi
+
 agent_updated=0
 if [ "$managed_agent_ensured" = "1" ]; then
   agent_hash_after="$(hash_file "$agent_path")"
@@ -353,13 +381,13 @@ launchd_configured() {
   # moment the agent should restart so telemetry reports the new version. It
   # cannot cause the per-session restart churn PATH did.
   [ -f "$launchd_plist" ] &&
-    grep -Fq "<string>$agent_path</string>" "$launchd_plist" &&
-    grep -q "<string>$auth_client_id</string>" "$launchd_plist" &&
-    grep -q "<string>$auth_url</string>" "$launchd_plist" &&
-    grep -q "<string>$auth_audience</string>" "$launchd_plist" &&
-    grep -q "<string>$autospin_url</string>" "$launchd_plist" &&
-    grep -q "<string>${MONK_AGENT_LOCAL:-}</string>" "$launchd_plist" &&
-    grep -q "<string>${MONK_PLUGIN_VERSION:-}</string>" "$launchd_plist"
+    grep -Fq "<string>$esc_agent_path</string>" "$launchd_plist" &&
+    grep -Fq "<string>$esc_auth_client_id</string>" "$launchd_plist" &&
+    grep -Fq "<string>$esc_auth_url</string>" "$launchd_plist" &&
+    grep -Fq "<string>$esc_auth_audience</string>" "$launchd_plist" &&
+    grep -Fq "<string>$esc_autospin_url</string>" "$launchd_plist" &&
+    grep -Fq "<string>$esc_agent_local</string>" "$launchd_plist" &&
+    grep -Fq "<string>$esc_plugin_version</string>" "$launchd_plist"
 }
 
 # The background-process (non-launchd) path has no plist to introspect, so the
@@ -399,15 +427,15 @@ start_with_launchd() {
 <plist version="1.0">
 <dict>
   <key>Label</key>
-  <string>$launchd_label</string>
+  <string>$esc_launchd_label</string>
   <key>ProgramArguments</key>
   <array>
-    <string>$agent_path</string>
+    <string>$esc_agent_path</string>
     <string>serve</string>
     <string>--host</string>
-    <string>$host</string>
+    <string>$esc_host</string>
     <string>--port</string>
-    <string>$port</string>
+    <string>$esc_port</string>
   </array>
   <key>RunAtLoad</key>
   <true/>
@@ -428,30 +456,30 @@ start_with_launchd() {
   <key>EnvironmentVariables</key>
   <dict>
     <key>MONK_AUTH_URL</key>
-    <string>$auth_url</string>
+    <string>$esc_auth_url</string>
     <key>MONK_AGENT_AUTH_CLIENT_ID</key>
-    <string>$auth_client_id</string>
+    <string>$esc_auth_client_id</string>
     <key>MONK_AUTH_AUDIENCE</key>
-    <string>$auth_audience</string>
+    <string>$esc_auth_audience</string>
     <key>MONK_AUTOSPIN_URL</key>
-    <string>$autospin_url</string>
+    <string>$esc_autospin_url</string>
     <key>MONK_AGENT_LOCAL</key>
-    <string>${MONK_AGENT_LOCAL:-}</string>
+    <string>$esc_agent_local</string>
     <key>MONK_PLUGIN_VERSION</key>
-    <string>${MONK_PLUGIN_VERSION:-}</string>
+    <string>$esc_plugin_version</string>
     <!-- Deliberately NOT gated in launchd_configured(): the launching client
          legitimately differs per session, and gating a restart on it would
          reintroduce the per-session churn the PATH exclusion comment warns
          about. On macOS this reflects the client of the last real (re)start. -->
     <key>MONK_AGENT_LAUNCH_CLIENT</key>
-    <string>$client</string>
+    <string>$esc_client</string>
     <key>PATH</key>
-    <string>$agent_path_env</string>
+    <string>$esc_agent_path_env</string>
   </dict>
   <key>StandardOutPath</key>
-  <string>$log_file</string>
+  <string>$esc_log_file</string>
   <key>StandardErrorPath</key>
-  <string>$log_file</string>
+  <string>$esc_log_file</string>
 </dict>
 </plist>
 EOF

--- a/tests/start-monk-agent-launchd-plist-escaping.sh
+++ b/tests/start-monk-agent-launchd-plist-escaping.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env sh
+# Dynamic launchd values must be serialized as XML text. Valid paths and URLs
+# containing XML metacharacters must round-trip through the generated plist.
+set -eu
+
+repo_root="${MONK_TEST_REPO_ROOT:-$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)}"
+work_dir="$(mktemp -d)"
+trap 'rm -rf "$work_dir"' EXIT HUP INT TERM
+
+python_cmd="$(command -v python3 || command -v python || true)"
+if [ -z "$python_cmd" ]; then
+  echo "python is required to validate the generated plist" >&2
+  exit 2
+fi
+
+fake_bin="$work_dir/bin"
+mkdir -p "$fake_bin"
+for command_name in cat date dirname grep head id kill mkdir mktemp mv sed sh sleep tr; do
+  command_path="$(command -v "$command_name" || true)"
+  case "$command_path" in
+    /*)
+      printf '#!/usr/bin/sh\nexec "%s" "$@"\n' "$command_path" >"$fake_bin/$command_name"
+      chmod +x "$fake_bin/$command_name"
+      ;;
+  esac
+done
+
+cat >"$fake_bin/uname" <<'EOF'
+#!/usr/bin/sh
+printf '%s\n' Darwin
+EOF
+cat >"$fake_bin/curl" <<'EOF'
+#!/usr/bin/sh
+printf '%s\n' '{"resource":"http://127.0.0.1:7419/mcp"}'
+EOF
+cat >"$fake_bin/launchctl" <<'EOF'
+#!/usr/bin/sh
+exit 0
+EOF
+chmod +x "$fake_bin/uname" "$fake_bin/curl" "$fake_bin/launchctl"
+
+home_root="$work_dir"
+case "$(uname -s 2>/dev/null || printf unknown)" in
+  MINGW*|MSYS*|CYGWIN*) home_root="$(cygpath -m "$work_dir")" ;;
+esac
+home="$home_root/home&fixture"
+agent_path="$home_root/agent&fixture/monk-agent"
+auth_url='https://auth.monk.io/oauth?tenant=a&mode=<test>'
+agent_local="local<&>\"'"
+plist="$home/Library/LaunchAgents/io.monk.agent.plist"
+expected_log="$home/.monk/agent/launcher/logs/monk-agent.log"
+mkdir -p "$(dirname "$agent_path")"
+printf '#!/usr/bin/sh\nexit 0\n' >"$agent_path"
+chmod +x "$agent_path"
+
+HOME="$home" \
+PATH="$fake_bin" \
+MONK_AGENT_PATH="$agent_path" \
+MONK_AGENT_HOME="$home/.monk" \
+MONK_AUTH_URL="$auth_url" \
+MONK_AGENT_LOCAL="$agent_local" \
+MONK_AGENT_SKIP_SIGNIN_NUDGE=1 \
+MONK_DISABLE_ANALYTICS=1 \
+MONK_PLUGIN_VERSION=0.1.58 \
+  /usr/bin/sh "$repo_root/scripts/start-monk-agent.sh"
+
+"$python_cmd" - "$plist" "$agent_path" "$auth_url" "$agent_local" "$expected_log" <<'PY'
+import plistlib
+import sys
+
+(
+    plist_path,
+    expected_agent_path,
+    expected_auth_url,
+    expected_agent_local,
+    expected_log,
+) = sys.argv[1:]
+with open(plist_path, "rb") as handle:
+    config = plistlib.load(handle)
+
+assert config["ProgramArguments"][0] == expected_agent_path
+assert config["EnvironmentVariables"]["MONK_AUTH_URL"] == expected_auth_url
+assert config["EnvironmentVariables"]["MONK_AGENT_LOCAL"] == expected_agent_local
+assert config["StandardOutPath"] == expected_log
+assert config["StandardErrorPath"] == expected_log
+PY
+
+# XML serialization is launchd-only. Guard against accidentally paying for the
+# escaping subprocesses on the Linux fast path by counting sed invocations.
+cat >"$fake_bin/uname" <<'EOF'
+#!/usr/bin/sh
+printf '%s\n' Linux
+EOF
+real_sed="$(command -v sed)"
+printf '#!/usr/bin/sh\nprintf "%%s\\n" "$*" >>"$MONK_TEST_SED_LOG"\nexec "%s" "$@"\n' \
+  "$real_sed" >"$fake_bin/sed"
+chmod +x "$fake_bin/uname" "$fake_bin/sed"
+
+linux_home="$home_root/linux-home"
+linux_run_dir="$linux_home/.monk/agent/launcher/run"
+sed_log="$home_root/linux-sed.log"
+mkdir -p "$linux_run_dir"
+{
+  printf 'agent_path=%s\n' "$agent_path"
+  printf 'auth_url=%s\n' "$auth_url"
+  printf 'auth_client_id=UW84YWcJME3buMSLfqLX8IbBsYdNWi47\n'
+  printf 'auth_audience=oaknode.com\n'
+  printf 'autospin_url=wss://api.app.monk.io/autospin/\n'
+} >"$linux_run_dir/monk-agent.state"
+
+HOME="$linux_home" \
+PATH="$fake_bin" \
+MONK_AGENT_PATH="$agent_path" \
+MONK_AGENT_HOME="$linux_home/.monk" \
+MONK_AUTH_URL="$auth_url" \
+MONK_AGENT_SKIP_SIGNIN_NUDGE=1 \
+MONK_DISABLE_ANALYTICS=1 \
+MONK_PLUGIN_VERSION=0.1.58 \
+MONK_TEST_SED_LOG="$sed_log" \
+  /usr/bin/sh "$repo_root/scripts/start-monk-agent.sh"
+
+sed_calls=0
+while IFS= read -r _line; do
+  sed_calls=$((sed_calls + 1))
+done <"$sed_log"
+if [ "$sed_calls" -ne 1 ]; then
+  echo "Linux fast path ran $sed_calls sed commands; expected only the health parser" >&2
+  exit 1
+fi
+
+echo "launchd plist values round-trip XML metacharacters."


### PR DESCRIPTION
## Summary
- XML-escape every dynamic string before writing the macOS launchd plist, only on the Darwin path (no Linux startup overhead)
- reuse the same escaped values in the launchd fast-path comparison
- update all three shipped launcher mirrors
- add a deterministic Darwin-path regression that round-trips `&`, `<`, `>`, `"`, and `'` through Python `plistlib`

## Why
The launcher currently interpolates paths, URLs, and environment values directly into XML. A valid path such as `/tmp/agent&fixture/monk-agent` produces a malformed plist, so `launchctl bootstrap` cannot start the companion.

This supersedes the rejected implementation in #206. The escaped values are computed before `launchd_configured()` can run, avoiding the unbound `esc_*` variables called out in the maintainer review. Fixed-string checks also compare the exact serialized value rather than interpreting configuration as a regular expression.

## Red-to-green proof
On current v0.1.58 `main` (`8d9a2c3`), the new regression fails in `plistlib.load()` with:

```text
xml.parsers.expat.ExpatError: not well-formed (invalid token): line 9, column 74
```

With this patch:

```text
launchd plist values round-trip XML metacharacters.
```

## Validation
- `tests/start-monk-agent-launchd-plist-escaping.sh` (including a Linux fast-path guard verifying XML escaping adds no non-Darwin `sed` calls)
- `tests/start-monk-agent-fastpath.sh`
- `tests/start-monk-agent-readiness-timeout.sh`
- `bash -n scripts/start-monk-agent.sh`
- SHA-256 equality across all three launcher mirrors
- `git diff --check`

## Generated artifacts
`GENERATED.md` says the public tree is generated from the private `monk-agent/plugin` source. This PR updates the mirrored public artifacts consistently; the corresponding source change should be ported before regeneration.

Fixes #181


