### PR TITLE
fix(scripts): normalise non-object mcpServers before jq update in Antigravity registration (#380)

### DIFF
--- a/scripts/start-monk-agent.sh
+++ b/scripts/start-monk-agent.sh
@@ -123,7 +123,7 @@ raise SystemExit(0 if isinstance(cfg, dict) else 1)' "$mcp_cfg" >/dev/null 2>&1 
     # prior host/port must be refreshed, not mistaken for an existing one.
     already_registered=0
     if command -v jq >/dev/null 2>&1; then
-      jq -e --arg u "$server_url" '.mcpServers.monk.serverUrl == $u' "$mcp_cfg" >/dev/null 2>&1 &&
+      jq -e --arg u "$server_url" 'if (.mcpServers | type) == "object" then .mcpServers.monk.serverUrl == $u else false end' "$mcp_cfg" >/dev/null 2>&1 &&
         already_registered=1
     elif command -v python3 >/dev/null 2>&1; then
       python3 -c '
@@ -144,7 +144,7 @@ sys.exit(0 if isinstance(monk, dict) and monk.get("serverUrl") == sys.argv[2] el
   tmp="$(mktemp)"
   if command -v jq >/dev/null 2>&1; then
     if [ "$has_existing" = "1" ]; then
-      jq --arg u "$server_url" '.mcpServers.monk = {serverUrl: $u}' "$mcp_cfg" >"$tmp"
+      jq --arg u "$server_url" '.mcpServers = (if (.mcpServers | type) == "object" then .mcpServers else {} end) | .mcpServers.monk = {serverUrl: $u}' "$mcp_cfg" >"$tmp"
     else
       jq -n --arg u "$server_url" '{mcpServers: {monk: {serverUrl: $u}}}' >"$tmp"
     fi

--- a/tests/start-monk-agent-antigravity-jq-mcpServers-normalize.sh
+++ b/tests/start-monk-agent-antigravity-jq-mcpServers-normalize.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env sh
+# Regression coverage for plugin#380: the Antigravity MCP registration's jq path
+# must normalise a non-object mcpServers value to an object instead of aborting.
+set -eu
+
+repo_root="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+fixture_src="$repo_root/tests/fixtures/start-monk-agent"
+work_dir="$(mktemp -d)"
+trap 'rm -rf "$work_dir"' EXIT HUP INT TERM
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq not available; skipping Antigravity jq normalisation regression" >&2
+  exit 0
+fi
+
+fake_bin="$work_dir/bin"
+mkdir -p "$fake_bin"
+for command_name in cat date dirname grep head id kill mkdir mktemp mv sed sh tr; do
+  command_path="$(command -v "$command_name" || true)"
+  case "$command_path" in
+    /*) ln -s "$command_path" "$fake_bin/$command_name" ;;
+  esac
+done
+ln -s "$fixture_src/curl" "$fake_bin/curl"
+ln -s "$fixture_src/uname" "$fake_bin/uname"
+
+home="$work_dir/home"
+config="$home/.gemini/config/mcp_config.json"
+mkdir -p "$(dirname "$config")"
+printf '%s\n' '{"mcpServers":"legacy-string-value","preserved":{"value":"still here"}}' >"$config"
+
+HOME="$home" \
+PATH="$fake_bin" \
+MONK_AGENT_HOME="$home/.monk" \
+MONK_AGENT_PATH=/usr/bin/true \
+MONK_AGENT_SKIP_SIGNIN_NUDGE=1 \
+  "$repo_root/scripts/start-monk-agent.sh"
+
+jq -e '
+  .mcpServers | type == "object" and
+  .mcpServers.monk.serverUrl == "http://127.0.0.1:7419/mcp" and
+  .preserved == {"value":"still here"}
+' "$config" >/dev/null
+
+echo "Antigravity jq fallback normalises non-object mcpServers."


### PR DESCRIPTION
Fixes #380.

The jq path in `register_antigravity_mcp` assumed `mcpServers` was already an object. When the existing `~/.gemini/config/mcp_config.json` contained a string or array under `mcpServers`, jq aborted under `set -e` and the launcher exited.

Changes:
- Before reading `.mcpServers.monk.serverUrl`, guard with `if (.mcpServers | type) == "object"`.
- Before writing `.mcpServers.monk`, normalise a non-object `mcpServers` to `{}`.
- This mirrors the existing python3 fallback behaviour.
- Add regression test `tests/start-monk-agent-antigravity-jq-mcpServers-normalize.sh` (skipped when jq is unavailable).

Verification:
- New test validates that a config with `"mcpServers":"legacy-string-value"` is repaired while preserving unrelated top-level keys.