### PR TITLE
Harden deploy verification for #346 (catch port black-hole + missing secrets)

### DIFF
--- a/agents/monk-deployer.md
+++ b/agents/monk-deployer.md
@@ -198,11 +198,25 @@ When deployment fails:
 
 ## Verification
 
-After deploy:
+After deploy, independent verification is REQUIRED — a green `monk.project.deploy`
+return is not proof the workload is reachable or that secrets were injected.
 
 - Read `monk.workload.status` and `monk://workspace/workloads`.
-- Verify returned endpoints with browser or HTTP checks when available.
-- Report endpoint URLs, workload health, and any remaining unverified pieces.
+- **Host-port reachability (loopback + public):** for each `host-port` service the
+  MANIFEST declares, probe `http://127.0.0.1:<port>/` and `http://<public-ip>:<port>/`
+  with a short timeout using the agent's own HTTP client (the same one that reached
+  the monk-agent MCP). If either hangs/times out while the container reports "Up",
+  the binding is black-holed — **report it as a failed deploy, do not claim success**.
+  (A LISTENING socket that answers nowhere is a black-hole, not a working deploy.
+  See monk-io/monk-plugin#346.)
+- **Secret-injection assertion:** for each MANIFEST `SECRET` line whose name is
+  present in `monk.secret.list` / the vault, assert the variable is non-null in the
+  running workload via `monk.workload.status` / the workload env view. If it resolves
+  to `null`/empty while the vault lists it, **report "secret <name> not injected"**
+  and do not proceed as ready. (See monk-io/monk-plugin#346.)
+- Only report endpoints + health as ready when BOTH reachability probes pass AND
+  declared secrets are non-null. Otherwise hand off to `monk-editor` or surface the
+  specific failure to the user.
 
 Do not run `monk`, cloud CLIs, Terraform, Kubernetes, Docker, or Podman to
 operate Monk-managed infrastructure. Source-code fixes and tests are allowed


### PR DESCRIPTION
## Addresses #346

After a cluster lifecycle, new deploys report success while host-ports are black-holed and MANIFEST secrets resolve to null. The root cause lives in monkd (closed-source); this PR hardens the plugin-side verification so the agent catches the failure instead of green-washing it.

## What changed (agents/monk-deployer.md, Verification section)
- Added an explicit host-port reachability check: probe loopback AND public-IP for each host-port service; a LISTENING socket that answers nowhere is reported as a failed deploy, not success.
- Added a secret-injection assertion: for each MANIFEST SECRET present in the vault, assert the running workload var is non-null; report 'secret <name> not injected' instead of proceeding as ready.
- Clarified that a green monk.project.deploy return is necessary but NOT sufficient proof of a working deploy.

## Scope / honesty
This is a detection and hardening fix on the agent-facing skill. It does not patch monkd lifecycle port/secret state (that remains an upstream platform issue). But it directly enforces azygoss's expectation in #346: a deploy must never report success while its published ports are unreachable from every source and its MANIFEST secrets were silently skipped.

## Verification of the change
- No infra CLIs used (per the skill's own constraint). The checks use the agent's HTTP client, same as reaching the monk-agent MCP.
- Skill text reviewed against the live main source; markdown structure preserved.

Happy to adjust wording or move the reference into skills/monk/references/ if maintainers prefer.