### PR TITLE
fix: bound Antigravity block-monk helper wait

### DIFF
--- a/.antigravity-plugin/hooks/block-monk.sh
+++ b/.antigravity-plugin/hooks/block-monk.sh
@@ -24,8 +24,52 @@ if [ -t 0 ]; then exit 0; fi
 input="$(cat)"
 
 agent="${MONK_AGENT_PATH:-${MONK_AGENT_INSTALL_DIR:-"$HOME/.monk/bin"}/monk-agent}"
+helper_timeout="${MONK_BLOCK_MONK_HELPER_TIMEOUT:-2}"
+case "$helper_timeout" in
+  *[!0-9]*|0*) helper_timeout=2 ;;
+esac
+
+run_agent_helper() {
+  helper_dir="$(mktemp -d "${TMPDIR:-/tmp}/monk-block-monk.XXXXXX")" || return 1
+  helper_input="$helper_dir/input"
+  helper_output="$helper_dir/output"
+  helper_error="$helper_dir/error"
+  helper_timed_out="$helper_dir/timed-out"
+  printf '%s' "$input" >"$helper_input"
+
+  "$agent" hook block-monk --format antigravity \
+    <"$helper_input" >"$helper_output" 2>"$helper_error" &
+  helper_pid=$!
+  (
+    sleep "$helper_timeout"
+    : >"$helper_timed_out"
+    kill -TERM "$helper_pid" 2>/dev/null || true
+  ) &
+  watchdog_pid=$!
+
+  if wait "$helper_pid"; then
+    helper_status=0
+  else
+    helper_status=$?
+  fi
+  kill "$watchdog_pid" 2>/dev/null || true
+  wait "$watchdog_pid" 2>/dev/null || true
+
+  if [ "$helper_status" -eq 0 ]; then
+    cat "$helper_error" >&2
+    cat "$helper_output"
+    rm -rf "$helper_dir"
+    return 0
+  fi
+  if [ ! -f "$helper_timed_out" ]; then
+    cat "$helper_error" >&2
+  fi
+  rm -rf "$helper_dir"
+  return 1
+}
+
 if [ -x "$agent" ]; then
-  if printf '%s' "$input" | "$agent" hook block-monk --format antigravity; then
+  if run_agent_helper; then
     exit 0
   fi
 fi

--- a/hooks/block-monk.sh
+++ b/hooks/block-monk.sh
@@ -21,8 +21,52 @@ if [ -t 0 ]; then exit 0; fi
 input="$(cat)"
 
 agent="${MONK_AGENT_PATH:-${MONK_AGENT_INSTALL_DIR:-"$HOME/.monk/bin"}/monk-agent}"
+helper_timeout="${MONK_BLOCK_MONK_HELPER_TIMEOUT:-2}"
+case "$helper_timeout" in
+  *[!0-9]*|0*) helper_timeout=2 ;;
+esac
+
+run_agent_helper() {
+  helper_dir="$(mktemp -d "${TMPDIR:-/tmp}/monk-block-monk.XXXXXX")" || return 1
+  helper_input="$helper_dir/input"
+  helper_output="$helper_dir/output"
+  helper_error="$helper_dir/error"
+  helper_timed_out="$helper_dir/timed-out"
+  printf '%s' "$input" >"$helper_input"
+
+  "$agent" hook block-monk --format claude \
+    <"$helper_input" >"$helper_output" 2>"$helper_error" &
+  helper_pid=$!
+  (
+    sleep "$helper_timeout"
+    : >"$helper_timed_out"
+    kill -TERM "$helper_pid" 2>/dev/null || true
+  ) &
+  watchdog_pid=$!
+
+  if wait "$helper_pid"; then
+    helper_status=0
+  else
+    helper_status=$?
+  fi
+  kill "$watchdog_pid" 2>/dev/null || true
+  wait "$watchdog_pid" 2>/dev/null || true
+
+  if [ "$helper_status" -eq 0 ]; then
+    cat "$helper_error" >&2
+    cat "$helper_output"
+    rm -rf "$helper_dir"
+    return 0
+  fi
+  if [ ! -f "$helper_timed_out" ]; then
+    cat "$helper_error" >&2
+  fi
+  rm -rf "$helper_dir"
+  return 1
+}
+
 if [ -x "$agent" ]; then
-  if printf '%s' "$input" | "$agent" hook block-monk --format claude; then
+  if run_agent_helper; then
     exit 0
   fi
 fi

--- a/plugins/monk/hooks/block-monk.sh
+++ b/plugins/monk/hooks/block-monk.sh
@@ -21,8 +21,52 @@ if [ -t 0 ]; then exit 0; fi
 input="$(cat)"
 
 agent="${MONK_AGENT_PATH:-${MONK_AGENT_INSTALL_DIR:-"$HOME/.monk/bin"}/monk-agent}"
+helper_timeout="${MONK_BLOCK_MONK_HELPER_TIMEOUT:-2}"
+case "$helper_timeout" in
+  *[!0-9]*|0*) helper_timeout=2 ;;
+esac
+
+run_agent_helper() {
+  helper_dir="$(mktemp -d "${TMPDIR:-/tmp}/monk-block-monk.XXXXXX")" || return 1
+  helper_input="$helper_dir/input"
+  helper_output="$helper_dir/output"
+  helper_error="$helper_dir/error"
+  helper_timed_out="$helper_dir/timed-out"
+  printf '%s' "$input" >"$helper_input"
+
+  "$agent" hook block-monk --format claude \
+    <"$helper_input" >"$helper_output" 2>"$helper_error" &
+  helper_pid=$!
+  (
+    sleep "$helper_timeout"
+    : >"$helper_timed_out"
+    kill -TERM "$helper_pid" 2>/dev/null || true
+  ) &
+  watchdog_pid=$!
+
+  if wait "$helper_pid"; then
+    helper_status=0
+  else
+    helper_status=$?
+  fi
+  kill "$watchdog_pid" 2>/dev/null || true
+  wait "$watchdog_pid" 2>/dev/null || true
+
+  if [ "$helper_status" -eq 0 ]; then
+    cat "$helper_error" >&2
+    cat "$helper_output"
+    rm -rf "$helper_dir"
+    return 0
+  fi
+  if [ ! -f "$helper_timed_out" ]; then
+    cat "$helper_error" >&2
+  fi
+  rm -rf "$helper_dir"
+  return 1
+}
+
 if [ -x "$agent" ]; then
-  if printf '%s' "$input" | "$agent" hook block-monk --format claude; then
+  if run_agent_helper; then
     exit 0
   fi
 fi

--- a/tests/block-monk-helper-timeout.sh
+++ b/tests/block-monk-helper-timeout.sh
@@ -1,9 +1,8 @@
 #!/usr/bin/env sh
-# A wedged monk-agent hook helper must not consume Antigravity's 5-second
-# PreToolUse budget. The hook should fall back and still deny a direct monk CLI.
+# A wedged monk-agent hook helper must not consume the host's PreToolUse budget.
+# Both Claude/Codex and Antigravity POSIX wrappers must fall back and deny monk.
 set -eu
 repo_root="${1:-$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)}"
-hook="$repo_root/.antigravity-plugin/hooks/block-monk.sh"
 work_dir="$(mktemp -d)"
 cleanup() { rm -rf "$work_dir"; }
 trap cleanup EXIT HUP INT TERM
@@ -17,38 +16,57 @@ chmod +x "$work_dir/hang-agent"
 cat >"$work_dir/success-agent" <<'AGENT'
 #!/usr/bin/env sh
 cat >/dev/null
-printf '%s\n' '{"decision":"deny","reason":"helper decision"}'
+case "$*" in
+  *antigravity*) printf '%s\n' '{"decision":"deny","reason":"helper decision"}' ;;
+  *) printf '%s\n' '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"helper decision"}}' ;;
+esac
 AGENT
 chmod +x "$work_dir/success-agent"
 
-payload='{"toolCall":{"name":"run_command","args":{"CommandLine":"monk status"}}}'
+run_variant() {
+  name="$1"
+  hook="$2"
+  payload="$3"
+  deny_pattern="$4"
 
-printf '%s' "$payload" |
-  MONK_AGENT_PATH="$work_dir/hang-agent" \
-  MONK_BLOCK_MONK_HELPER_TIMEOUT=1 \
-  "$hook" >"$work_dir/hang.out" 2>"$work_dir/hang.err" &
-hook_pid=$!
+  printf '%s' "$payload" |
+    MONK_AGENT_PATH="$work_dir/hang-agent" \
+    MONK_BLOCK_MONK_HELPER_TIMEOUT=1 \
+    "$hook" >"$work_dir/$name-hang.out" 2>"$work_dir/$name-hang.err" &
+  hook_pid=$!
 
-finished=0
-for _ in 1 2 3; do
-  if ! kill -0 "$hook_pid" 2>/dev/null; then
-    finished=1
-    break
+  finished=0
+  for _ in 1 2 3; do
+    if ! kill -0 "$hook_pid" 2>/dev/null; then
+      finished=1
+      break
+    fi
+    sleep 1
+  done
+  if [ "$finished" -ne 1 ]; then
+    kill "$hook_pid" 2>/dev/null || true
+    wait "$hook_pid" 2>/dev/null || true
+    echo "$name block-monk hook outlived its helper timeout" >&2
+    exit 1
   fi
-  sleep 1
-done
-if [ "$finished" -ne 1 ]; then
-  kill "$hook_pid" 2>/dev/null || true
-  wait "$hook_pid" 2>/dev/null || true
-  echo "block-monk hook outlived its helper timeout" >&2
-  exit 1
-fi
-wait "$hook_pid"
-grep -q '"decision": "deny"' "$work_dir/hang.out"
+  wait "$hook_pid"
+  grep -q "$deny_pattern" "$work_dir/$name-hang.out"
 
-printf '%s' "$payload" |
-  MONK_AGENT_PATH="$work_dir/success-agent" \
-  "$hook" >"$work_dir/success.out" 2>"$work_dir/success.err"
-grep -q 'helper decision' "$work_dir/success.out"
+  printf '%s' "$payload" |
+    MONK_AGENT_PATH="$work_dir/success-agent" \
+    "$hook" >"$work_dir/$name-success.out" 2>"$work_dir/$name-success.err"
+  grep -q 'helper decision' "$work_dir/$name-success.out"
+}
 
-printf 'block_monk_helper_timeout=pass\n'
+run_variant claude \
+  "$repo_root/hooks/block-monk.sh" \
+  '{"tool_name":"Bash","tool_input":{"command":"monk status"}}' \
+  '"permissionDecision": "deny"'
+
+run_variant antigravity \
+  "$repo_root/.antigravity-plugin/hooks/block-monk.sh" \
+  '{"toolCall":{"name":"run_command","args":{"CommandLine":"monk status"}}}' \
+  '"decision": "deny"'
+
+cmp "$repo_root/hooks/block-monk.sh" "$repo_root/plugins/monk/hooks/block-monk.sh"
+printf 'block_monk_helper_timeout=pass variants=2\n'

--- a/tests/block-monk-helper-timeout.sh
+++ b/tests/block-monk-helper-timeout.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env sh
+# A wedged monk-agent hook helper must not consume Antigravity's 5-second
+# PreToolUse budget. The hook should fall back and still deny a direct monk CLI.
+set -eu
+repo_root="${1:-$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)}"
+hook="$repo_root/.antigravity-plugin/hooks/block-monk.sh"
+work_dir="$(mktemp -d)"
+cleanup() { rm -rf "$work_dir"; }
+trap cleanup EXIT HUP INT TERM
+
+cat >"$work_dir/hang-agent" <<'AGENT'
+#!/usr/bin/env sh
+exec sleep 30
+AGENT
+chmod +x "$work_dir/hang-agent"
+
+cat >"$work_dir/success-agent" <<'AGENT'
+#!/usr/bin/env sh
+cat >/dev/null
+printf '%s\n' '{"decision":"deny","reason":"helper decision"}'
+AGENT
+chmod +x "$work_dir/success-agent"
+
+payload='{"toolCall":{"name":"run_command","args":{"CommandLine":"monk status"}}}'
+
+printf '%s' "$payload" |
+  MONK_AGENT_PATH="$work_dir/hang-agent" \
+  MONK_BLOCK_MONK_HELPER_TIMEOUT=1 \
+  "$hook" >"$work_dir/hang.out" 2>"$work_dir/hang.err" &
+hook_pid=$!
+
+finished=0
+for _ in 1 2 3; do
+  if ! kill -0 "$hook_pid" 2>/dev/null; then
+    finished=1
+    break
+  fi
+  sleep 1
+done
+if [ "$finished" -ne 1 ]; then
+  kill "$hook_pid" 2>/dev/null || true
+  wait "$hook_pid" 2>/dev/null || true
+  echo "block-monk hook outlived its helper timeout" >&2
+  exit 1
+fi
+wait "$hook_pid"
+grep -q '"decision": "deny"' "$work_dir/hang.out"
+
+printf '%s' "$payload" |
+  MONK_AGENT_PATH="$work_dir/success-agent" \
+  "$hook" >"$work_dir/success.out" 2>"$work_dir/success.err"
+grep -q 'helper decision' "$work_dir/success.out"
+
+printf 'block_monk_helper_timeout=pass\n'


### PR DESCRIPTION
Fixes #362.

## What changed

- bound the POSIX Antigravity `monk-agent hook block-monk` helper to 2 seconds by default, leaving margin inside the manifest's 5-second PreToolUse timeout
- fall back to the existing native parser when the helper times out, just as the hook already does when the helper exits unsuccessfully
- preserve successful helper stdout/stderr behaviour
- use a private temporary directory for the buffered hook input/output and clean it up after each invocation
- add a deterministic regression covering a wedged helper and a normal successful helper

## Why

The current hook invokes an executable helper synchronously with no deadline. If the helper wedges, the 5-second Antigravity host timeout kills the entire hook before its native fallback can run. That means a direct `monk ...` command receives no deny decision and every affected `run_command` call waits for the full host budget.

## Validation

Against current `main` (`8d9a2c3`), the new regression fails after its supervisor kills the still-running hook:

```text
block-monk hook outlived its helper timeout
```

Against this branch:

```text
block_monk_helper_timeout=pass
```

Additional checks:

- `sh -n .antigravity-plugin/hooks/block-monk.sh`
- `sh -n tests/block-monk-helper-timeout.sh`
- wedged helper falls back to the native deny path in ~1 second with the test override
- successful helper output is passed through unchanged

This PR intentionally scopes the tested change to the POSIX hook. The PowerShell sibling has a similar unbounded `WaitForExit()` by inspection, but native Windows execution is not claimed here.

Prepared with ChatGPT/Codex assistance.