### PR TITLE
fix: bound Windows agent download stalls

### DIFF
--- a/.antigravity-plugin/scripts/ensure-monk-agent.ps1
+++ b/.antigravity-plugin/scripts/ensure-monk-agent.ps1
@@ -32,6 +32,53 @@ $DownloadBase = if ($env:MONK_AGENT_DOWNLOAD_BASE) { $env:MONK_AGENT_DOWNLOAD_BA
 }
 $AutoUpdate = if ($env:MONK_AGENT_AUTO_UPDATE) { $env:MONK_AGENT_AUTO_UPDATE } else { "1" }
 
+function Get-PositiveTimeoutSeconds {
+  param([string]$Name, [int]$DefaultValue)
+  $Raw = [Environment]::GetEnvironmentVariable($Name)
+  if ([string]::IsNullOrWhiteSpace($Raw)) {
+    return $DefaultValue
+  }
+  $Parsed = 0
+  if (-not [int]::TryParse($Raw, [ref]$Parsed) -or $Parsed -le 0) {
+    [Console]::Error.WriteLine("$Name must be a positive integer number of seconds.")
+    exit 2
+  }
+  return $Parsed
+}
+
+$DownloadConnectTimeout = Get-PositiveTimeoutSeconds "MONK_AGENT_DOWNLOAD_CONNECT_TIMEOUT" 10
+$DownloadStallTimeout = Get-PositiveTimeoutSeconds "MONK_AGENT_DOWNLOAD_STALL_TIMEOUT" 30
+
+# Windows PowerShell's Invoke-WebRequest has no no-progress timeout for a file
+# body. A distribution endpoint can accept the connection (or send headers and a
+# few bytes) and then hold the blocking SessionStart installer indefinitely.
+# HttpWebRequest exposes separate request and stream read/write deadlines on
+# Windows PowerShell 5.1. ReadWriteTimeout resets on successful stream I/O, so a
+# slow but advancing archive is not subject to an absolute transfer deadline.
+function Invoke-BoundedDownload {
+  param([string]$Uri, [string]$OutFile)
+  $Request = [System.Net.HttpWebRequest]::Create($Uri)
+  $Request.Timeout = $DownloadConnectTimeout * 1000
+  $Request.ReadWriteTimeout = $DownloadStallTimeout * 1000
+  $Request.AllowAutoRedirect = $true
+  $Response = $null
+  $Input = $null
+  $Output = $null
+  try {
+    $Response = $Request.GetResponse()
+    $Input = $Response.GetResponseStream()
+    $Output = [System.IO.File]::Open($OutFile, [System.IO.FileMode]::Create, [System.IO.FileAccess]::Write, [System.IO.FileShare]::None)
+    $Buffer = New-Object byte[] 65536
+    while (($Read = $Input.Read($Buffer, 0, $Buffer.Length)) -gt 0) {
+      $Output.Write($Buffer, 0, $Read)
+    }
+  } finally {
+    if ($Output) { $Output.Dispose() }
+    if ($Input) { $Input.Dispose() }
+    if ($Response) { $Response.Dispose() }
+  }
+}
+
 $Target = Join-Path $InstallDir "monk-agent.exe"
 $ChecksumInstalled = Join-Path $InstallDir "monk-agent.sha256"
 $MonkHome = if ($env:MONK_AGENT_HOME) { $env:MONK_AGENT_HOME } else { Join-Path $HOME ".monk" }
@@ -162,12 +209,10 @@ try {
     $InstallerMutexOwned = $true
   }
 
-  # Windows PowerShell 5.1 otherwise delegates response parsing to the Internet
-  # Explorer engine, which is unavailable on Server Core and can be uninitialized
-  # on fresh desktop profiles. Downloads are files, so always use the independent
-  # basic parser (ENG-501).
+  # The bounded raw file-stream helper also avoids Windows PowerShell 5.1's
+  # Internet Explorer response parser dependency (ENG-501).
   try {
-    Invoke-WebRequest -Uri $ChecksumUrl -OutFile $ChecksumTmp -UseBasicParsing
+    Invoke-BoundedDownload -Uri $ChecksumUrl -OutFile $ChecksumTmp
   } catch {
     # A transient failure fetching the update-check sidecar must not abort a
     # cold start when a previously-verified local binary is already installed
@@ -208,7 +253,7 @@ try {
   }
 
   Write-Host "Installing monk-agent from $Url"
-  Invoke-WebRequest -Uri $Url -OutFile $ArchiveTmp -UseBasicParsing
+  Invoke-BoundedDownload -Uri $Url -OutFile $ArchiveTmp
 
   $Actual = Get-FileSha256 $ArchiveTmp
   if ($Actual -ne $Expected) {

--- a/.github/workflows/install-e2e.yml
+++ b/.github/workflows/install-e2e.yml
@@ -82,6 +82,10 @@ jobs:
         shell: pwsh
         run: .\tests\start-monk-agent-readiness-timeout.ps1
 
+      - name: Check Windows installer download deadlines
+        shell: pwsh
+        run: .\tests\ensure-monk-agent-download-timeout.ps1
+
       - name: Install monk-agent
         shell: pwsh
         env:

--- a/plugins/monk/scripts/ensure-monk-agent.ps1
+++ b/plugins/monk/scripts/ensure-monk-agent.ps1
@@ -32,6 +32,53 @@ $DownloadBase = if ($env:MONK_AGENT_DOWNLOAD_BASE) { $env:MONK_AGENT_DOWNLOAD_BA
 }
 $AutoUpdate = if ($env:MONK_AGENT_AUTO_UPDATE) { $env:MONK_AGENT_AUTO_UPDATE } else { "1" }
 
+function Get-PositiveTimeoutSeconds {
+  param([string]$Name, [int]$DefaultValue)
+  $Raw = [Environment]::GetEnvironmentVariable($Name)
+  if ([string]::IsNullOrWhiteSpace($Raw)) {
+    return $DefaultValue
+  }
+  $Parsed = 0
+  if (-not [int]::TryParse($Raw, [ref]$Parsed) -or $Parsed -le 0) {
+    [Console]::Error.WriteLine("$Name must be a positive integer number of seconds.")
+    exit 2
+  }
+  return $Parsed
+}
+
+$DownloadConnectTimeout = Get-PositiveTimeoutSeconds "MONK_AGENT_DOWNLOAD_CONNECT_TIMEOUT" 10
+$DownloadStallTimeout = Get-PositiveTimeoutSeconds "MONK_AGENT_DOWNLOAD_STALL_TIMEOUT" 30
+
+# Windows PowerShell's Invoke-WebRequest has no no-progress timeout for a file
+# body. A distribution endpoint can accept the connection (or send headers and a
+# few bytes) and then hold the blocking SessionStart installer indefinitely.
+# HttpWebRequest exposes separate request and stream read/write deadlines on
+# Windows PowerShell 5.1. ReadWriteTimeout resets on successful stream I/O, so a
+# slow but advancing archive is not subject to an absolute transfer deadline.
+function Invoke-BoundedDownload {
+  param([string]$Uri, [string]$OutFile)
+  $Request = [System.Net.HttpWebRequest]::Create($Uri)
+  $Request.Timeout = $DownloadConnectTimeout * 1000
+  $Request.ReadWriteTimeout = $DownloadStallTimeout * 1000
+  $Request.AllowAutoRedirect = $true
+  $Response = $null
+  $Input = $null
+  $Output = $null
+  try {
+    $Response = $Request.GetResponse()
+    $Input = $Response.GetResponseStream()
+    $Output = [System.IO.File]::Open($OutFile, [System.IO.FileMode]::Create, [System.IO.FileAccess]::Write, [System.IO.FileShare]::None)
+    $Buffer = New-Object byte[] 65536
+    while (($Read = $Input.Read($Buffer, 0, $Buffer.Length)) -gt 0) {
+      $Output.Write($Buffer, 0, $Read)
+    }
+  } finally {
+    if ($Output) { $Output.Dispose() }
+    if ($Input) { $Input.Dispose() }
+    if ($Response) { $Response.Dispose() }
+  }
+}
+
 $Target = Join-Path $InstallDir "monk-agent.exe"
 $ChecksumInstalled = Join-Path $InstallDir "monk-agent.sha256"
 $MonkHome = if ($env:MONK_AGENT_HOME) { $env:MONK_AGENT_HOME } else { Join-Path $HOME ".monk" }
@@ -162,12 +209,10 @@ try {
     $InstallerMutexOwned = $true
   }
 
-  # Windows PowerShell 5.1 otherwise delegates response parsing to the Internet
-  # Explorer engine, which is unavailable on Server Core and can be uninitialized
-  # on fresh desktop profiles. Downloads are files, so always use the independent
-  # basic parser (ENG-501).
+  # The bounded raw file-stream helper also avoids Windows PowerShell 5.1's
+  # Internet Explorer response parser dependency (ENG-501).
   try {
-    Invoke-WebRequest -Uri $ChecksumUrl -OutFile $ChecksumTmp -UseBasicParsing
+    Invoke-BoundedDownload -Uri $ChecksumUrl -OutFile $ChecksumTmp
   } catch {
     # A transient failure fetching the update-check sidecar must not abort a
     # cold start when a previously-verified local binary is already installed
@@ -208,7 +253,7 @@ try {
   }
 
   Write-Host "Installing monk-agent from $Url"
-  Invoke-WebRequest -Uri $Url -OutFile $ArchiveTmp -UseBasicParsing
+  Invoke-BoundedDownload -Uri $Url -OutFile $ArchiveTmp
 
   $Actual = Get-FileSha256 $ArchiveTmp
   if ($Actual -ne $Expected) {

--- a/scripts/ensure-monk-agent.ps1
+++ b/scripts/ensure-monk-agent.ps1
@@ -32,6 +32,53 @@ $DownloadBase = if ($env:MONK_AGENT_DOWNLOAD_BASE) { $env:MONK_AGENT_DOWNLOAD_BA
 }
 $AutoUpdate = if ($env:MONK_AGENT_AUTO_UPDATE) { $env:MONK_AGENT_AUTO_UPDATE } else { "1" }
 
+function Get-PositiveTimeoutSeconds {
+  param([string]$Name, [int]$DefaultValue)
+  $Raw = [Environment]::GetEnvironmentVariable($Name)
+  if ([string]::IsNullOrWhiteSpace($Raw)) {
+    return $DefaultValue
+  }
+  $Parsed = 0
+  if (-not [int]::TryParse($Raw, [ref]$Parsed) -or $Parsed -le 0) {
+    [Console]::Error.WriteLine("$Name must be a positive integer number of seconds.")
+    exit 2
+  }
+  return $Parsed
+}
+
+$DownloadConnectTimeout = Get-PositiveTimeoutSeconds "MONK_AGENT_DOWNLOAD_CONNECT_TIMEOUT" 10
+$DownloadStallTimeout = Get-PositiveTimeoutSeconds "MONK_AGENT_DOWNLOAD_STALL_TIMEOUT" 30
+
+# Windows PowerShell's Invoke-WebRequest has no no-progress timeout for a file
+# body. A distribution endpoint can accept the connection (or send headers and a
+# few bytes) and then hold the blocking SessionStart installer indefinitely.
+# HttpWebRequest exposes separate request and stream read/write deadlines on
+# Windows PowerShell 5.1. ReadWriteTimeout resets on successful stream I/O, so a
+# slow but advancing archive is not subject to an absolute transfer deadline.
+function Invoke-BoundedDownload {
+  param([string]$Uri, [string]$OutFile)
+  $Request = [System.Net.HttpWebRequest]::Create($Uri)
+  $Request.Timeout = $DownloadConnectTimeout * 1000
+  $Request.ReadWriteTimeout = $DownloadStallTimeout * 1000
+  $Request.AllowAutoRedirect = $true
+  $Response = $null
+  $Input = $null
+  $Output = $null
+  try {
+    $Response = $Request.GetResponse()
+    $Input = $Response.GetResponseStream()
+    $Output = [System.IO.File]::Open($OutFile, [System.IO.FileMode]::Create, [System.IO.FileAccess]::Write, [System.IO.FileShare]::None)
+    $Buffer = New-Object byte[] 65536
+    while (($Read = $Input.Read($Buffer, 0, $Buffer.Length)) -gt 0) {
+      $Output.Write($Buffer, 0, $Read)
+    }
+  } finally {
+    if ($Output) { $Output.Dispose() }
+    if ($Input) { $Input.Dispose() }
+    if ($Response) { $Response.Dispose() }
+  }
+}
+
 $Target = Join-Path $InstallDir "monk-agent.exe"
 $ChecksumInstalled = Join-Path $InstallDir "monk-agent.sha256"
 $MonkHome = if ($env:MONK_AGENT_HOME) { $env:MONK_AGENT_HOME } else { Join-Path $HOME ".monk" }
@@ -162,12 +209,10 @@ try {
     $InstallerMutexOwned = $true
   }
 
-  # Windows PowerShell 5.1 otherwise delegates response parsing to the Internet
-  # Explorer engine, which is unavailable on Server Core and can be uninitialized
-  # on fresh desktop profiles. Downloads are files, so always use the independent
-  # basic parser (ENG-501).
+  # The bounded raw file-stream helper also avoids Windows PowerShell 5.1's
+  # Internet Explorer response parser dependency (ENG-501).
   try {
-    Invoke-WebRequest -Uri $ChecksumUrl -OutFile $ChecksumTmp -UseBasicParsing
+    Invoke-BoundedDownload -Uri $ChecksumUrl -OutFile $ChecksumTmp
   } catch {
     # A transient failure fetching the update-check sidecar must not abort a
     # cold start when a previously-verified local binary is already installed
@@ -208,7 +253,7 @@ try {
   }
 
   Write-Host "Installing monk-agent from $Url"
-  Invoke-WebRequest -Uri $Url -OutFile $ArchiveTmp -UseBasicParsing
+  Invoke-BoundedDownload -Uri $Url -OutFile $ArchiveTmp
 
   $Actual = Get-FileSha256 $ArchiveTmp
   if ($Actual -ne $Expected) {

--- a/tests/ensure-monk-agent-download-timeout.ps1
+++ b/tests/ensure-monk-agent-download-timeout.ps1
@@ -1,0 +1,159 @@
+$ErrorActionPreference = "Stop"
+
+$RepoRoot = Split-Path -Parent $PSScriptRoot
+$EnsureScript = Join-Path $RepoRoot "scripts\ensure-monk-agent.ps1"
+$PowerShellExe = (Get-Command powershell.exe -ErrorAction SilentlyContinue).Source
+if (-not $PowerShellExe) {
+  $PowerShellExe = (Get-Process -Id $PID).Path
+}
+
+function New-TestListener {
+  $Listener = [System.Net.Sockets.TcpListener]::new([Net.IPAddress]::Loopback, 0)
+  $Listener.Start()
+  return $Listener
+}
+
+function Start-InstallerProcess {
+  param([string]$Root, [int]$Port)
+  $env:MONK_AGENT_INSTALL_DIR = Join-Path $Root "install"
+  $env:MONK_AGENT_HOME = Join-Path $Root "home"
+  $env:MONK_AGENT_DOWNLOAD_BASE = "http://127.0.0.1:$Port"
+  $env:MONK_AGENT_DOWNLOAD_CONNECT_TIMEOUT = "2"
+  $env:MONK_AGENT_DOWNLOAD_STALL_TIMEOUT = "2"
+
+  $Info = [Diagnostics.ProcessStartInfo]::new()
+  $Info.FileName = $PowerShellExe
+  $Info.UseShellExecute = $false
+  $Info.RedirectStandardOutput = $true
+  $Info.RedirectStandardError = $true
+  if ($PowerShellExe -match '(?i)powershell\.exe$') {
+    $Info.Arguments = "-NoLogo -NoProfile -ExecutionPolicy Bypass -File `"$EnsureScript`""
+  } else {
+    $Info.Arguments = "-NoLogo -NoProfile -File `"$EnsureScript`""
+  }
+  $Process = [Diagnostics.Process]::new()
+  $Process.StartInfo = $Info
+  if (-not $Process.Start()) { throw "failed to start installer child" }
+  return $Process
+}
+
+function Wait-ForClient {
+  param($Listener, $Process, [int]$TimeoutMs = 5000)
+  $Deadline = [DateTime]::UtcNow.AddMilliseconds($TimeoutMs)
+  while ([DateTime]::UtcNow -lt $Deadline) {
+    if ($Listener.Pending()) { return $Listener.AcceptTcpClient() }
+    if ($Process.HasExited) {
+      $Process.WaitForExit()
+      $Out = $Process.StandardOutput.ReadToEnd()
+      $Err = $Process.StandardError.ReadToEnd()
+      throw "installer exited before connecting (exit=$($Process.ExitCode)): stdout=[$Out] stderr=[$Err]"
+    }
+    Start-Sleep -Milliseconds 25
+  }
+  throw "installer did not connect to the fixture within ${TimeoutMs}ms"
+}
+
+function Wait-BoundedExit {
+  param($Process, [int]$TimeoutMs = 7000)
+  if (-not $Process.WaitForExit($TimeoutMs)) {
+    try { $Process.Kill() } catch {}
+    throw "installer exceeded its configured download deadline"
+  }
+  $Process.WaitForExit()
+  return [pscustomobject]@{
+    ExitCode = $Process.ExitCode
+    Stdout = $Process.StandardOutput.ReadToEnd()
+    Stderr = $Process.StandardError.ReadToEnd()
+  }
+}
+
+$TempRoot = Join-Path ([IO.Path]::GetTempPath()) ("monk-win-download-timeout-" + [guid]::NewGuid().ToString("N"))
+New-Item -ItemType Directory -Force -Path $TempRoot | Out-Null
+$Saved = @{}
+foreach ($Name in @(
+  "MONK_AGENT_INSTALL_DIR",
+  "MONK_AGENT_HOME",
+  "MONK_AGENT_DOWNLOAD_BASE",
+  "MONK_AGENT_DOWNLOAD_CONNECT_TIMEOUT",
+  "MONK_AGENT_DOWNLOAD_STALL_TIMEOUT"
+)) {
+  $Saved[$Name] = [Environment]::GetEnvironmentVariable($Name, "Process")
+}
+
+try {
+  # Control 1: the TCP connection succeeds, but the server never sends response
+  # headers. The connect/request deadline must terminate the installer.
+  $Listener = New-TestListener
+  try {
+    $Port = ([Net.IPEndPoint]$Listener.LocalEndpoint).Port
+    $P = Start-InstallerProcess (Join-Path $TempRoot "headers") $Port
+    $Client = Wait-ForClient $Listener $P
+    try {
+      $Timer = [Diagnostics.Stopwatch]::StartNew()
+      $Result = Wait-BoundedExit $P
+      $Timer.Stop()
+      if ($Result.ExitCode -eq 0) { throw "header-stall installer unexpectedly succeeded" }
+      if ($Timer.Elapsed.TotalSeconds -gt 6) { throw "header stall was not bounded: $($Timer.Elapsed.TotalSeconds)s" }
+    } finally {
+      $Client.Dispose()
+    }
+  } finally {
+    $Listener.Stop()
+  }
+
+  # Control 2: checksum completes, archive returns HTTP 200 plus three bytes and
+  # then makes no further progress. ReadWriteTimeout must terminate that stream
+  # without imposing an absolute deadline on a normally advancing download.
+  $Listener = New-TestListener
+  try {
+    $Port = ([Net.IPEndPoint]$Listener.LocalEndpoint).Port
+    $P = Start-InstallerProcess (Join-Path $TempRoot "body") $Port
+
+    $ChecksumClient = Wait-ForClient $Listener $P
+    try {
+      $Stream = $ChecksumClient.GetStream()
+      $Body = ([string]::new('0', 64) + "  monk-agent-windows-latest.zip`n")
+      $Bytes = [Text.Encoding]::ASCII.GetBytes($Body)
+      $Header = [Text.Encoding]::ASCII.GetBytes("HTTP/1.1 200 OK`r`nContent-Length: $($Bytes.Length)`r`nConnection: close`r`n`r`n")
+      $Stream.Write($Header, 0, $Header.Length)
+      $Stream.Write($Bytes, 0, $Bytes.Length)
+      $Stream.Flush()
+    } finally {
+      $ChecksumClient.Dispose()
+    }
+
+    $ArchiveClient = Wait-ForClient $Listener $P
+    try {
+      $Stream = $ArchiveClient.GetStream()
+      $Header = [Text.Encoding]::ASCII.GetBytes("HTTP/1.1 200 OK`r`nContent-Length: 100000`r`nConnection: close`r`n`r`nabc")
+      $Stream.Write($Header, 0, $Header.Length)
+      $Stream.Flush()
+      $Timer = [Diagnostics.Stopwatch]::StartNew()
+      $Result = Wait-BoundedExit $P
+      $Timer.Stop()
+      if ($Result.ExitCode -eq 0) { throw "body-stall installer unexpectedly succeeded" }
+      if ($Timer.Elapsed.TotalSeconds -gt 6) { throw "body stall was not bounded: $($Timer.Elapsed.TotalSeconds)s" }
+    } finally {
+      $ArchiveClient.Dispose()
+    }
+  } finally {
+    $Listener.Stop()
+  }
+
+  $Copies = @(
+    "scripts\ensure-monk-agent.ps1",
+    "plugins\monk\scripts\ensure-monk-agent.ps1",
+    ".antigravity-plugin\scripts\ensure-monk-agent.ps1"
+  ) | ForEach-Object { Join-Path $RepoRoot $_ }
+  $Hashes = $Copies | ForEach-Object { (Get-FileHash -Algorithm SHA256 $_).Hash }
+  if (($Hashes | Select-Object -Unique).Count -ne 1) {
+    throw "distributed PowerShell installer copies differ"
+  }
+
+  Write-Host "windows_download_timeout_status=pass header_stall=bounded body_stall=bounded copies=3"
+} finally {
+  foreach ($Name in $Saved.Keys) {
+    [Environment]::SetEnvironmentVariable($Name, $Saved[$Name], "Process")
+  }
+  Remove-Item -Recurse -Force $TempRoot -ErrorAction SilentlyContinue
+}


### PR DESCRIPTION
Fixes #375.

The Windows PowerShell bootstrap currently uses unbounded `Invoke-WebRequest` file downloads. A server/proxy can accept the request (or send response headers and a few archive bytes) and then stop making progress, leaving the blocking SessionStart installer waiting indefinitely.

This change:

- adds configurable `MONK_AGENT_DOWNLOAD_CONNECT_TIMEOUT` (default 10s) and `MONK_AGENT_DOWNLOAD_STALL_TIMEOUT` (default 30s);
- validates both values as positive integer seconds;
- uses a Windows PowerShell 5.1-compatible `HttpWebRequest` streaming helper with separate request and read/write deadlines, so a slow-but-progressing archive is not subject to a short absolute transfer cap;
- preserves the existing raw-download behaviour that avoids the Windows PowerShell IE parser dependency;
- applies the change identically to all three distributed PowerShell installer copies;
- adds deterministic regression coverage for both a response-header stall and an archive that sends three bytes then stops;
- runs that regression in the existing Windows install E2E job.

Validation performed before opening:

- regression **fails** against untouched v0.1.58 by exceeding its configured deadline;
- regression **passes** on this branch: `header_stall=bounded body_stall=bounded copies=3`;
- invalid zero timeout exits 2;
- all changed PowerShell files parse cleanly;
- three installer copies are byte-identical;
- complete local checksum/archive install control passes;
- isolated smoke test against the real current stable `get.monk.io` Windows artifact completed successfully in ~9s.

This is the independent Windows PowerShell counterpart to #360 / #361, which only changes the POSIX shell installer.