### PR TITLE
fix(antigravity): use forward slashes in hooks.json commands (#466)

### DIFF
--- a/.antigravity-plugin/hooks.json
+++ b/.antigravity-plugin/hooks.json
@@ -4,7 +4,7 @@
     "PreInvocation": [
       {
         "type": "command",
-        "command": "scripts\\run-powershell.cmd hooks\\ensure-monk-agent.ps1",
+        "command": "scripts/run-powershell.cmd hooks/ensure-monk-agent.ps1",
         "timeout": 20
       },
       {
@@ -22,7 +22,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "scripts\\run-powershell.cmd hooks\\block-monk.ps1",
+            "command": "scripts/run-powershell.cmd hooks/block-monk.ps1",
             "timeout": 5
           },
           {
@@ -42,7 +42,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "scripts\\run-powershell.cmd hooks\\monk-diagnostics.ps1",
+            "command": "scripts/run-powershell.cmd hooks/monk-diagnostics.ps1",
             "timeout": 30
           },
           {

--- a/tests/hooks-json-no-backslash.sh
+++ b/tests/hooks-json-no-backslash.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env sh
+# Regression coverage for plugin#466: Antigravity hooks.json must not contain
+# literal Windows backslashes in command strings, because POSIX /bin/sh consumes
+# them as escape characters and breaks the path.
+set -eu
+
+repo_root="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+hook_json="$repo_root/.antigravity-plugin/hooks.json"
+
+if [ ! -f "$hook_json" ]; then
+  echo "hooks.json not found: $hook_json" >&2
+  exit 1
+fi
+
+if grep -F '\\' "$hook_json" >/dev/null 2>&1; then
+  echo "found unescaped backslash in $hook_json" >&2
+  exit 1
+fi
+
+echo "hooks.json contains no unescaped Windows backslashes."


### PR DESCRIPTION
Closes #466

Replaces Windows backslashes with forward slashes in `.antigravity-plugin/hooks.json` command strings so POSIX `/bin/sh` no longer consumes them as escape characters. The `scripts/run-powershell.cmd` shim already exits 0 when run under sh, and the sibling `.sh` hook entry performs the real work on Linux/macOS.

- Adds a regression test.