### PR TITLE
Add WSL relay recovery diagnostics (fix for #286)

### DIFF
--- a/.monk-recovery-plugin/plugin.json
+++ b/.monk-recovery-plugin/plugin.json
@@ -1,0 +1,19 @@
+{
+  "name": "monk-wsl-relay-recovery",
+  "version": "0.1.0",
+  "description": "Recovery diagnostics for the Monk WSL localhost relay (127.0.0.1:2137). Detects the dead-relay state from monk-io/monk-plugin#286 (accepted) and prints the exact recovery step instead of failing silently with ECONNREFUSED.",
+  "author": "NyxSpecter4",
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$PLUGIN_ROOT/monk-relay-recovery.sh",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/monk-relay-recovery.sh
+++ b/monk-relay-recovery.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+# monk-relay-recovery.sh — recovery diagnostics for Monk WSL relay (fix for #286)
+#
+# Problem (monk-io/monk-plugin#286, accepted): after Windows reboot or WSL
+# idle-shutdown, the WSL localhost relay (127.0.0.1:2137) is not rebuilt, so
+# monkd inside WSL is unreachable -> "connect ECONNREFUSED 127.0.0.1:2137".
+# The plugin previously failed silently with no recovery hint.
+#
+# This hook detects the dead relay and prints the exact recovery step, so the
+# agent (and the user) gets an actionable message instead of a stack of
+# ECONNREFUSED errors. It does NOT auto-run `wsl --shutdown` (destructive,
+# user-approved only) — it reports.
+#
+# Invoked from hooks.json PostToolUse / a dedicated recovery check, or manually.
+set -euo pipefail
+
+PORT="${MONK_RELAY_PORT:-2137}"
+HOST="${MONK_RELAY_HOST:-127.0.0.1}"
+
+# Quick reachability probe (cross-platform: bash on the WSL side, or Windows).
+if command -v wsl >/dev/null 2>&1; then
+  # We are on Windows host. Check the Windows-side listener.
+  if command -v netstat >/dev/null 2>&1; then
+    if netstat -an 2>/dev/null | grep -q ":$PORT "; then
+      echo "monk-relay: 127.0.0.1:$PORT LISTENING on Windows side — relay up."
+      exit 0
+    fi
+  fi
+  # Relay not listening. Determine WSL distro state.
+  if command -v wsl >/dev/null 2>&1; then
+    WSLSTATE="$(wsl -l -v 2>/dev/null | grep -i running || echo 'NO DISTRO RUNNING')"
+    echo "monk-relay: 127.0.0.1:$PORT NOT listening on Windows side (relay down)."
+    echo "monk-relay: WSL state: $WSLSTATE"
+    echo "monk-relay: RECOVERY -> run 'wsl --shutdown' then restart the distro to rebuild the localhost relay, then retry."
+    echo "monk-relay: (monk-io/monk-plugin#286 — accepted)"
+    exit 2
+  fi
+fi
+
+# Fallback: direct TCP probe.
+if command -v bash >/dev/null 2>&1; then
+  if (exec 3<>/dev/tcp/$HOST/$PORT) 2>/dev/null; then
+    echo "monk-relay: $HOST:$PORT reachable."
+    exit 0
+  else
+    echo "monk-relay: $HOST:$PORT UNREACHABLE (ECONNREFUSED)."
+    echo "monk-relay: RECOVERY -> ensure monkd is running and the WSL/localhost relay is up (monk-io/monk-plugin#286)."
+    exit 2
+  fi
+fi
+
+exit 0


### PR DESCRIPTION
## What
Adds `monk-relay-recovery.sh` + a `.monk-recovery-plugin/plugin.json` manifest that detects the dead WSL localhost relay (127.0.0.1:2137) and prints the exact recovery step instead of failing silently with ECONNREFUSED.

## Why
Related to accepted bug #286: after Windows reboot / WSL idle-shutdown the relay is not rebuilt, and the plugin currently surfaces a stack of ECONNREFUSED errors with no actionable hint. This hook reports the WSL distro state and the one-line recovery (`wsl --shutdown` + restart) so the agent/user gets a clear path instead of a silent failure.

It does NOT auto-run `wsl --shutdown` (destructive, user-approved only) — it reports.

## Verify
`bash monk-relay-recovery.sh` on a host without the relay prints `UNREACHABLE (ECONNREFUSED)` + the #286 recovery hint and exits 2. Tested locally.

Happy to adjust hook wiring (e.g. PostToolUse vs SessionStart) to match the repo convention.