### PR TITLE
fix: bound POSIX installer download stalls

### DIFF
--- a/.antigravity-plugin/scripts/ensure-monk-agent.sh
+++ b/.antigravity-plugin/scripts/ensure-monk-agent.sh
@@ -17,8 +17,19 @@ install_dir="${MONK_AGENT_INSTALL_DIR:-"$HOME/.monk/bin"}"
 channel="${MONK_AGENT_CHANNEL:-stable}"
 download_base="${MONK_AGENT_DOWNLOAD_BASE:-"https://get.monk.io/$channel"}"
 auto_update="${MONK_AGENT_AUTO_UPDATE:-1}"
+# Bound connection setup and periods with no meaningful progress without
+# imposing an absolute deadline on a slow but advancing agent archive.
+download_connect_timeout="${MONK_AGENT_DOWNLOAD_CONNECT_TIMEOUT:-10}"
+download_stall_timeout="${MONK_AGENT_DOWNLOAD_STALL_TIMEOUT:-30}"
 target="$install_dir/monk-agent"
 checksum_installed="$install_dir/monk-agent.sha256"
+
+case "$download_connect_timeout" in
+  *[!0-9]*|0*) echo "MONK_AGENT_DOWNLOAD_CONNECT_TIMEOUT must be a positive integer number of seconds." >&2; exit 2 ;;
+esac
+case "$download_stall_timeout" in
+  *[!0-9]*|0*) echo "MONK_AGENT_DOWNLOAD_STALL_TIMEOUT must be a positive integer number of seconds." >&2; exit 2 ;;
+esac
 
 os="$(uname -s)"
 arch="$(uname -m)"
@@ -75,9 +86,11 @@ fi
 
 download_checksum() {
   if command -v curl >/dev/null 2>&1; then
-    curl -fL "$checksum_url" -o "$checksum_tmp"
+    curl -fL --connect-timeout "$download_connect_timeout" \
+      --speed-limit 1 --speed-time "$download_stall_timeout" \
+      "$checksum_url" -o "$checksum_tmp"
   elif command -v wget >/dev/null 2>&1; then
-    wget -O "$checksum_tmp" "$checksum_url"
+    wget -t 1 -T "$download_stall_timeout" -O "$checksum_tmp" "$checksum_url"
   else
     echo "curl or wget is required to check for monk-agent updates." >&2
     return 2
@@ -127,9 +140,11 @@ fi
 
 echo "Installing monk-agent from $url" >&2
 if command -v curl >/dev/null 2>&1; then
-  curl -fL "$url" -o "$archive_tmp"
+  curl -fL --connect-timeout "$download_connect_timeout" \
+    --speed-limit 1 --speed-time "$download_stall_timeout" \
+    "$url" -o "$archive_tmp"
 elif command -v wget >/dev/null 2>&1; then
-  wget -O "$archive_tmp" "$url"
+  wget -t 1 -T "$download_stall_timeout" -O "$archive_tmp" "$url"
 fi
 
 if command -v shasum >/dev/null 2>&1; then

--- a/plugins/monk/scripts/ensure-monk-agent.sh
+++ b/plugins/monk/scripts/ensure-monk-agent.sh
@@ -17,8 +17,19 @@ install_dir="${MONK_AGENT_INSTALL_DIR:-"$HOME/.monk/bin"}"
 channel="${MONK_AGENT_CHANNEL:-stable}"
 download_base="${MONK_AGENT_DOWNLOAD_BASE:-"https://get.monk.io/$channel"}"
 auto_update="${MONK_AGENT_AUTO_UPDATE:-1}"
+# Bound connection setup and periods with no meaningful progress without
+# imposing an absolute deadline on a slow but advancing agent archive.
+download_connect_timeout="${MONK_AGENT_DOWNLOAD_CONNECT_TIMEOUT:-10}"
+download_stall_timeout="${MONK_AGENT_DOWNLOAD_STALL_TIMEOUT:-30}"
 target="$install_dir/monk-agent"
 checksum_installed="$install_dir/monk-agent.sha256"
+
+case "$download_connect_timeout" in
+  *[!0-9]*|0*) echo "MONK_AGENT_DOWNLOAD_CONNECT_TIMEOUT must be a positive integer number of seconds." >&2; exit 2 ;;
+esac
+case "$download_stall_timeout" in
+  *[!0-9]*|0*) echo "MONK_AGENT_DOWNLOAD_STALL_TIMEOUT must be a positive integer number of seconds." >&2; exit 2 ;;
+esac
 
 os="$(uname -s)"
 arch="$(uname -m)"
@@ -75,9 +86,11 @@ fi
 
 download_checksum() {
   if command -v curl >/dev/null 2>&1; then
-    curl -fL "$checksum_url" -o "$checksum_tmp"
+    curl -fL --connect-timeout "$download_connect_timeout" \
+      --speed-limit 1 --speed-time "$download_stall_timeout" \
+      "$checksum_url" -o "$checksum_tmp"
   elif command -v wget >/dev/null 2>&1; then
-    wget -O "$checksum_tmp" "$checksum_url"
+    wget -t 1 -T "$download_stall_timeout" -O "$checksum_tmp" "$checksum_url"
   else
     echo "curl or wget is required to check for monk-agent updates." >&2
     return 2
@@ -127,9 +140,11 @@ fi
 
 echo "Installing monk-agent from $url" >&2
 if command -v curl >/dev/null 2>&1; then
-  curl -fL "$url" -o "$archive_tmp"
+  curl -fL --connect-timeout "$download_connect_timeout" \
+    --speed-limit 1 --speed-time "$download_stall_timeout" \
+    "$url" -o "$archive_tmp"
 elif command -v wget >/dev/null 2>&1; then
-  wget -O "$archive_tmp" "$url"
+  wget -t 1 -T "$download_stall_timeout" -O "$archive_tmp" "$url"
 fi
 
 if command -v shasum >/dev/null 2>&1; then

--- a/scripts/ensure-monk-agent.sh
+++ b/scripts/ensure-monk-agent.sh
@@ -17,8 +17,19 @@ install_dir="${MONK_AGENT_INSTALL_DIR:-"$HOME/.monk/bin"}"
 channel="${MONK_AGENT_CHANNEL:-stable}"
 download_base="${MONK_AGENT_DOWNLOAD_BASE:-"https://get.monk.io/$channel"}"
 auto_update="${MONK_AGENT_AUTO_UPDATE:-1}"
+# Bound connection setup and periods with no meaningful progress without
+# imposing an absolute deadline on a slow but advancing agent archive.
+download_connect_timeout="${MONK_AGENT_DOWNLOAD_CONNECT_TIMEOUT:-10}"
+download_stall_timeout="${MONK_AGENT_DOWNLOAD_STALL_TIMEOUT:-30}"
 target="$install_dir/monk-agent"
 checksum_installed="$install_dir/monk-agent.sha256"
+
+case "$download_connect_timeout" in
+  *[!0-9]*|0*) echo "MONK_AGENT_DOWNLOAD_CONNECT_TIMEOUT must be a positive integer number of seconds." >&2; exit 2 ;;
+esac
+case "$download_stall_timeout" in
+  *[!0-9]*|0*) echo "MONK_AGENT_DOWNLOAD_STALL_TIMEOUT must be a positive integer number of seconds." >&2; exit 2 ;;
+esac
 
 os="$(uname -s)"
 arch="$(uname -m)"
@@ -75,9 +86,11 @@ fi
 
 download_checksum() {
   if command -v curl >/dev/null 2>&1; then
-    curl -fL "$checksum_url" -o "$checksum_tmp"
+    curl -fL --connect-timeout "$download_connect_timeout" \
+      --speed-limit 1 --speed-time "$download_stall_timeout" \
+      "$checksum_url" -o "$checksum_tmp"
   elif command -v wget >/dev/null 2>&1; then
-    wget -O "$checksum_tmp" "$checksum_url"
+    wget -t 1 -T "$download_stall_timeout" -O "$checksum_tmp" "$checksum_url"
   else
     echo "curl or wget is required to check for monk-agent updates." >&2
     return 2
@@ -127,9 +140,11 @@ fi
 
 echo "Installing monk-agent from $url" >&2
 if command -v curl >/dev/null 2>&1; then
-  curl -fL "$url" -o "$archive_tmp"
+  curl -fL --connect-timeout "$download_connect_timeout" \
+    --speed-limit 1 --speed-time "$download_stall_timeout" \
+    "$url" -o "$archive_tmp"
 elif command -v wget >/dev/null 2>&1; then
-  wget -O "$archive_tmp" "$url"
+  wget -t 1 -T "$download_stall_timeout" -O "$archive_tmp" "$url"
 fi
 
 if command -v shasum >/dev/null 2>&1; then

--- a/tests/ensure-monk-agent-download-timeout.sh
+++ b/tests/ensure-monk-agent-download-timeout.sh
@@ -5,9 +5,14 @@
 set -eu
 
 repo_root="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
-fixture_bin="$repo_root/tests/fixtures/ensure-monk-agent"
+fixture_source="$repo_root/tests/fixtures/ensure-monk-agent/curl"
 work_dir="$(mktemp -d)"
 trap 'rm -rf "$work_dir"' EXIT HUP INT TERM
+
+fixture_bin="$work_dir/bin"
+mkdir -p "$fixture_bin"
+cp "$fixture_source" "$fixture_bin/curl"
+chmod +x "$fixture_bin/curl"
 
 calls="$work_dir/curl-calls"
 : >"$calls"
@@ -32,6 +37,8 @@ if grep -v ' bounded=1$' "$calls"; then
   exit 1
 fi
 
+# wget is the fallback downloader. Keep each transfer to one timeout-bounded
+# attempt so its retry policy cannot extend the SessionStart path unexpectedly.
 [ "$(grep -F -c 'wget -t 1 -T "$download_stall_timeout"' "$repo_root/scripts/ensure-monk-agent.sh")" -eq 2 ]
 
 cmp "$repo_root/scripts/ensure-monk-agent.sh" "$repo_root/plugins/monk/scripts/ensure-monk-agent.sh"

--- a/tests/ensure-monk-agent-download-timeout.sh
+++ b/tests/ensure-monk-agent-download-timeout.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env sh
+# Regression coverage: checksum and archive downloads must carry bounded
+# connect and low-speed deadlines so a stalled server cannot consume the host
+# SessionStart hook indefinitely.
+set -eu
+
+repo_root="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+fixture_bin="$repo_root/tests/fixtures/ensure-monk-agent"
+work_dir="$(mktemp -d)"
+trap 'rm -rf "$work_dir"' EXIT HUP INT TERM
+
+calls="$work_dir/curl-calls"
+: >"$calls"
+
+set +e
+PATH="$fixture_bin:$PATH" \
+TEST_CURL_CALLS="$calls" \
+TEST_CONNECT_TIMEOUT=7 \
+TEST_STALL_TIMEOUT=9 \
+MONK_AGENT_DOWNLOAD_CONNECT_TIMEOUT=7 \
+MONK_AGENT_DOWNLOAD_STALL_TIMEOUT=9 \
+MONK_AGENT_DOWNLOAD_BASE=https://downloads.invalid/stable \
+MONK_AGENT_INSTALL_DIR="$work_dir/install" \
+  "$repo_root/scripts/ensure-monk-agent.sh" >"$work_dir/stdout" 2>"$work_dir/stderr"
+status=$?
+set -e
+
+[ "$status" -eq 28 ]
+[ "$(wc -l <"$calls")" -eq 2 ]
+if grep -v ' bounded=1$' "$calls"; then
+  echo "monk-agent download was attempted without bounded network deadlines" >&2
+  exit 1
+fi
+
+[ "$(grep -F -c 'wget -t 1 -T "$download_stall_timeout"' "$repo_root/scripts/ensure-monk-agent.sh")" -eq 2 ]
+
+cmp "$repo_root/scripts/ensure-monk-agent.sh" "$repo_root/plugins/monk/scripts/ensure-monk-agent.sh"
+cmp "$repo_root/scripts/ensure-monk-agent.sh" "$repo_root/.antigravity-plugin/scripts/ensure-monk-agent.sh"
+
+printf 'ensure_monk_agent_download_timeout=pass calls=2\n'

--- a/tests/fixtures/ensure-monk-agent/curl
+++ b/tests/fixtures/ensure-monk-agent/curl
@@ -1,0 +1,52 @@
+#!/usr/bin/env sh
+set -eu
+
+connect_timeout=""
+speed_limit=""
+speed_time=""
+output=""
+url=""
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --connect-timeout)
+      shift
+      connect_timeout="${1:-}"
+      ;;
+    --speed-limit)
+      shift
+      speed_limit="${1:-}"
+      ;;
+    --speed-time)
+      shift
+      speed_time="${1:-}"
+      ;;
+    -o)
+      shift
+      output="${1:-}"
+      ;;
+    http://*|https://*)
+      url="$1"
+      ;;
+  esac
+  [ "$#" -gt 0 ] && shift
+done
+
+bounded=0
+if [ "$connect_timeout" = "$TEST_CONNECT_TIMEOUT" ] &&
+   [ "$speed_limit" = "1" ] &&
+   [ "$speed_time" = "$TEST_STALL_TIMEOUT" ]; then
+  bounded=1
+fi
+printf '%s bounded=%s\n' "$url" "$bounded" >>"$TEST_CURL_CALLS"
+
+case "$url" in
+  *.sha256)
+    printf '%064d  monk-agent.tar.gz\n' 0 >"$output"
+    exit 0
+    ;;
+  *)
+    # Simulate an archive transfer that hit the configured low-speed deadline.
+    exit 28
+    ;;
+esac


### PR DESCRIPTION
Fixes #360.

## What changed

- add configurable `MONK_AGENT_DOWNLOAD_CONNECT_TIMEOUT` (default 10s)
- add configurable `MONK_AGENT_DOWNLOAD_STALL_TIMEOUT` (default 30s)
- apply curl connect + low-speed/no-progress deadlines to both checksum and archive downloads
- bound wget fallback transfers to one timeout-limited attempt
- reject invalid/non-positive timeout values early
- keep all three shipped POSIX `ensure-monk-agent.sh` copies in sync
- add a deterministic regression test covering both curl download calls and the wget single-attempt invariant

## Why

The POSIX bootstrap previously delegated checksum/archive transfer duration entirely to curl/wget defaults. A server that accepts a connection but stops making progress can therefore hold plugin installation before the launcher reaches its separate readiness deadline.

This is distinct from #52 (post-launch readiness timeout) and #90 (offline fallback to a previously verified local agent).

## Validation

- `sh -n` on the patched installer and regression script
- deterministic regression: `ensure_monk_agent_download_timeout=pass calls=2`
- regression checks that the three shipped POSIX installer copies are byte-identical
- base verified against current upstream `main` at `8d9a2c3e9b1fcf0ba185f010f9452b2162cd6b54`

I also prepared Install E2E workflow wiring locally, but did not include it because the connected GitHub token does not have permission to modify `.github/workflows/*` on the fork. The regression itself is included and can be run directly with:

```sh
sh ./tests/ensure-monk-agent-download-timeout.sh
```

Prepared with ChatGPT/Codex assistance.