### PR TITLE
fix(antigravity): kill stale monk-agent PID in ensure hooks (#394)

### DIFF
--- a/.antigravity-plugin/hooks/ensure-monk-agent.ps1
+++ b/.antigravity-plugin/hooks/ensure-monk-agent.ps1
@@ -92,6 +92,48 @@ function Test-AgentRunning {
   }
 }
 
+# Kill a stale monk-agent process recorded in the PID file before starting a
+# replacement. Mirrors Stop-ManagedAgent in scripts/start-monk-agent.ps1 so the
+# ensure path does not leave hung orphans behind (plugin#394).
+function Stop-StaleAgent {
+  param([string]$PidFilePath, [string]$ExpectedPath)
+
+  if (-not (Test-Path $PidFilePath)) { return }
+
+  $RawPid = (Get-Content -Raw $PidFilePath).Trim()
+  if (-not $RawPid) { return }
+
+  $ParsedPid = 0
+  if (-not [int]::TryParse($RawPid, [ref]$ParsedPid) -or $ParsedPid -le 0) {
+    Remove-Item -Force $PidFilePath -ErrorAction SilentlyContinue
+    return
+  }
+
+  $OldProcess = Get-Process -Id $ParsedPid -ErrorAction SilentlyContinue
+  if (-not $OldProcess) { return }
+
+  $ProcessPath = ""
+  try { $ProcessPath = $OldProcess.Path } catch { $ProcessPath = "" }
+
+  $KillIt = $false
+  if ($ProcessPath) {
+    try {
+      $ExpectedFull = [IO.Path]::GetFullPath($ExpectedPath)
+      $ProcessFull = [IO.Path]::GetFullPath($ProcessPath)
+      if ($ExpectedFull -ieq $ProcessFull) { $KillIt = $true }
+    } catch { }
+  } elseif (Test-Path $ExpectedPath) {
+    # No path available from the OS; only kill if the expected binary exists
+    # as a safety guard against killing an unrelated process that reused the PID.
+    $KillIt = $true
+  }
+
+  if ($KillIt) {
+    Stop-Process -Id $OldProcess.Id -Force -ErrorAction SilentlyContinue
+    Wait-Process -Id $OldProcess.Id -Timeout 5 -ErrorAction SilentlyContinue
+  }
+}
+
 # Fast path - already up. No telemetry here: this is a PreInvocation hook that
 # fires per model step, so emitting on the warm path would spam. The beacon fires
 # only on the cold-start paths below (install-needed / (re)start), which is the
@@ -138,6 +180,9 @@ $LogErr = Join-Path $LogDir "monk-agent.err.log"
 # scripts/uninstall-monk-agent.ps1) so a companion this hook starts in the
 # background is found and stopped on uninstall instead of surviving it.
 $PidFile = Join-Path $RunDir "monk-agent.pid"
+
+# Ensure we do not leave a hung orphan from a previous launch (plugin#394).
+Stop-StaleAgent -PidFilePath $PidFile -ExpectedPath $AgentPath
 
 $env:MONK_AUTH_URL = if ($env:MONK_AUTH_URL) { $env:MONK_AUTH_URL } else { "https://auth.monk.io" }
 $env:MONK_AGENT_AUTH_CLIENT_ID = if ($env:MONK_AGENT_AUTH_CLIENT_ID) { $env:MONK_AGENT_AUTH_CLIENT_ID } else { "UW84YWcJME3buMSLfqLX8IbBsYdNWi47" }

--- a/.antigravity-plugin/hooks/ensure-monk-agent.sh
+++ b/.antigravity-plugin/hooks/ensure-monk-agent.sh
@@ -47,6 +47,71 @@ emit_inject_steps() {
   printf '%s\n' "{\"injectSteps\":[{\"ephemeralMessage\":\"$escaped\"}]}"
 }
 
+# Kill a stale monk-agent process recorded in the PID file before starting a
+# replacement. Mirrors Stop-StaleAgent in ensure-monk-agent.ps1 so the ensure
+# path does not leave hung orphans behind (plugin#394).
+stop_stale_agent() {
+  _pid_file="$1"
+  _agent_path="$2"
+
+  [ -f "$_pid_file" ] || return 0
+
+  _old_pid="$(cat "$_pid_file" 2>/dev/null || true)"
+  case "$_old_pid" in
+    ''|*[!0-9]*) rm -f "$_pid_file"; return 0 ;;
+  esac
+
+  if ! kill -0 "$_old_pid" 2>/dev/null; then
+    rm -f "$_pid_file"
+    return 0
+  fi
+
+  _kill_it=0
+  _os="$(uname -s 2>/dev/null || printf unknown)"
+  if [ "$_os" = "Linux" ]; then
+    _actual_path=""
+    if command -v readlink >/dev/null 2>&1; then
+      _actual_path="$(readlink "/proc/$_old_pid/exe" 2>/dev/null || true)"
+    fi
+    case "$_actual_path" in
+      *" (deleted)") _actual_path="${_actual_path% *}" ;;
+    esac
+    _expected_path="$_agent_path"
+    if [ -n "$_actual_path" ]; then
+      if command -v realpath >/dev/null 2>&1; then
+        _expected_path="$(realpath "$_agent_path" 2>/dev/null || printf '%s' "$_agent_path")"
+        _actual_path="$(realpath "$_actual_path" 2>/dev/null || printf '%s' "$_actual_path")"
+      elif command -v readlink >/dev/null 2>&1; then
+        _expected_path="$(readlink -f "$_agent_path" 2>/dev/null || printf '%s' "$_agent_path")"
+        _actual_path="$(readlink -f "$_actual_path" 2>/dev/null || printf '%s' "$_actual_path")"
+      fi
+    fi
+    if [ -n "$_actual_path" ] && [ "$_actual_path" = "$_expected_path" ]; then
+      _kill_it=1
+    fi
+  else
+    # Non-Linux: fall back to command name so we don't kill an unrelated reused PID.
+    _comm=""
+    if command -v ps >/dev/null 2>&1; then
+      _comm="$(ps -p "$_old_pid" -o comm= 2>/dev/null || true)"
+    fi
+    case "$_comm" in
+      *monk-agent*) _kill_it=1 ;;
+    esac
+  fi
+
+  if [ "$_kill_it" = "1" ]; then
+    kill -TERM "$_old_pid" 2>/dev/null || true
+    _wait=0
+    while kill -0 "$_old_pid" 2>/dev/null && [ "$_wait" -lt 10 ]; do
+      sleep 1
+      _wait=$((_wait + 1))
+    done
+    kill -KILL "$_old_pid" 2>/dev/null || true
+  fi
+  rm -f "$_pid_file"
+}
+
 # Fast path — already up. No telemetry here: this is a PreInvocation hook that
 # fires per model step, so emitting on the warm path would spam. The beacon
 # fires only on the cold-start paths below (install-needed / (re)start), which
@@ -84,6 +149,9 @@ log_file="$log_dir/monk-agent.log"
 # scripts/uninstall-monk-agent.sh) so a companion this hook starts in the
 # background is found and stopped on uninstall instead of surviving it.
 pid_file="$run_dir/monk-agent.pid"
+
+# Ensure we do not leave a hung orphan from a previous launch (plugin#394).
+stop_stale_agent "$pid_file" "$agent_path"
 
 export MONK_AUTH_URL="${MONK_AUTH_URL:-https://auth.monk.io}"
 export MONK_AGENT_AUTH_CLIENT_ID="${MONK_AGENT_AUTH_CLIENT_ID:-UW84YWcJME3buMSLfqLX8IbBsYdNWi47}"

--- a/tests/ensure-monk-agent-kill-stale-pid.ps1
+++ b/tests/ensure-monk-agent-kill-stale-pid.ps1
@@ -1,0 +1,127 @@
+$ErrorActionPreference = "Stop"
+
+# Regression coverage for plugin#394: the Antigravity ensure hook must kill a
+# stale monk-agent PID recorded in its PID file before starting a replacement.
+
+$Repo = Split-Path -Parent (Split-Path -Parent $MyInvocation.MyCommand.Path)
+$Root = Join-Path ([IO.Path]::GetTempPath()) ("monk-ensure-kill-" + [guid]::NewGuid().ToString("N"))
+$SourcePath = Join-Path $Root "fake-agent.cs"
+$AgentPath = Join-Path $Root "monk-agent.exe"
+$MonkHome = Join-Path $Root "home"
+$RunDir = Join-Path $MonkHome "agent\launcher\run"
+$PidFile = Join-Path $RunDir "monk-agent.pid"
+$HookPath = Join-Path $Repo ".antigravity-plugin\hooks\ensure-monk-agent.ps1"
+
+$EnvironmentNames = @(
+  "MONK_AGENT_HOME",
+  "MONK_AGENT_PATH",
+  "MONK_AGENT_PORT",
+  "MONK_AGENT_SKIP_SIGNIN_NUDGE",
+  "NO_COLOR"
+)
+$OriginalEnvironment = @{}
+foreach ($Name in $EnvironmentNames) {
+  $OriginalEnvironment[$Name] = [Environment]::GetEnvironmentVariable($Name, "Process")
+}
+
+$StaleProcess = $null
+$NewProcess = $null
+$HookProcess = $null
+
+function Test-ProcessAlive {
+  param([int]$ProcessId)
+  return $null -ne (Get-Process -Id $ProcessId -ErrorAction SilentlyContinue)
+}
+
+try {
+  New-Item -ItemType Directory -Force -Path $Root, $RunDir | Out-Null
+
+  # A companion binary that ignores serve/host/port args and just sleeps, so
+  # the hook's readiness loop sees a live process without a real MCP listener.
+  @"
+using System;
+using System.Threading;
+
+class Program
+{
+    static void Main(string[] args)
+    {
+        Thread.Sleep(TimeSpan.FromSeconds(60));
+    }
+}
+"@ | Set-Content -Encoding UTF8 $SourcePath
+
+  $Csc = Join-Path $env:WINDIR "Microsoft.NET\Framework64\v4.0.30319\csc.exe"
+  if (-not (Test-Path $Csc)) {
+    $Csc = (Get-ChildItem "$env:WINDIR\Microsoft.NET\Framework64" -Filter csc.exe -Recurse -ErrorAction SilentlyContinue |
+      Select-Object -First 1 -ExpandProperty FullName)
+  }
+  if (-not $Csc) {
+    throw "csc.exe not found; cannot build the fake agent fixture"
+  }
+  & $Csc /nologo /out:$AgentPath $SourcePath | Out-Null
+  if (-not (Test-Path $AgentPath)) {
+    throw "failed to compile fake-agent.exe"
+  }
+
+  # Seed a stale process and record it as the previous launch.
+  $StaleProcess = Start-Process -FilePath $AgentPath -PassThru
+  $StaleProcess.Id | Set-Content -NoNewline -Encoding ASCII $PidFile
+  Start-Sleep -Seconds 1
+
+  $env:MONK_AGENT_HOME = $MonkHome
+  $env:MONK_AGENT_PATH = $AgentPath
+  $env:MONK_AGENT_PORT = "57420"
+  $env:MONK_AGENT_SKIP_SIGNIN_NUDGE = "1"
+  $env:NO_COLOR = "1"
+
+  # The hook drains [Console]::In; run it in a child with an empty redirected
+  # stdin so this test's console is not blocked.
+  $ProcessInfo = New-Object Diagnostics.ProcessStartInfo
+  $ProcessInfo.FileName = (Get-Process -Id $PID).Path
+  $ProcessInfo.Arguments = "-NoLogo -NoProfile -Command `"& '$HookPath'`""
+  $ProcessInfo.UseShellExecute = $false
+  $ProcessInfo.CreateNoWindow = $true
+  $ProcessInfo.RedirectStandardInput = $true
+  $ProcessInfo.RedirectStandardOutput = $true
+  $ProcessInfo.RedirectStandardError = $true
+  $HookProcess = New-Object Diagnostics.Process
+  $HookProcess.StartInfo = $ProcessInfo
+  if (-not $HookProcess.Start()) {
+    throw "failed to start hook child process"
+  }
+  $HookProcess.StandardInput.Close()
+  $Finished = $HookProcess.WaitForExit(25000)
+  if (-not $Finished) {
+    throw "ensure hook did not exit within the bounded test wait"
+  }
+
+  if (-not (Test-Path $PidFile)) {
+    throw "PID file was not written by the hook"
+  }
+  $NewPid = [int](Get-Content -Raw $PidFile).Trim()
+  if ($NewPid -eq $StaleProcess.Id) {
+    throw "PID file still contains the stale process ID"
+  }
+  $NewProcess = Get-Process -Id $NewPid -ErrorAction SilentlyContinue
+  Start-Sleep -Seconds 1
+
+  if (Test-ProcessAlive $StaleProcess.Id) {
+    throw "stale monk-agent process $($StaleProcess.Id) was not killed"
+  }
+  if (-not (Test-ProcessAlive $NewPid)) {
+    throw "replacement monk-agent process $NewPid is not running"
+  }
+
+  Write-Host "ensure-monk-agent.ps1 stale PID kill test passed."
+} finally {
+  foreach ($Proc in @($HookProcess, $NewProcess, $StaleProcess)) {
+    if ($null -ne $Proc) {
+      Stop-Process -Id $Proc.Id -Force -ErrorAction SilentlyContinue
+    }
+  }
+  foreach ($Name in $EnvironmentNames) {
+    [Environment]::SetEnvironmentVariable($Name, $OriginalEnvironment[$Name], "Process")
+  }
+  Remove-Item -LiteralPath $Root -Recurse -Force -ErrorAction SilentlyContinue
+}

--- a/tests/ensure-monk-agent-kill-stale-pid.sh
+++ b/tests/ensure-monk-agent-kill-stale-pid.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env sh
+# Regression coverage for plugin#394: the Antigravity ensure hook must kill a
+# stale monk-agent PID recorded in its PID file before starting a replacement.
+set -eu
+
+repo_root="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+work_dir="$(mktemp -d)"
+old_pid=""
+new_pid=""
+
+stop_agents() {
+  if [ -n "$old_pid" ]; then
+    kill "$old_pid" >/dev/null 2>&1 || true
+  fi
+  if [ -n "$new_pid" ]; then
+    kill "$new_pid" >/dev/null 2>&1 || true
+  fi
+  # Also try to clean up via the PID file left behind by the hook.
+  if [ -f "$work_dir/monk/agent/launcher/run/monk-agent.pid" ]; then
+    candidate="$(cat "$work_dir/monk/agent/launcher/run/monk-agent.pid" 2>/dev/null || true)"
+    case "$candidate" in
+      ''|*[!0-9]*) ;;
+      *) kill "$candidate" >/dev/null 2>&1 || true ;;
+    esac
+  fi
+}
+cleanup() {
+  stop_agents
+  rm -rf "$work_dir"
+}
+trap cleanup EXIT HUP INT TERM
+
+# This test exercises /proc/<pid>/exe (Linux) and ps -o comm= (Darwin). The
+# PowerShell sibling covers Windows native execution.
+case "$(uname -s)" in
+  Linux|Darwin) ;;
+  *) echo "ensure-monk-agent.sh stale PID kill test skipped on $(uname -s)"; exit 0 ;;
+esac
+
+fake_bin="$work_dir/bin"
+run_dir="$work_dir/monk/agent/launcher/run"
+log_dir="$work_dir/monk/agent/launcher/logs"
+mkdir -p "$fake_bin" "$run_dir" "$log_dir"
+
+# Use a copy of /bin/sh as the fake monk-agent binary so /proc/<pid>/exe on
+# Linux resolves to the expected path and stop_stale_agent() authenticates the
+# stale process before killing it. The hook invokes it as
+#   monk-agent serve --host <host> --port <port>
+# so provide a fake `serve` command in PATH that just sleeps.
+sh_bin="$(command -v sh)"
+[ -n "$sh_bin" ]
+cp "$sh_bin" "$fake_bin/monk-agent"
+chmod +x "$fake_bin/monk-agent"
+
+cat >"$fake_bin/curl" <<'EOF'
+#!/usr/bin/env sh
+exit 7
+EOF
+chmod +x "$fake_bin/curl"
+
+cat >"$fake_bin/serve" <<'EOF'
+#!/usr/bin/env sh
+exec sleep 1000
+EOF
+chmod +x "$fake_bin/serve"
+
+pid_file="$run_dir/monk-agent.pid"
+
+# Start a stale monk-agent process and record it as the previous launch.
+"$fake_bin/monk-agent" -c 'sleep 1000' &
+old_pid=$!
+printf '%s\n' "$old_pid" >"$pid_file"
+sleep 1
+
+# Run the hook. The health probe always fails, forcing a cold start.
+HOME="$work_dir/home" \
+PATH="$fake_bin:/usr/bin:/bin" \
+MONK_AGENT_PATH="$fake_bin/monk-agent" \
+MONK_AGENT_HOME="$work_dir/monk" \
+MONK_AGENT_PORT="57420" \
+MONK_AGENT_SKIP_SIGNIN_NUDGE=1 \
+  "$repo_root/.antigravity-plugin/hooks/ensure-monk-agent.sh" </dev/null >/dev/null 2>&1 || true
+
+# Wait for the hook to finish its readiness loop and write a new PID.
+attempt=0
+while [ "$attempt" -lt 15 ]; do
+  if [ -f "$pid_file" ]; then
+    candidate="$(cat "$pid_file" 2>/dev/null || true)"
+    case "$candidate" in
+      ''|*[!0-9]*) ;;
+      *) if [ "$candidate" != "$old_pid" ]; then new_pid="$candidate"; break; fi ;;
+    esac
+  fi
+  sleep 1
+  attempt=$((attempt + 1))
+done
+
+if [ -z "$new_pid" ]; then
+  echo "new monk-agent PID was not recorded" >&2
+  exit 1
+fi
+
+if kill -0 "$old_pid" 2>/dev/null; then
+  echo "stale monk-agent process ($old_pid) was not killed" >&2
+  exit 1
+fi
+
+if ! kill -0 "$new_pid" 2>/dev/null; then
+  echo "replacement monk-agent process ($new_pid) is not running" >&2
+  exit 1
+fi
+
+echo "ensure-monk-agent.sh stale PID kill test passed."


### PR DESCRIPTION
Closes #394

The PreInvocation ensure hooks (`.antigravity-plugin/hooks/ensure-monk-agent.ps1` and `.sh`) now kill a stale `monk-agent` process recorded in their PID file before spawning a replacement, matching the cleanup already performed by `scripts/start-monk-agent.{ps1,sh}`.

- PowerShell: adds `Stop-StaleAgent` and calls it after the PID file path is resolved.
- POSIX shell: adds `stop_stale_agent` and calls it before starting the binary.
- Adds regression tests for both paths.