### PR TITLE
fix: bound Windows block-monk helper wait

### DIFF
--- a/.antigravity-plugin/hooks/block-monk.ps1
+++ b/.antigravity-plugin/hooks/block-monk.ps1
@@ -60,10 +60,21 @@ if (Test-Path $agent) {
     $errorTask = $agentProcess.StandardError.ReadToEndAsync()
     $agentProcess.StandardInput.BaseStream.Write($hookBytes, 0, $hookBytes.Length)
     $agentProcess.StandardInput.BaseStream.Close()
-    $agentProcess.WaitForExit()
-    $agentText = $outputTask.GetAwaiter().GetResult()
-    [void]$errorTask.GetAwaiter().GetResult()
-    $agentExitCode = $agentProcess.ExitCode
+
+    # Stay inside the host hook budget. If the compiled helper wedges, kill it
+    # and fall through to the native parser instead of letting the host timeout
+    # terminate this hook before it can return a deny decision.
+    $helperFinished = $agentProcess.WaitForExit(2000)
+    if ($helperFinished) {
+      $agentText = $outputTask.GetAwaiter().GetResult()
+      [void]$errorTask.GetAwaiter().GetResult()
+      $agentExitCode = $agentProcess.ExitCode
+    } else {
+      try { $agentProcess.Kill() } catch { }
+      try { [void]$agentProcess.WaitForExit(1000) } catch { }
+      $agentText = $null
+      $agentExitCode = $null
+    }
   } catch {
     $agentText = $null
   } finally {

--- a/hooks/block-monk.ps1
+++ b/hooks/block-monk.ps1
@@ -49,10 +49,21 @@ if (Test-Path $agent) {
     $errorTask = $agentProcess.StandardError.ReadToEndAsync()
     $agentProcess.StandardInput.BaseStream.Write($hookBytes, 0, $hookBytes.Length)
     $agentProcess.StandardInput.BaseStream.Close()
-    $agentProcess.WaitForExit()
-    $agentText = $outputTask.GetAwaiter().GetResult()
-    [void]$errorTask.GetAwaiter().GetResult()
-    $agentExitCode = $agentProcess.ExitCode
+
+    # Stay inside the host hook budget. If the compiled helper wedges, kill it
+    # and fall through to the native parser instead of letting the host timeout
+    # terminate this hook before it can return a deny decision.
+    $helperFinished = $agentProcess.WaitForExit(2000)
+    if ($helperFinished) {
+      $agentText = $outputTask.GetAwaiter().GetResult()
+      [void]$errorTask.GetAwaiter().GetResult()
+      $agentExitCode = $agentProcess.ExitCode
+    } else {
+      try { $agentProcess.Kill() } catch { }
+      try { [void]$agentProcess.WaitForExit(1000) } catch { }
+      $agentText = $null
+      $agentExitCode = $null
+    }
   } catch {
     $agentText = $null
   } finally {

--- a/plugins/monk/hooks/block-monk.ps1
+++ b/plugins/monk/hooks/block-monk.ps1
@@ -49,10 +49,21 @@ if (Test-Path $agent) {
     $errorTask = $agentProcess.StandardError.ReadToEndAsync()
     $agentProcess.StandardInput.BaseStream.Write($hookBytes, 0, $hookBytes.Length)
     $agentProcess.StandardInput.BaseStream.Close()
-    $agentProcess.WaitForExit()
-    $agentText = $outputTask.GetAwaiter().GetResult()
-    [void]$errorTask.GetAwaiter().GetResult()
-    $agentExitCode = $agentProcess.ExitCode
+
+    # Stay inside the host hook budget. If the compiled helper wedges, kill it
+    # and fall through to the native parser instead of letting the host timeout
+    # terminate this hook before it can return a deny decision.
+    $helperFinished = $agentProcess.WaitForExit(2000)
+    if ($helperFinished) {
+      $agentText = $outputTask.GetAwaiter().GetResult()
+      [void]$errorTask.GetAwaiter().GetResult()
+      $agentExitCode = $agentProcess.ExitCode
+    } else {
+      try { $agentProcess.Kill() } catch { }
+      try { [void]$agentProcess.WaitForExit(1000) } catch { }
+      $agentText = $null
+      $agentExitCode = $null
+    }
   } catch {
     $agentText = $null
   } finally {

--- a/tests/block-monk-powershell-helper-timeout.sh
+++ b/tests/block-monk-powershell-helper-timeout.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env sh
+set -eu
+repo="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+image="${MONK_PWSH_IMAGE:-mcr.microsoft.com/powershell:latest}"
+# Pull/start the runtime before timing the hook itself.
+docker run --rm "$image" pwsh -NoProfile -Command 'exit 0' >/dev/null
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT HUP INT TERM
+cat >"$tmp/wedged-agent.exe" <<'AGENT'
+#!/bin/sh
+exec sleep 30
+AGENT
+chmod +x "$tmp/wedged-agent.exe"
+cat >"$tmp/success-agent.exe" <<'AGENT'
+#!/bin/sh
+cat >/dev/null
+printf '%s\n' '{"decision":"deny","reason":"helper-control"}'
+AGENT
+chmod +x "$tmp/success-agent.exe"
+printf '%s' '{"toolCall":{"name":"run_command","args":{"CommandLine":"monk deploy"}}}' >"$tmp/antigravity.json"
+printf '%s' '{"tool_input":{"command":"monk deploy"}}' >"$tmp/claude.json"
+run_case() {
+  hook="$1"
+  payload="$2"
+  expected="$3"
+  start="$(date +%s)"
+  out="$(timeout 6s docker run --rm -i -e OS=Windows_NT -e MONK_AGENT_PATH=/fixture/wedged-agent.exe \
+    -v "$repo:/repo:ro" -v "$tmp/wedged-agent.exe:/fixture/wedged-agent.exe:ro" \
+    "$image" pwsh -NoProfile -File "/repo/$hook" <"$payload")"
+  elapsed=$(( $(date +%s) - start ))
+  [ "$elapsed" -lt 6 ] || { echo "$hook outlived helper deadline" >&2; exit 1; }
+  printf '%s' "$out" | grep -F "$expected" >/dev/null || { echo "$hook did not fall back to deny" >&2; exit 1; }
+}
+run_case ".antigravity-plugin/hooks/block-monk.ps1" "$tmp/antigravity.json" '"decision":"deny"'
+run_case "hooks/block-monk.ps1" "$tmp/claude.json" '"permissionDecision":"deny"'
+out="$(docker run --rm -i -e OS=Windows_NT -e MONK_AGENT_PATH=/fixture/success-agent.exe \
+  -v "$repo:/repo:ro" -v "$tmp/success-agent.exe:/fixture/success-agent.exe:ro" \
+  "$image" pwsh -NoProfile -File /repo/.antigravity-plugin/hooks/block-monk.ps1 <"$tmp/antigravity.json")"
+printf '%s' "$out" | grep -F 'helper-control' >/dev/null
+echo block_monk_powershell_helper_timeout=pass


### PR DESCRIPTION
Fixes #382.

Bounds the PowerShell `monk-agent hook block-monk` helper wait so a wedged helper cannot consume the host hook timeout before the existing native parser can return a deny decision.

- replaces unbounded `.WaitForExit()` with a 2-second helper deadline
- kills a wedged helper and falls back to the native parser
- covers Claude-style and Antigravity PowerShell hook copies
- adds deterministic wedged-helper and successful-helper controls

Validation: `block_monk_powershell_helper_timeout=pass`; patched Antigravity and Claude-style cases return deny in ~3.08s / ~2.83s including container startup; PowerShell parser checks, distributed-copy equality and `git diff --check` pass.

Exact commit: `052c727c1274f1fabf0a457d6604528e46ff0f55`.

Note: GitHub created this as a draft during the cross-fork API instability. The diff and validation are complete; the available credential currently cannot toggle the draft flag through GraphQL.

Assisted-by: GPT-5.6 Sol
