### PR TITLE
Fix #369: add Unregister-AntigravityMcp to PowerShell uninstaller

### DIFF
--- a/scripts/uninstall-monk-agent.ps1
+++ b/scripts/uninstall-monk-agent.ps1
@@ -209,4 +209,50 @@ if ($Runtime) {
   Remove-MonkRuntime
 }
 
+
+# Remove the monk MCP server entry from ~/.gemini/config/mcp_config.json on
+# uninstall, restoring POSIX/PowerShell parity.
+# POSIX uninstaller calls remove_antigravity_mcp(); the PowerShell uninstaller
+# was missing this step (monk-io/monk-plugin#369). Mirrors Register-AntigravityMcp
+# in start-monk-agent.ps1.
+function Unregister-AntigravityMcp {
+  $ConfigDir = Join-Path $HOME ".gemini\config"
+  if (-not (Test-Path $ConfigDir)) { return }
+
+  $ConfigPath = Join-Path $ConfigDir "mcp_config.json"
+  if (-not (Test-Path $ConfigPath) -or (Get-Item $ConfigPath).Length -eq 0) { return }
+
+  try {
+    $Config = Get-Content -Raw $ConfigPath | ConvertFrom-Json
+  } catch {
+    Write-Warning "Could not unregister Monk MCP server because $ConfigPath is not valid JSON."
+    return
+  }
+  if ($null -eq $Config -or $Config.GetType().FullName -ne "System.Management.Automation.PSCustomObject") {
+    Write-Warning "Could not unregister Monk MCP server because $ConfigPath is not a JSON object."
+    return
+  }
+  if ($null -eq $Config.mcpServers -or $Config.mcpServers.GetType().FullName -ne "System.Management.Automation.PSCustomObject") {
+    return
+  }
+  if (-not ($Config.mcpServers.PSObject.Properties.Name -contains "monk")) {
+    return
+  }
+
+  $Config.mcpServers.PSObject.Properties.Remove("monk")
+  if ($Config.mcpServers.PSObject.Properties.Name.Count -eq 0) {
+    $Config.PSObject.Properties.Remove("mcpServers")
+  }
+
+  $TempPath = "$ConfigPath.tmp-$PID"
+  try {
+    $Config | ConvertTo-Json -Depth 100 | Set-Content -Encoding UTF8 $TempPath
+    Move-Item -Force $TempPath $ConfigPath
+  } finally {
+    Remove-Item -Force $TempPath -ErrorAction SilentlyContinue
+  }
+}
+
+Unregister-AntigravityMcp
+
 Write-Host "monk-agent uninstall complete."


### PR DESCRIPTION
## Fixes #369

The PowerShell uninstaller (`scripts/uninstall-monk-agent.ps1`) never removed the Antigravity MCP server registration that `start-monk-agent.ps1` creates via `Register-AntigravityMcp`. After uninstall on Windows, a dead `monk` entry remained in `~/.gemini/config/mcp_config.json` pointing at a binary that no longer exists. The POSIX uninstaller already calls `remove_antigravity_mcp()` — this restores platform parity.

## What changed
- Added `Unregister-AntigravityMcp` to `uninstall-monk-agent.ps1`, mirroring `Register-AntigravityMcp` (same path logic, JSON parse/remove/write with temp-file swap).
- Called before the final `uninstall complete` message.
- Removes the `monk` server entry; drops the `mcpServers` key if it becomes empty.

## Verification
- POSIX parity: `uninstall-monk-agent.sh` already calls `remove_antigravity_mcp()` (2 refs) — unchanged.
- `Register-AntigravityMcp` still idempotent on install; `Unregister-AntigravityMcp` is its inverse on uninstall.
- Script authored and reviewed against the live `main` source; cannot run Windows PowerShell CI here, but the JSON edit path is the same safe temp-swap pattern the launcher already uses.

Happy to adjust if the maintainers prefer the function live in a shared module.