### PR TITLE
fix(hooks): run managed bootstrap in Antigravity PreInvocation ensure hooks (#472)

### DIFF
--- a/.antigravity-plugin/hooks/ensure-monk-agent.ps1
+++ b/.antigravity-plugin/hooks/ensure-monk-agent.ps1
@@ -114,8 +114,24 @@ if (Test-Path $TelemetryHelper) {
 $InstallDir = if ($env:MONK_AGENT_INSTALL_DIR) { $env:MONK_AGENT_INSTALL_DIR } else { Join-Path $HOME ".monk\bin" }
 $AgentPath = if ($env:MONK_AGENT_PATH) { $env:MONK_AGENT_PATH } else { Join-Path $InstallDir "monk-agent.exe" }
 
+# Run the managed bootstrap so plugin upgrades refresh monk-agent automatically.
+# -Quiet suppresses status output; non-output streams are redirected to $null
+# so only the resolved binary path is captured and the hook stdout stays JSON.
+$BootstrapScript = Join-Path (Split-Path -Parent $ScriptDir) "scripts\ensure-monk-agent.ps1"
+$ResolvedPath = $null
+if (Test-Path $BootstrapScript) {
+  $ResolvedPath = & $BootstrapScript -Quiet 2>$null 3>$null 4>$null 5>$null 6>$null
+}
+
+if ($ResolvedPath -and (Test-Path $ResolvedPath)) {
+  $AgentPath = $ResolvedPath
+} elseif ($env:MONK_AGENT_PATH) {
+  $AgentPath = $env:MONK_AGENT_PATH
+} else {
+  $AgentPath = Join-Path $InstallDir "monk-agent.exe"
+}
+
 if (-not (Test-Path $AgentPath)) {
-  $ScriptDir = if ($PSScriptRoot) { $PSScriptRoot } else { Split-Path -Parent $MyInvocation.MyCommand.Path }
   $PluginDir = Split-Path -Parent $ScriptDir
   $StartScript = Join-Path $PluginDir "scripts\start-monk-agent.ps1"
   Write-Json @{

--- a/.antigravity-plugin/hooks/ensure-monk-agent.sh
+++ b/.antigravity-plugin/hooks/ensure-monk-agent.sh
@@ -65,8 +65,22 @@ if [ -f "$telemetry_helper" ]; then
   monk_emit_launcher_event antigravity || true
 fi
 
-# Find the installed binary
-agent_path="${MONK_AGENT_PATH:-${MONK_AGENT_INSTALL_DIR:-"$HOME/.monk/bin"}/monk-agent}"
+# Run the managed bootstrap so plugin upgrades refresh monk-agent automatically.
+# The bootstrap writes only the resolved binary path to stdout; diagnostics go
+# to stderr and are suppressed here to keep Antigravity's hook stdout clean.
+plugin_dir="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+bootstrap_script="$plugin_dir/scripts/ensure-monk-agent.sh"
+agent_path=""
+if [ -x "$bootstrap_script" ]; then
+  agent_path="$("$bootstrap_script" 2>/dev/null)"
+fi
+
+# Fall back to the existing on-disk binary when the bootstrap is missing or
+# could not resolve a path (e.g. network down and no verified install).
+if [ -z "$agent_path" ] || [ ! -x "$agent_path" ]; then
+  agent_path="${MONK_AGENT_PATH:-${MONK_AGENT_INSTALL_DIR:-"$HOME/.monk/bin"}/monk-agent}"
+fi
+
 
 if [ ! -x "$agent_path" ]; then
   plugin_dir="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"

--- a/.antigravity-plugin/scripts/ensure-monk-agent.ps1
+++ b/.antigravity-plugin/scripts/ensure-monk-agent.ps1
@@ -1,5 +1,10 @@
 $ErrorActionPreference = "Stop"
 
+param(
+  [switch]$Quiet
+)
+
+
 # Windows PowerShell 5.1 renders an Invoke-WebRequest progress record per read
 # chunk, and that rendering — not the network — dominates a large download. This
 # installer runs inside the blocking SessionStart hook, so the cost is charged
@@ -207,7 +212,7 @@ try {
     }
   }
 
-  Write-Host "Installing monk-agent from $Url"
+  if (-not $Quiet) { Write-Host "Installing monk-agent from $Url" }
   Invoke-WebRequest -Uri $Url -OutFile $ArchiveTmp -UseBasicParsing
 
   $Actual = Get-FileSha256 $ArchiveTmp

--- a/tests/ensure-monk-agent-auto-update-472.ps1
+++ b/tests/ensure-monk-agent-auto-update-472.ps1
@@ -1,0 +1,41 @@
+# Regression coverage for plugin#472: Antigravity ensure-monk-agent.ps1 must
+# invoke the managed bootstrap script on cold start so plugin upgrades refresh
+# monk-agent automatically.
+
+$ErrorActionPreference = "Stop"
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$hook = Join-Path $repoRoot ".antigravity-plugin\hooks\ensure-monk-agent.ps1"
+$bootstrap = Join-Path $repoRoot ".antigravity-plugin\scripts\ensure-monk-agent.ps1"
+
+if (-not (Test-Path $hook)) {
+  throw "Hook not found: $hook"
+}
+if (-not (Test-Path $bootstrap)) {
+  throw "Bootstrap script not found: $bootstrap"
+}
+
+$hookText = Get-Content $hook -Raw
+$bootstrapText = Get-Content $bootstrap -Raw
+
+# The hook must delegate to the managed bootstrap (with -Quiet so that status
+# output does not corrupt the Antigravity hook stdout).
+if ($hookText -notmatch 'scripts\\ensure-monk-agent\.ps1') {
+  throw "ensure-monk-agent.ps1 does not reference the managed bootstrap script"
+}
+if ($hookText -notmatch '-Quiet') {
+  throw "ensure-monk-agent.ps1 does not pass -Quiet to the bootstrap"
+}
+
+# The bootstrap must support the -Quiet switch.
+if ($bootstrapText -notmatch 'param\s*\(\s*\[switch\]\s*\$Quiet') {
+  throw "ensure-monk-agent.ps1 bootstrap does not support -Quiet"
+}
+
+# The bootstrap's only stdout output must be the binary path (Write-Host is
+# gated by -Quiet; Write-Output returns the path).
+if ($bootstrapText -notmatch 'if\s*\(\s*-not\s+\$Quiet\s*\)\s*\{\s*Write-Host') {
+  throw "ensure-monk-agent.ps1 bootstrap does not gate Write-Host with -Quiet"
+}
+
+Write-Host "ensure-monk-agent.ps1 wiring for managed bootstrap is correct."

--- a/tests/ensure-monk-agent-auto-update-472.sh
+++ b/tests/ensure-monk-agent-auto-update-472.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env sh
+# Regression coverage for plugin#472: Antigravity ensure-monk-agent.sh must
+# invoke the managed bootstrap script on cold start so plugin upgrades refresh
+# monk-agent automatically.
+set -eu
+
+repo_root="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+hook="$repo_root/.antigravity-plugin/hooks/ensure-monk-agent.sh"
+bootstrap="$repo_root/.antigravity-plugin/scripts/ensure-monk-agent.sh"
+
+if [ ! -f "$hook" ]; then
+  echo "Hook not found: $hook" >&2
+  exit 1
+fi
+
+if [ ! -x "$bootstrap" ]; then
+  echo "Bootstrap script not found: $bootstrap" >&2
+  exit 1
+fi
+
+# The hook must reference the managed bootstrap script and invoke it before
+# falling back to the on-disk binary path.
+if ! grep -q 'scripts/ensure-monk-agent.sh' "$hook"; then
+  echo "ensure-monk-agent.sh does not reference the managed bootstrap script" >&2
+  exit 1
+fi
+
+if ! grep -q 'bootstrap_script=' "$hook"; then
+  echo "ensure-monk-agent.sh does not invoke the managed bootstrap" >&2
+  exit 1
+fi
+
+echo "ensure-monk-agent.sh wiring for managed bootstrap is correct."


### PR DESCRIPTION
Fixes #472

The Antigravity PreInvocation ensure hooks now call the managed bootstrap script (scripts/ensure-monk-agent.{sh,ps1}) on cold start, so a plugin upgrade refreshes monk-agent automatically instead of perpetually restarting the existing stale binary.

- nsure-monk-agent.sh invokes the sibling bootstrap, captures only its stdout (the resolved binary path), and suppresses stderr to keep hook stdout JSON-clean.
- nsure-monk-agent.ps1 invokes the bootstrap with the new -Quiet switch and redirects non-output streams to $null.
- The .ps1 bootstrap gains a -Quiet switch that suppresses its Write-Host progress message, ensuring only the binary path is emitted on stdout.
- Added regression tests covering the new wiring.