### PR TITLE
fix: only nudge on explicit signed-out auth state

### DIFF
--- a/.antigravity-plugin/scripts/start-monk-agent.sh
+++ b/.antigravity-plugin/scripts/start-monk-agent.sh
@@ -214,12 +214,14 @@ emit_signin_nudge() {
   # JSON output may render as `"signedIn": true` with a space, which the exact
   # substring match below would otherwise miss and misreport as signed-out.
   compact_body="$(printf '%s' "$body" | tr -d '[:space:]')"
+  # Treat auth status as three-state: only an explicit signedIn:false is a
+  # confirmed signed-out result. signedIn:true is signed in; empty, malformed,
+  # partial, or unrelated payloads are non-definitive and must stay quiet.
   case "$compact_body" in
     *'"signedIn":true'*) return 0 ;;
+    *'"signedIn":false'*) ;;
+    *) return 0 ;;
   esac
-  # Empty body = read error / 500 / timeout, NOT a confirmed signed-out state —
-  # suppress the nudge. Only an affirmative signedIn:false reaches the nudge below.
-  [ -n "$body" ] || return 0
   # $client is resolved once at the top of the script (Cursor-aware ordering).
   nudge_url="$base_url/plugin/nudge?type=signin&client=$client"
   if command -v curl >/dev/null 2>&1; then

--- a/plugins/monk/scripts/start-monk-agent.sh
+++ b/plugins/monk/scripts/start-monk-agent.sh
@@ -214,12 +214,14 @@ emit_signin_nudge() {
   # JSON output may render as `"signedIn": true` with a space, which the exact
   # substring match below would otherwise miss and misreport as signed-out.
   compact_body="$(printf '%s' "$body" | tr -d '[:space:]')"
+  # Treat auth status as three-state: only an explicit signedIn:false is a
+  # confirmed signed-out result. signedIn:true is signed in; empty, malformed,
+  # partial, or unrelated payloads are non-definitive and must stay quiet.
   case "$compact_body" in
     *'"signedIn":true'*) return 0 ;;
+    *'"signedIn":false'*) ;;
+    *) return 0 ;;
   esac
-  # Empty body = read error / 500 / timeout, NOT a confirmed signed-out state —
-  # suppress the nudge. Only an affirmative signedIn:false reaches the nudge below.
-  [ -n "$body" ] || return 0
   # $client is resolved once at the top of the script (Cursor-aware ordering).
   nudge_url="$base_url/plugin/nudge?type=signin&client=$client"
   if command -v curl >/dev/null 2>&1; then

--- a/scripts/start-monk-agent.sh
+++ b/scripts/start-monk-agent.sh
@@ -214,12 +214,14 @@ emit_signin_nudge() {
   # JSON output may render as `"signedIn": true` with a space, which the exact
   # substring match below would otherwise miss and misreport as signed-out.
   compact_body="$(printf '%s' "$body" | tr -d '[:space:]')"
+  # Treat auth status as three-state: only an explicit signedIn:false is a
+  # confirmed signed-out result. signedIn:true is signed in; empty, malformed,
+  # partial, or unrelated payloads are non-definitive and must stay quiet.
   case "$compact_body" in
     *'"signedIn":true'*) return 0 ;;
+    *'"signedIn":false'*) ;;
+    *) return 0 ;;
   esac
-  # Empty body = read error / 500 / timeout, NOT a confirmed signed-out state —
-  # suppress the nudge. Only an affirmative signedIn:false reaches the nudge below.
-  [ -n "$body" ] || return 0
   # $client is resolved once at the top of the script (Cursor-aware ordering).
   nudge_url="$base_url/plugin/nudge?type=signin&client=$client"
   if command -v curl >/dev/null 2>&1; then

--- a/tests/fixtures/start-monk-agent/curl
+++ b/tests/fixtures/start-monk-agent/curl
@@ -1,2 +1,19 @@
 #!/usr/bin/env sh
-printf '%s\n' '{"resource":"http://127.0.0.1:7419/mcp"}'
+case "$*" in
+  *"/auth.json"*)
+    if [ "${MONK_TEST_AUTH_BODY+x}" = "x" ]; then
+      printf '%s\n' "$MONK_TEST_AUTH_BODY"
+    else
+      printf '%s\n' '{"signedIn":true}'
+    fi
+    ;;
+  *"/plugin/nudge?type=signin"*)
+    if [ -n "${MONK_TEST_NUDGE_LOG:-}" ]; then
+      printf '%s\n' nudge >>"$MONK_TEST_NUDGE_LOG"
+    fi
+    printf '%s\n' '{}'
+    ;;
+  *)
+    printf '%s\n' '{"resource":"http://127.0.0.1:7419/mcp"}'
+    ;;
+esac

--- a/tests/start-monk-agent-fastpath.sh
+++ b/tests/start-monk-agent-fastpath.sh
@@ -65,4 +65,55 @@ if ! grep -Fxq "auth_url=https://auth-two.invalid" "$drift_run_dir/monk-agent.st
   exit 1
 fi
 
+# Case 3: sign-in nudges are tri-state. Only an explicit signedIn:false should
+# emit the SessionStart instruction / POST the nudge endpoint. Malformed,
+# unrelated, and explicit-true auth payloads must remain quiet.
+nudge_dir="$work_dir/nudge/monk"
+nudge_run_dir="$nudge_dir/agent/launcher/run"
+mkdir -p "$nudge_run_dir"
+write_state "$nudge_run_dir/monk-agent.state" "https://auth.monk.io"
+
+run_nudge_case() {
+  name="$1"
+  auth_body="$2"
+  expect_nudges="$3"
+  nudge_log="$work_dir/nudge-$name.log"
+  output="$work_dir/nudge-$name.out"
+  : >"$nudge_log"
+
+  HOME="$work_dir/home" \
+  PATH="$fixture_bin:/usr/bin:/bin" \
+  MONK_AGENT_PATH=/usr/bin/true \
+  MONK_AGENT_HOME="$nudge_dir" \
+  MONK_AUTH_URL="https://auth.monk.io" \
+  MONK_TEST_AUTH_BODY="$auth_body" \
+  MONK_TEST_NUDGE_LOG="$nudge_log" \
+    "$repo_root/scripts/start-monk-agent.sh" >"$output"
+
+  actual_nudges="$(wc -l <"$nudge_log" | tr -d ' ')"
+  if [ "$actual_nudges" != "$expect_nudges" ]; then
+    echo "$name: expected $expect_nudges sign-in nudge POST(s), got $actual_nudges" >&2
+    exit 1
+  fi
+
+  if [ "$expect_nudges" = "1" ]; then
+    grep -Fq "you are NOT signed in to Monk" "$output" || {
+      echo "$name: explicit signed-out state did not emit SessionStart guidance" >&2
+      exit 1
+    }
+  elif grep -Fq "you are NOT signed in to Monk" "$output"; then
+    echo "$name: non-definitive/signed-in auth response emitted a false sign-out message" >&2
+    exit 1
+  fi
+}
+
+run_nudge_case malformed '{"error":"keychain unavailable"}' 0
+run_nudge_case unrelated '{"status":"ok"}' 0
+run_nudge_case explicit_false '{"signedIn":false}' 1
+run_nudge_case explicit_true '{"signedIn":true}' 0
+
+# Generated/shipped POSIX launcher copies must remain byte-identical.
+cmp "$repo_root/scripts/start-monk-agent.sh" "$repo_root/plugins/monk/scripts/start-monk-agent.sh"
+cmp "$repo_root/scripts/start-monk-agent.sh" "$repo_root/.antigravity-plugin/scripts/start-monk-agent.sh"
+
 echo "start-monk-agent fast-path tests passed."


### PR DESCRIPTION
Fixes #364.

The POSIX launcher previously treated every non-empty `/auth.json` body that was not `signedIn:true` as a confirmed signed-out state. That meant malformed, partial, or unrelated auth responses emitted the SessionStart sign-in warning and posted the sign-in nudge.

This change makes the shell path tri-state:
- `signedIn:true` -> quiet
- `signedIn:false` -> nudge
- anything else -> quiet

Regression coverage is added to the existing `start-monk-agent-fastpath.sh` test, which is already run by the repository's Ubuntu/macOS Install E2E job. The fixture exercises malformed, unrelated, explicit-false, and explicit-true payloads, and the test also asserts the three shipped POSIX launcher copies remain byte-identical.

Local validation:
- `./tests/start-monk-agent-fastpath.sh` ✅
- `./tests/start-monk-agent-readiness-timeout.sh` ✅
- `./tests/start-monk-agent-antigravity-python-path.sh` ✅
- `sh -n` on all three POSIX launcher copies ✅
- generated-copy `cmp` checks ✅
- `git diff --check` ✅

Prepared with ChatGPT/Codex assistance.