### PR TITLE
fix(ensure-monk-agent): add 60s timeout to POSIX install lock (#413)

### DIFF
--- a/scripts/ensure-monk-agent.sh
+++ b/scripts/ensure-monk-agent.sh
@@ -58,7 +58,10 @@ if command -v flock >/dev/null 2>&1; then
   exec 3>"$lock_file"
   if ! flock -n 3; then
     echo "Another monk-agent install is in progress; waiting..." >&2
-    flock 3
+    if ! flock -w 60 3; then
+      echo "Timed out waiting for monk-agent install lock after 60 seconds." >&2
+      exit 1
+    fi
   fi
 fi
 


### PR DESCRIPTION
Closes #413.

When another monk-agent install holds the `flock`-backed install lock, `ensure-monk-agent.sh` previously waited indefinitely. This changes the blocking wait to a 60-second timeout, prints a clear error, and exits non-zero if the lock is still held.

No behavior changes for the uncontended path: the fast-path `flock -n` remains unchanged.

## Validation
- Added `tests/ensure-monk-agent-lock-timeout.sh`.
- The test injects a deterministic fake `flock` so the real 60-second wait is not charged to CI.
- Verified locally with Git Bash: the script exits 1, prints the timeout message, does not continue past the lock, and finishes in under 5 seconds.
- Wired the test into the Unix `Install E2E` workflow.