### PR TITLE
fix(hooks): block monk CLI invocations followed by shell separators (#471)

### DIFF
--- a/.antigravity-plugin/hooks/block-monk.ps1
+++ b/.antigravity-plugin/hooks/block-monk.ps1
@@ -118,7 +118,7 @@ if (-not $command) { exit 0 }
 # `find -exec monk ...` or stacked wrappers (see plugin/static/claude/hooks/
 # block-monk.ps1 for the same tradeoff, spelled out in more detail).
 $normalized = $command.Replace('\', '').Replace('"', '').Replace("'", '')
-if ($normalized -match '(^|[\r\n;&|`({])\s*(sudo|command|env|exec|nohup|time|eval|xargs|awk|perl|python[0-9.]*|powershell(\.exe)?\s+-(Command|c)|cmd(\.exe)?\s+/c|(bash|sh|zsh)(\s+-c)?)?\s*(timeout(\s+-[A-Za-z]+(\s+\S+)?)*\s+[0-9.]+\s+)?([A-Za-z_][A-Za-z0-9_]*=\S*\s+)*([^\s;&|`(){}]*[\\/])?monkd?(\.(exe|cmd|bat|ps1))?(\s|$)') {
+if ($normalized -match '(^|[\r\n;&|`({])\s*(sudo|command|env|exec|nohup|time|eval|xargs|awk|perl|python[0-9.]*|powershell(\.exe)?\s+-(Command|c)|cmd(\.exe)?\s+/c|(bash|sh|zsh)(\s+-c)?)?\s*(timeout(\s+-[A-Za-z]+(\s+\S+)?)*\s+[0-9.]+\s+)?([A-Za-z_][A-Za-z0-9_]*=\S*\s+)*([^\s;&|`(){}]*[\\/])?monkd?(\.(exe|cmd|bat|ps1))?(\s|[;&|`)}]|$)') {
   @{
     decision = "deny"
     reason   = "Blocked: do not shell out to the ``monk`` CLI - it desyncs the cluster state Monk manages. Use the monk-agent MCP tools instead."

--- a/.antigravity-plugin/hooks/block-monk.sh
+++ b/.antigravity-plugin/hooks/block-monk.sh
@@ -73,7 +73,7 @@ raw_command="$(printf '%s' "$input" |
 # to a real newline first (same for \r).
 raw_command="$(printf '%s' "$raw_command" | awk '{gsub(/\\n/, "\n"); gsub(/\\r/, "\r"); print}')"
 normalized="$(printf '%s' "$raw_command" | tr -d '\\' | tr -d '"' | tr -d "'")"
-if printf '%s' "$normalized" | grep -Eq '(^|[;&|`(){}])[[:space:]]*(sudo|command|env|exec|nohup|time|nice|eval|xargs|awk|perl|python[0-9.]*|(bash|sh|zsh)([[:space:]]+-c)?)?[[:space:]]*(timeout([[:space:]]+-[A-Za-z]+([[:space:]]+[^[:space:]]+)?)*[[:space:]]+[0-9.]+[[:space:]]+)?([A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*[[:space:]]+)*([^[:space:];&|`(){}]*[/\\])?monkd?(\.(exe|cmd|bat|ps1))?([[:space:]]|$)'; then
+if printf '%s' "$normalized" | grep -Eq '(^|[;&|`(){}])[[:space:]]*(sudo|command|env|exec|nohup|time|nice|eval|xargs|awk|perl|python[0-9.]*|(bash|sh|zsh)([[:space:]]+-c)?)?[[:space:]]*(timeout([[:space:]]+-[A-Za-z]+([[:space:]]+[^[:space:]]+)?)*[[:space:]]+[0-9.]+[[:space:]]+)?([A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*[[:space:]]+)*([^[:space:];&|`(){}]*[/\\])?monkd?(\.(exe|cmd|bat|ps1))?([[:space:];&|`)}]|$)'; then
   cat <<'JSON'
 {
   "decision": "deny",

--- a/hooks/block-monk.ps1
+++ b/hooks/block-monk.ps1
@@ -111,7 +111,7 @@ if (-not $command) { exit 0 }
 # (`sudo env monk`) — the compiled binary's quote-state-aware tokenizer
 # handles those cases correctly.
 $normalized = $command.Replace('\', '').Replace('"', '').Replace("'", '')
-if ($normalized -match '(^|[\r\n;&|`({])\s*(sudo|command|env|exec|nohup|time|eval|xargs|awk|perl|python[0-9.]*|powershell(\.exe)?\s+-(Command|c)|cmd(\.exe)?\s+/c|(bash|sh|zsh)(\s+-c)?)?\s*(timeout(\s+-[A-Za-z]+(\s+\S+)?)*\s+[0-9.]+\s+)?([A-Za-z_][A-Za-z0-9_]*=\S*\s+)*([^\s;&|`(){}]*[\\/])?monkd?(\.(exe|cmd|bat|ps1))?(\s|$)') {
+if ($normalized -match '(^|[\r\n;&|`({])\s*(sudo|command|env|exec|nohup|time|eval|xargs|awk|perl|python[0-9.]*|powershell(\.exe)?\s+-(Command|c)|cmd(\.exe)?\s+/c|(bash|sh|zsh)(\s+-c)?)?\s*(timeout(\s+-[A-Za-z]+(\s+\S+)?)*\s+[0-9.]+\s+)?([A-Za-z_][A-Za-z0-9_]*=\S*\s+)*([^\s;&|`(){}]*[\\/])?monkd?(\.(exe|cmd|bat|ps1))?(\s|[;&|`)}]|$)') {
   @{
     hookSpecificOutput = @{
       hookEventName            = "PreToolUse"

--- a/hooks/block-monk.sh
+++ b/hooks/block-monk.sh
@@ -73,7 +73,7 @@ raw_command="$(printf '%s' "$input" |
 # below unless restored to a real newline first (same for \r).
 raw_command="$(printf '%s' "$raw_command" | awk '{gsub(/\\n/, "\n"); gsub(/\\r/, "\r"); print}')"
 normalized="$(printf '%s' "$raw_command" | tr -d '\\' | tr -d '"' | tr -d "'")"
-if printf '%s' "$normalized" | grep -Eq '(^|[;&|`(){}])[[:space:]]*(sudo|command|env|exec|nohup|time|nice|eval|xargs|awk|perl|python[0-9.]*|(bash|sh|zsh)([[:space:]]+-c)?)?[[:space:]]*(timeout([[:space:]]+-[A-Za-z]+([[:space:]]+[^[:space:]]+)?)*[[:space:]]+[0-9.]+[[:space:]]+)?([A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*[[:space:]]+)*([^[:space:];&|`(){}]*[/\\])?monkd?(\.(exe|cmd|bat|ps1))?([[:space:]]|$)'; then
+if printf '%s' "$normalized" | grep -Eq '(^|[;&|`(){}])[[:space:]]*(sudo|command|env|exec|nohup|time|nice|eval|xargs|awk|perl|python[0-9.]*|(bash|sh|zsh)([[:space:]]+-c)?)?[[:space:]]*(timeout([[:space:]]+-[A-Za-z]+([[:space:]]+[^[:space:]]+)?)*[[:space:]]+[0-9.]+[[:space:]]+)?([A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*[[:space:]]+)*([^[:space:];&|`(){}]*[/\\])?monkd?(\.(exe|cmd|bat|ps1))?([[:space:];&|`)}]|$)'; then
   cat <<'JSON'
 {
   "hookSpecificOutput": {

--- a/plugins/monk/hooks/block-monk.ps1
+++ b/plugins/monk/hooks/block-monk.ps1
@@ -111,7 +111,7 @@ if (-not $command) { exit 0 }
 # (`sudo env monk`) — the compiled binary's quote-state-aware tokenizer
 # handles those cases correctly.
 $normalized = $command.Replace('\', '').Replace('"', '').Replace("'", '')
-if ($normalized -match '(^|[\r\n;&|`({])\s*(sudo|command|env|exec|nohup|time|eval|xargs|awk|perl|python[0-9.]*|powershell(\.exe)?\s+-(Command|c)|cmd(\.exe)?\s+/c|(bash|sh|zsh)(\s+-c)?)?\s*(timeout(\s+-[A-Za-z]+(\s+\S+)?)*\s+[0-9.]+\s+)?([A-Za-z_][A-Za-z0-9_]*=\S*\s+)*([^\s;&|`(){}]*[\\/])?monkd?(\.(exe|cmd|bat|ps1))?(\s|$)') {
+if ($normalized -match '(^|[\r\n;&|`({])\s*(sudo|command|env|exec|nohup|time|eval|xargs|awk|perl|python[0-9.]*|powershell(\.exe)?\s+-(Command|c)|cmd(\.exe)?\s+/c|(bash|sh|zsh)(\s+-c)?)?\s*(timeout(\s+-[A-Za-z]+(\s+\S+)?)*\s+[0-9.]+\s+)?([A-Za-z_][A-Za-z0-9_]*=\S*\s+)*([^\s;&|`(){}]*[\\/])?monkd?(\.(exe|cmd|bat|ps1))?(\s|[;&|`)}]|$)') {
   @{
     hookSpecificOutput = @{
       hookEventName            = "PreToolUse"

--- a/plugins/monk/hooks/block-monk.sh
+++ b/plugins/monk/hooks/block-monk.sh
@@ -73,7 +73,7 @@ raw_command="$(printf '%s' "$input" |
 # below unless restored to a real newline first (same for \r).
 raw_command="$(printf '%s' "$raw_command" | awk '{gsub(/\\n/, "\n"); gsub(/\\r/, "\r"); print}')"
 normalized="$(printf '%s' "$raw_command" | tr -d '\\' | tr -d '"' | tr -d "'")"
-if printf '%s' "$normalized" | grep -Eq '(^|[;&|`(){}])[[:space:]]*(sudo|command|env|exec|nohup|time|nice|eval|xargs|awk|perl|python[0-9.]*|(bash|sh|zsh)([[:space:]]+-c)?)?[[:space:]]*(timeout([[:space:]]+-[A-Za-z]+([[:space:]]+[^[:space:]]+)?)*[[:space:]]+[0-9.]+[[:space:]]+)?([A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*[[:space:]]+)*([^[:space:];&|`(){}]*[/\\])?monkd?(\.(exe|cmd|bat|ps1))?([[:space:]]|$)'; then
+if printf '%s' "$normalized" | grep -Eq '(^|[;&|`(){}])[[:space:]]*(sudo|command|env|exec|nohup|time|nice|eval|xargs|awk|perl|python[0-9.]*|(bash|sh|zsh)([[:space:]]+-c)?)?[[:space:]]*(timeout([[:space:]]+-[A-Za-z]+([[:space:]]+[^[:space:]]+)?)*[[:space:]]+[0-9.]+[[:space:]]+)?([A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*[[:space:]]+)*([^[:space:];&|`(){}]*[/\\])?monkd?(\.(exe|cmd|bat|ps1))?([[:space:];&|`)}]|$)'; then
   cat <<'JSON'
 {
   "hookSpecificOutput": {

--- a/tests/block-monk-windows.ps1
+++ b/tests/block-monk-windows.ps1
@@ -30,7 +30,14 @@ $Cases = @(
   # ENG-448: the monkd daemon binary is blocked too, but monkdb (a different
   # program) is not — the trailing boundary still requires whitespace/EOL.
   @{ Name = "monkd"; Command = "monkd status"; Denied = $true },
-  @{ Name = "monkdb-lookalike"; Command = "monkdb migrate"; Denied = $false }
+  @{ Name = "monkdb-lookalike"; Command = "monkdb migrate"; Denied = $false },
+  # Shell separators must be treated as a trailing boundary so commands like
+  # "monk;ls" are blocked even when no whitespace follows the monk invocation.
+  @{ Name = "separator-semicolon"; Command = "monk;ls"; Denied = $true },
+  @{ Name = "separator-ampersand"; Command = "monk&ls"; Denied = $true },
+  @{ Name = "separator-pipe"; Command = "monk|ls"; Denied = $true },
+  @{ Name = "separator-double-ampersand"; Command = "monk&&ls"; Denied = $true },
+  @{ Name = "separator-multiple"; Command = "echo x; monk; ls"; Denied = $true }
 )
 
 function Assert-HookCases {


### PR DESCRIPTION
Fixes #471.

The fallback regex in lock-monk.ps1 and lock-monk.sh treated whitespace/EOL as the only valid trailing boundary. Commands like monk;ls, monk&ls, monk|ls, and monk&&ls were therefore allowed when the monk-agent binary was unavailable and the native fallback ran.

Changes:
- Extend the trailing boundary to include shell separators (;, &, |, backtick, ), }) and end-of-string in both the PowerShell and POSIX shell fallbacks.
- Add regression tests for monk;ls, monk&ls, monk|ls, monk&&ls, and cho x; monk; ls.

Verification:
- 	ests/block-monk-windows.ps1 passes locally.